### PR TITLE
ci(agent): fix agent-4-git Task 7 and Task 8 for bare-repo worktree setup

### DIFF
--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -154,12 +154,13 @@ gh pr create --base develop --title "<title>" --body "<body>"
 
 ### Task 7: Merge pull request
 
-Run:
+Run from inside `<repo>.git/` (the bare repository root — **not** from inside the worktree):
 
 ```bash
-gh pr merge <pr-url> --rebase --delete-branch
+cd <repo>.git && gh pr merge <pr-url> --rebase --delete-branch
 ```
 
+- Always run from the bare repo root. Running from a worktree causes `gh` to attempt a local `git switch develop` after merging, which fails because `develop` is already checked out in its own worktree.
 - Always rebase-merge to keep `develop` history linear (the repository does not allow squash or merge commits).
 - `--delete-branch` removes the remote branch automatically.
 
@@ -169,14 +170,15 @@ Run from inside `<repo>.git/` (the bare repository root):
 
 ```bash
 git fetch origin
+git worktree remove --force <type>_<slug>
 git worktree prune
-git worktree remove <type>_<slug>
 git branch -D <type>/<slug>
 ```
 
 Notes:
-- `git worktree prune` must run before `git worktree remove` to clear stale refs when the worktree directory is already empty.
-- Use `-D` (force) instead of `-d` because GitHub squash-merges do not create a merge commit, so git never considers the local branch "fully merged".
+- Run `git worktree remove --force` **before** `git worktree prune`. Prune deregisters stale entries first; if the worktree directory still exists but is deregistered, a subsequent `remove` will fail with a permission error.
+- `--force` handles Windows file-lock edge cases where git would otherwise refuse to delete the directory.
+- Use `-D` (force) instead of `-d` on `git branch` because GitHub rebase-merges do not create a merge commit, so git never considers the local branch "fully merged".
 
 Then run `git -C <repo>.git/develop pull origin develop` to ensure `develop` reflects the merged commit.
 


### PR DESCRIPTION
## Summary

- **Task 7:** run `gh pr merge` from the bare repo root (`<repo>.git/`) instead of from inside the feature worktree. Running from the worktree caused `gh` to attempt a local `git switch develop` after merging, which fails with `fatal: 'develop' is already used by worktree`.
- **Task 8:** reorder cleanup to `worktree remove --force` → `prune` → `branch -D`. The old order (`prune` first) deregistered the worktree entry before `remove` could act on it, causing a Windows permission error on the remaining directory. `--force` handles file-lock edge cases.

## Test plan

- [ ] Run a pipeline end-to-end and confirm Task 7 merge succeeds without the "develop already used by worktree" error
- [ ] Confirm Task 8 removes the worktree directory cleanly without permission errors

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)