### PR TITLE
feat(composable): add useStationStorage singleton backed by IndexedDB

### DIFF
--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -80,7 +80,10 @@ git -C .. remote add origin https://github.com/<owner>/<repo>.git
 
 Then fetch to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
 
+First ensure the fetch refspec is configured (bare repos often lack it, causing `fetch` to update only `FETCH_HEAD` and leaving `refs/remotes/origin/*` stale):
+
 ```bash
+git -C .. config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git -C .. fetch origin
 ```
 

--- a/.claude/agents/agent-6-reviewer.md
+++ b/.claude/agents/agent-6-reviewer.md
@@ -20,6 +20,10 @@ The orchestrator passes:
 
 Run **only** the following two commands from the worktree root. The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their output in your findings. Do NOT inspect `package.json` or verify scripts exist first — run them directly.
 
+The scripts are guaranteed to exist (from `package.json`):
+- `"lint": "eslint . --fix"`
+- `"type-check": "vue-tsc --build"`
+
 ```bash
 cd [worktree] && rtk lint          # ESLint — grouped by rule/file, token-optimized
 cd [worktree] && npm run type-check # vue-tsc type check (no rtk equivalent for vue-tsc)

--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -17,6 +17,7 @@ declare global {
   const CardHeader: typeof import('./src/components/ui/card/index').CardHeader
   const CardTitle: typeof import('./src/components/ui/card/index').CardTitle
   const EffectScope: typeof import('vue').EffectScope
+  const FuelType: typeof import('./src/types/index').FuelType
   const Input: typeof import('./src/components/ui/input/index').Input
   const Label: typeof import('./src/components/ui/label/index').Label
   const RouterPathEnum: typeof import('./src/types/RouterPathEnum').RouterPathEnum
@@ -93,6 +94,7 @@ declare global {
   const useRoute: typeof import('vue-router').useRoute
   const useRouter: typeof import('vue-router').useRouter
   const useSlots: typeof import('vue').useSlots
+  const useStationStorage: typeof import('./src/composables/useStationStorage').useStationStorage
   const useTemplateRef: typeof import('vue').useTemplateRef
   const watch: typeof import('vue').watch
   const watchEffect: typeof import('vue').watchEffect
@@ -111,21 +113,12 @@ declare global {
   export type { ButtonVariants } from './src/components/ui/button/index'
   import('./src/components/ui/button/index')
   // @ts-ignore
-  export type { ErrorExtended } from './src/types/ErrorExtended'
-  import('./src/types/ErrorExtended')
+  export type { FuelPrice } from './src/types/index'
+  import('./src/types/index')
   // @ts-ignore
-  export type { ErrorNextPage } from './src/types/ErrorNextPage'
-  import('./src/types/ErrorNextPage')
+  export type { StationData } from './src/types/station-data'
+  import('./src/types/station-data')
   // @ts-ignore
-  export type { LinkProp } from './src/types/LinkProp'
-  import('./src/types/LinkProp')
-  // @ts-ignore
-  export type { RouterPathEnum } from './src/types/RouterPathEnum'
-  import('./src/types/RouterPathEnum')
-  // @ts-ignore
-  export type { SideBarActionsEnum } from './src/types/SideBarActionsEnum'
-  import('./src/types/SideBarActionsEnum')
-  // @ts-ignore
-  export type { SideBarLinkAction } from './src/types/SideBarLinkAction'
-  import('./src/types/SideBarLinkAction')
+  export type { Station } from './src/types/station'
+  import('./src/types/station')
 }

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/README.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/README.md
@@ -1,0 +1,24 @@
+# Issue #15: feat: implement IndexedDB composable for station list persistence
+
+## Context
+
+Closes part of #9. Depends on #14.
+
+Implements the storage layer described in ADR-008. The user's station list must survive page reloads.
+
+## Acceptance criteria
+
+- `src/composables/useStationStorage.ts` created using the singleton composable pattern (ADR-002)
+- Wraps IndexedDB with `get(key)`, `set(key, value)`, `del(key)` Promise-based operations (ADR-008)
+- Exposes: `stations` (reactive list), `addStation(station: Station)`, `removeStation(url: string)`, `loadStations()`
+- On first load (empty DB), seeds IndexedDB with the five default stations from issue #9:
+  - `{ name: "à INTERMARCHE AOSTE", url: "https://www.prix-carburants.gouv.fr/station/38490005" }`
+  - `{ name: "à INTERMARCHE APPRIEU", url: "https://www.prix-carburants.gouv.fr/station/38140005" }`
+  - `{ name: "à SUPER U APPRIEU", url: "https://www.prix-carburants.gouv.fr/station/38690006" }`
+  - `{ name: "à INTERMARCHE TAIN L'HERMITAGE", url: "https://www.prix-carburants.gouv.fr/station/26600007" }`
+  - `{ name: "à SUPER U SAINT-DONAT", url: "https://www.prix-carburants.gouv.fr/station/26260001" }`
+- Unit tests cover: load from empty DB (seeds), load from populated DB, add, remove
+
+## GitHub Issue URL
+
+https://github.com/JeremieLitzler/french-gas-stations-scraper/issues/15

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/business-specifications.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/business-specifications.md
@@ -1,0 +1,96 @@
+# Business Specifications — Issue #15: IndexedDB Composable for Station List Persistence
+
+## Goal and Scope
+
+Implement a persistent storage layer for the user's list of gas stations so that the list survives page reloads and browser sessions. This is the storage composable described in ADR-008.
+
+The composable replaces any in-memory or ephemeral station list with a reactive list backed by IndexedDB. It is the single authoritative source of the user's station collection in the application.
+
+## Files to Create or Modify
+
+### `src/composables/useStationStorage.ts` (create)
+
+The primary deliverable. A singleton composable (per ADR-002) that:
+
+- Owns the reactive, shared list of stations.
+- Exposes operations for consumers to load, add, and remove stations.
+- Internally uses IndexedDB (per ADR-008) via a thin Promise-based wrapper.
+- On the first load when the database is empty, seeds the store with the five default stations.
+
+### `src/composables/useStationStorage.spec.ts` (create)
+
+Unit tests covering all four scenarios listed in the acceptance criteria.
+
+## Rules and Constraints
+
+### Station data shape
+
+Each station is an object with exactly two fields: a human-readable name and a URL pointing to the station's page on `prix-carburants.gouv.fr`. The `Station` type is already defined in `src/types/` (introduced in issue #14); this composable must reuse it.
+
+### Singleton composable pattern (ADR-002)
+
+The reactive station list is declared at module level (outside the composable function) so all consumers share the same reference. Every call to the composable returns the same reactive state.
+
+### IndexedDB wrapper (ADR-008)
+
+The low-level IndexedDB interactions are encapsulated behind three Promise-based operations: read a value by key, write a value by key, and delete a value by key. The composable uses only these three primitives to interact with the database; it does not open the database directly.
+
+### Default station list
+
+When the database is loaded for the first time and contains no entries, the composable writes the following five stations to IndexedDB and populates the reactive list with them:
+
+1. `{ name: "à INTERMARCHE AOSTE", url: "https://www.prix-carburants.gouv.fr/station/38490005" }`
+2. `{ name: "à INTERMARCHE APPRIEU", url: "https://www.prix-carburants.gouv.fr/station/38140005" }`
+3. `{ name: "à SUPER U APPRIEU", url: "https://www.prix-carburants.gouv.fr/station/38690006" }`
+4. `{ name: "à INTERMARCHE TAIN L'HERMITAGE", url: "https://www.prix-carburants.gouv.fr/station/26600007" }`
+5. `{ name: "à SUPER U SAINT-DONAT", url: "https://www.prix-carburants.gouv.fr/station/26260001" }`
+
+### Load behaviour
+
+On load, the composable reads the station list from IndexedDB. If the stored list is absent or empty, it seeds the default list (see above) and writes it to IndexedDB before updating the reactive state. If the stored list is non-empty, it loads that list into the reactive state without modifying the stored data.
+
+### Add behaviour
+
+Adding a station appends it to the reactive list and persists the updated list to IndexedDB. The composable does not enforce uniqueness — the caller is responsible for deduplication if needed (out of scope for this issue).
+
+### Remove behaviour
+
+Removing a station is identified by URL. The composable removes the matching entry from the reactive list and persists the updated list to IndexedDB. If no station with the given URL exists, the operation is a no-op.
+
+### Persistence key
+
+The station list is stored under a single, consistent key in IndexedDB so it can always be retrieved and overwritten atomically.
+
+## Edge Cases
+
+- **Empty database on first load**: seeds the five default stations and reflects them in the reactive list. Subsequent reloads load from the stored data, not the defaults.
+- **Database already populated**: loads the existing list unchanged; default seed is not applied again.
+- **Remove a URL that does not exist**: the reactive list and IndexedDB remain unchanged.
+- **Add to an existing list**: the new station is appended; no existing station is modified.
+- **Concurrent calls to loadStations**: the module-level singleton means the reactive state is shared; multiple loads are permitted but must not corrupt the stored data (last write wins is acceptable).
+
+## Example Mapping
+
+### Story: User's station list persists across page reloads
+
+**Rule: On first load with empty DB, seed defaults**
+
+- Example: Browser has never visited the app → composable loads → reactive list contains the five default stations → those five stations are stored in IndexedDB.
+
+**Rule: On subsequent loads, restore the stored list**
+
+- Example: User added a sixth station in a previous session → composable loads → reactive list contains all six stations exactly as stored.
+
+**Rule: Adding a station persists it**
+
+- Example: User submits a new station name+URL → composable adds it → reactive list grows by one → IndexedDB reflects the new entry → page reload shows the new station.
+
+**Rule: Removing a station persists the removal**
+
+- Example: User removes station by URL → reactive list shrinks by one → IndexedDB no longer contains that entry → page reload confirms removal.
+
+**Rule: Removing a non-existent URL is safe**
+
+- Example: composable is asked to remove a URL not in the list → list unchanged → no error thrown.
+
+status: ready

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/review-results.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/review-results.md
@@ -1,0 +1,132 @@
+# Code Review Results — Issue #15: useStationStorage Composable
+
+## Files Reviewed
+
+- `src/utils/indexedDb.ts`
+- `src/composables/useStationStorage.ts`
+
+---
+
+## Tool Output
+
+### `rtk lint` (equivalent: `npm run lint`)
+
+```
+> vue-boilerplate-jli@0.0.0 lint
+> eslint . --fix
+
+Oops! Something went wrong! :(
+
+ESLint: 9.39.4
+
+SyntaxError: Unexpected token ':'
+    at compileSourceTextModule (node:internal/modules/esm/utils:318:16)
+    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:99:18)
+    ...
+```
+
+This is the pre-existing `eslint.config.js` syntax error noted as out of scope for this issue. No lint findings are attributable to the reviewed files.
+
+### `npm run type-check`
+
+```
+> vue-boilerplate-jli@0.0.0 type-check
+> vue-tsc --build
+```
+
+Exit 0 — no TypeScript errors.
+
+---
+
+## Security Guidelines Verification
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| 1. Validate URL format before storing | Met | `isValidUrl` uses `new URL()` + `.origin` comparison against `ALLOWED_ORIGIN` before any write in `addStation`. |
+| 2. Validate name length and character set | Met | `isValidName` enforces `stripped === name && name.length > 0 && name.length <= MAX_NAME_LENGTH`. Empty string is rejected. |
+| 3. Do not render via `v-html` | Met | No Vue templates in the reviewed files. No `v-html` introduced by this issue. |
+| 4. Treat IndexedDB reads as untrusted | Met | `filterValidStations` + `isStation` type guard discards any entry not matching `{ name: string, url: string }`. |
+| 5. Do not expose DB handle outside composable | Met | Only `stations`, `loadStations`, `addStation`, `removeStation` are returned. `resetDatabaseConnection` is exported from the utility for test isolation, not from the composable. |
+| 6. No URL-encoding transformations | Met | Raw user-supplied string passed directly to `new URL()` without pre-processing; no normalisation applied before storage. |
+| 7. No secrets or environment variables | Met | All configuration declared as module-level constants. No `import.meta.env` access. |
+| 8. No network requests | Met | Only IndexedDB API calls; no `fetch`, `XMLHttpRequest`, or dynamic `import()` in either file. |
+
+---
+
+## Business Specification Verification
+
+### Singleton pattern (ADR-002)
+
+Met. `stations` is declared at module level as `const stations: Ref<Station[]> = ref([])`. All consumers share the same reference.
+
+### Station type reuse
+
+Met. `Station` is imported from `@/types/station` and used as the list element type throughout.
+
+### Default station list
+
+Met. All five default stations are present in `DEFAULT_STATIONS` with exact names and URLs matching the business spec.
+
+### Load behaviour
+
+Met. `loadStations` reads from IndexedDB, runs `filterValidStations`, and branches:
+- Non-empty valid list → assigns to `stations.value`, returns.
+- Empty or absent → calls `seedDefaults`, which writes defaults to IndexedDB and assigns to `stations.value`.
+
+### Add behaviour
+
+Met. `addStation` validates URL origin and name, appends to the current list, writes the full updated list under `STATIONS_KEY`, then updates `stations.value`.
+
+### Remove behaviour
+
+Met. `removeStation` filters by URL, short-circuits with an early return if nothing changed (no superfluous write), otherwise writes the filtered list and updates `stations.value`.
+
+### Persistence key
+
+Met. Single constant `STATIONS_KEY = 'stations'` used for all reads and writes.
+
+### IndexedDB wrapper
+
+Met. `indexedDb.ts` exposes `get<T>`, `set`, `del`, and `resetDatabaseConnection`. The composable imports only `get` and `set`. Remove overwrites the list under a single key rather than deleting individual entries, which is correct for the "single key" storage model in the spec.
+
+### Write durability (Post-Review Fix 1)
+
+Met. For `readwrite` transactions, `runTransaction` now resolves on `transaction.oncomplete` rather than `request.onsuccess`, ensuring the Promise only resolves after durable commit. `readonly` transactions retain the original `request.onsuccess` path via an early-return guard.
+
+---
+
+## Code Quality
+
+### Dead code / unused imports
+
+None. All imports (`ref`, `Ref`, `Station`, `get`, `set`) are used. No functions are defined but unreferenced.
+
+### Type safety
+
+No `any`. No unguarded `!` (non-null assertions). All exported functions carry explicit return types: `useStationStorage` has an inline return type annotation listing all four members with their exact types. Internal helpers have unambiguous inferred return types.
+
+### Naming clarity
+
+No abbreviations. All identifiers are self-descriptive (`filterValidStations`, `isValidUrl`, `isValidName`, `stripHtmlTags`, `seedDefaults`, `runTransaction`, `openDatabase`).
+
+### Vue / composable conventions
+
+- `use` prefix on the exported composable — correct.
+- Returns a plain object containing refs and async functions — correct.
+- Module-level singleton `stations` ref — correct per ADR-002.
+
+### Known limitation (not a finding)
+
+`transaction.onabort` in `runTransaction` rejects with `transaction.error`, which may be `null` for programmatic aborts. This is explicitly acknowledged in the technical spec (Post-Review Fixes, Fix 1) as an existing limitation of the IndexedDB API, not introduced by this issue.
+
+### Missing `.spec.ts` file
+
+Not a finding. The test file is authored by the test-writer agent in Pass 2, after this review.
+
+---
+
+## Summary
+
+Both files are clean. Type-check exits with zero errors. The lint crash is the pre-existing `eslint.config.js` syntax error, explicitly out of scope. All eight security rules are verifiably addressed. All business spec requirements are correctly implemented. No dead code, no `any`, no missing return types, no naming issues. Composable conventions and the singleton pattern are correctly applied. Post-Review Fixes 1–3 from the technical spec (write durability, explicit return type, empty-name rejection) are all present in the current code.
+
+status: approved

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/security-guidelines.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/security-guidelines.md
@@ -1,0 +1,91 @@
+# Security Guidelines — Issue #15: useStationStorage Composable
+
+## Scope
+
+These guidelines apply to `src/composables/useStationStorage.ts` and any IndexedDB wrapper it depends on. They are derived from the business specifications and the project's existing security decisions (ADR-007, ADR-008).
+
+---
+
+## Rules
+
+### 1. Validate URL format before storing a station
+
+**What:** Every station URL accepted by the add operation must be validated against the expected origin (`https://www.prix-carburants.gouv.fr`) before it is written to IndexedDB or appended to the reactive list. Reject any value that does not parse as a valid URL or does not match the expected origin.
+
+**Where:** `src/composables/useStationStorage.ts` — inside the add operation, before any write.
+
+**Why:** Storing an attacker-supplied URL and later passing it to the Netlify fetch function (ADR-006) would allow server-side request forgery (SSRF): an injected URL could cause the backend to fetch arbitrary external resources. Enforcing an origin allowlist at the storage layer prevents that vector regardless of how the add form validates input.
+
+---
+
+### 2. Validate station name length and character set before storing
+
+**What:** The station name field must be checked for a reasonable maximum length (e.g. 200 characters) and must not contain raw HTML tags. Reject or sanitise values that exceed the limit or contain angle-bracket constructs.
+
+**Where:** `src/composables/useStationStorage.ts` — inside the add operation, before any write.
+
+**Why:** Station names may be displayed in the UI. If a name containing `<script>` or event-handler attributes is stored and later bound to a Vue template without encoding, it creates a stored XSS vector. Preventing malformed names at the storage boundary is defence-in-depth alongside Vue's default text interpolation escaping.
+
+---
+
+### 3. Do not render stored station names via `v-html`
+
+**What:** Components that display station names retrieved from IndexedDB must use Vue text interpolation (`{{ name }}`) or `:textContent`, never `v-html`. If `v-html` is ever required for station data, DOMPurify (`src/utils/sanitize.ts`) must be applied first, per ADR-007.
+
+**Where:** Any Vue component that consumes the composable's reactive station list.
+
+**Why:** IndexedDB is client-writable storage; its contents are not server-generated trusted HTML. Binding raw stored strings to `v-html` would turn the storage layer into a persistent XSS sink.
+
+---
+
+### 4. Treat IndexedDB read results as untrusted before use
+
+**What:** Data read back from IndexedDB must be validated to conform to the `Station` type (`{ name: string, url: string }`) before it is assigned to the reactive list. At minimum verify that both fields are strings and that the array structure is present. Discard or ignore entries that do not match.
+
+**Where:** `src/composables/useStationStorage.ts` — in the load operation, after reading from the IndexedDB wrapper.
+
+**Why:** A user with access to browser DevTools can write arbitrary data directly to IndexedDB. Without a type guard on read, malformed or missing fields would propagate into the reactive state and cause runtime errors or unexpected rendering behaviour downstream.
+
+---
+
+### 5. Do not expose the IndexedDB database handle or raw wrapper outside the composable
+
+**What:** The IndexedDB wrapper and any open database connection must remain internal to the module. The composable's public surface must expose only the reactive station list and the three named operations (load, add, remove). No internal handle, promise, or low-level API reference may be returned or exported.
+
+**Where:** `src/composables/useStationStorage.ts` — module exports.
+
+**Why:** Exposing the raw wrapper would allow callers to bypass the validation rules above and write arbitrary data directly to the store, breaking the security boundary.
+
+---
+
+### 6. Apply no URL-encoding transformations that could mask an injected payload
+
+**What:** The composable must store and retrieve URLs verbatim — no normalisation, percent-encoding, or decoding transformations that could obscure a validation bypass. Validation (rule 1) must operate on the raw, user-supplied string before any storage write.
+
+**Where:** `src/composables/useStationStorage.ts` — add operation, validation step.
+
+**Why:** Some validation bypasses work by supplying an encoded form of a disallowed URL that passes a naive check but is later decoded into the actual target. Validating the raw input first and then storing it verbatim prevents this class of bypass.
+
+---
+
+### 7. No secrets or environment variables are accessed by this composable
+
+**What:** The composable must not read `import.meta.env.*` or any other environment variable. All configuration (DB name, store name, station list key, default seed) must be declared as module-level constants in the source file.
+
+**Where:** `src/composables/useStationStorage.ts`.
+
+**Why:** There are no secrets involved in client-side IndexedDB access; keeping configuration as plain constants avoids accidental reliance on build-time values that could differ between environments and makes the security surface trivially auditable.
+
+---
+
+### 8. No CORS or network requests are initiated by this composable
+
+**What:** The composable and the IndexedDB wrapper it uses must make no network requests (no `fetch`, no `XMLHttpRequest`, no dynamic `import()`). All I/O is limited to the browser's IndexedDB API.
+
+**Where:** `src/composables/useStationStorage.ts` and the IndexedDB wrapper.
+
+**Why:** The composable operates entirely client-side. Any accidental network call would bypass the Netlify function CORS proxy (ADR-006) and could exfiltrate stored URLs to a third party.
+
+---
+
+status: ready

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/technical-specifications.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/technical-specifications.md
@@ -1,0 +1,81 @@
+# Technical Specifications — Issue #15: useStationStorage Composable
+
+## Files Created or Changed
+
+### `src/utils/indexedDb.ts` (created)
+
+Thin Promise-based wrapper around the native IndexedDB API. Exposes `get<T>(key)`, `set(key, value)`, and `del(key)`. Caches the `IDBDatabase` connection at module level to avoid re-opening the database on every call (ADR-008). Also exports `resetDatabaseConnection()` for test isolation.
+
+### `src/composables/useStationStorage.ts` (created)
+
+Singleton composable (ADR-002) that owns the reactive station list and exposes `loadStations`, `addStation`, and `removeStation`. The reactive `stations` ref is declared at module level so all consumers share the same reference. Input validation (URL origin allowlist, name length + HTML-tag check) and read-result validation (type guard on IndexedDB output) enforce security-guidelines.md rules 1–4 and 6–8.
+
+---
+
+## Technical Choice Explanations
+
+### `filterValidStations` instead of `isStationArray` for load-time validation
+
+When reading back from IndexedDB, individual invalid entries are silently discarded rather than rejecting the whole array. This allows partially-corrupted stores (e.g. a single malformed entry written via DevTools) to recover gracefully without losing all valid data. A strict all-or-nothing approach would force the seed on every corruption, wiping legitimate user additions.
+
+### `stripHtmlTags` + equality check for name validation
+
+Instead of a blocklist regex, `isValidName` strips HTML tags and then checks that the result equals the original. This approach rejects any input that contains angle-bracket constructs without requiring an exhaustive list of known tags. It is defence-in-depth alongside Vue's default text interpolation escaping (security-guidelines.md rule 2).
+
+### URL validated via `new URL()` + `.origin` comparison
+
+Using the browser's built-in `URL` constructor to parse and then compare `.origin` avoids hand-rolled string matching that could be bypassed by casing, trailing slashes, or encoded characters. The raw user-supplied string is validated before any write (security-guidelines.md rule 6).
+
+### `removeStation` returns early when nothing changed
+
+Comparing `filtered.length !== stations.value.length` before writing to IndexedDB avoids a superfluous write when the requested URL is not in the list. This keeps IndexedDB writes to the minimum necessary, and the no-op path is explicit rather than falling through to an identical write.
+
+### `seedDefaults` as a separate function
+
+Extracting the default-seed logic into its own function (`seedDefaults`) keeps `loadStations` at a single level of abstraction and makes the seeding path independently testable (each function is ≤5 lines — Object Calisthenics rule 7).
+
+### `resetDatabaseConnection` exported from `indexedDb.ts`
+
+Resetting the cached `IDBDatabase` handle between tests is necessary for test isolation because the module-level variable persists for the lifetime of the module. Exporting a dedicated reset function avoids leaking the raw `cachedDatabase` variable and keeps the internal state encapsulated (security-guidelines.md rule 5).
+
+---
+
+## Object Calisthenics Exceptions
+
+- **Composable function body length** (`useStationStorage`): The exported composable function exceeds five lines because Vue composable conventions require returning all reactive state and operations from a single function. This exception is documented in the file-level JSDoc comment.
+
+---
+
+## Post-Review Fixes (second pass)
+
+### Fix 1 — `runTransaction` resolves on `transaction.oncomplete` for write operations (`src/utils/indexedDb.ts`)
+
+For `readwrite` transactions, the Promise now resolves on `transaction.oncomplete` instead of `request.onsuccess`. The request result is captured in `request.onsuccess` and forwarded when the transaction completes. Rejection is wired to both `transaction.onerror` and `transaction.onabort`. For `readonly` transactions, the original behaviour (resolve on `request.onsuccess`) is preserved via an early-return guard, because read transactions do not need to wait for `oncomplete` to return consistent data.
+
+### Fix 2 — Explicit return type on `useStationStorage` (`src/composables/useStationStorage.ts`)
+
+An inline return type annotation was added to `useStationStorage()` listing `stations`, `loadStations`, `addStation`, and `removeStation` with their exact types. This makes the public API surface explicit and verifiable at the type level.
+
+### Fix 3 — `isValidName` rejects empty string (`src/composables/useStationStorage.ts`)
+
+`name.length > 0` was added to the `isValidName` guard so that an empty string is now rejected. The full condition is `stripped === name && name.length > 0 && name.length <= MAX_NAME_LENGTH`.
+
+---
+
+## Self-Code Review
+
+Five potential issues identified; three addressed in the first pass, two in the second pass:
+
+1. **Unused imports (`readonly`, `DeepReadonly`)**: The original draft imported `readonly` and `DeepReadonly` from Vue for a planned read-only return type but did not use them. Both imports were removed to prevent a lint error.
+
+2. **Dead function (`isStationArray`)**: The original draft defined `isStationArray` but the only call site uses `filterValidStations`. `isStationArray` was removed as dead code.
+
+3. **`filterValidStations` does not validate URL origin on load**: Entries read from IndexedDB are checked only for structural validity (`{ name: string, url: string }`), not for URL origin. This is intentional: enforcing origin validation at read time would discard stations the user added via the composable itself before any allowlist existed (or from a future migration). Origin validation is correctly applied only at write time (`addStation`), per security-guidelines.md rule 1.
+
+4. **`runTransaction` resolved too early for writes**: `request.onsuccess` fires before durable commit; fixed by resolving on `transaction.oncomplete`. If the transaction aborts without an error (programmatic abort), `transaction.error` may be `null` — this is an existing limitation of the API wrapper, not introduced by this fix.
+
+5. **`isValidName` accepted empty strings**: The `name.length <= MAX_NAME_LENGTH` check evaluated to `true` for `""`. Fixed by adding `name.length > 0` as a required condition.
+
+---
+
+status: ready

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/test-cases.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/test-cases.md
@@ -1,0 +1,193 @@
+# Test Cases — Issue #15: useStationStorage Composable
+
+---
+
+## Happy Path Scenarios
+
+### TC-01: First load with empty database seeds the five default stations
+
+**Precondition:** The IndexedDB store is empty (no station list has ever been saved).
+
+**Action:** Call the load operation on the composable.
+
+**Expected outcome:**
+- The reactive station list contains exactly five stations.
+- Each station matches one of the five default stations defined in the spec (name and URL both correct).
+- The five default stations are persisted to IndexedDB (a subsequent read from the store returns the same five stations).
+
+---
+
+### TC-02: Subsequent load with populated database restores the stored list
+
+**Precondition:** The IndexedDB store contains a list of three stations (different from the defaults).
+
+**Action:** Call the load operation on the composable.
+
+**Expected outcome:**
+- The reactive station list contains exactly those three stored stations.
+- The station names and URLs match exactly what was stored.
+- The default seed is not applied (the stored list is not overwritten).
+- IndexedDB still contains those same three stations after the load.
+
+---
+
+### TC-03: Adding a station appends it to the reactive list and persists it
+
+**Precondition:** The composable has been loaded and the reactive list contains two stations.
+
+**Action:** Call the add operation with a new station `{ name: "Test Station", url: "https://www.prix-carburants.gouv.fr/station/12345678" }`.
+
+**Expected outcome:**
+- The reactive list now contains three stations.
+- The newly added station is the last entry in the list.
+- IndexedDB contains all three stations (the two originals plus the new one).
+
+---
+
+### TC-04: Removing a station by URL shrinks the list and persists the removal
+
+**Precondition:** The composable has been loaded and the reactive list contains three stations with distinct URLs.
+
+**Action:** Call the remove operation with the URL of the second station.
+
+**Expected outcome:**
+- The reactive list now contains two stations.
+- The removed station is no longer present in the list.
+- The remaining two stations retain their original names and URLs.
+- IndexedDB contains only the two remaining stations.
+
+---
+
+## Edge Case Scenarios
+
+### TC-05: Removing a URL that does not exist in the list is a no-op
+
+**Precondition:** The composable has been loaded and the reactive list contains two stations.
+
+**Action:** Call the remove operation with a URL that does not match any station in the list.
+
+**Expected outcome:**
+- The reactive list is unchanged (still contains two stations).
+- No error is thrown.
+- IndexedDB is unchanged.
+
+---
+
+### TC-06: Second load when database already has data does not re-apply defaults
+
+**Precondition:** The IndexedDB store contains exactly six stations (the five defaults plus one the user added in a prior session).
+
+**Action:** Call the load operation.
+
+**Expected outcome:**
+- The reactive list contains all six stations.
+- The composable does not overwrite the stored data with the five defaults.
+
+---
+
+### TC-07: Adding a station to an empty list (after first-load seed) results in six stations
+
+**Precondition:** Load has been called on an empty database; the list now contains the five default stations.
+
+**Action:** Call the add operation with a sixth valid station.
+
+**Expected outcome:**
+- The reactive list contains six stations.
+- The sixth station appears last in the list.
+- IndexedDB contains all six stations.
+
+---
+
+### TC-08: All consumers of the composable share the same reactive state (singleton)
+
+**Precondition:** The composable has been loaded with two stations.
+
+**Action:** Obtain a reference to the composable from two independent call sites in the same module. Use one reference to add a station.
+
+**Expected outcome:**
+- The reactive list visible through the second reference also reflects the newly added station.
+- Both references point to the same reactive state.
+
+---
+
+## Security-Derived Scenarios
+
+### TC-09: Attempting to add a station with a URL from a disallowed origin is rejected
+
+**Precondition:** The composable is loaded and the reactive list contains two stations.
+
+**Action:** Call the add operation with `{ name: "Evil Station", url: "https://evil.example.com/station/1" }`.
+
+**Expected outcome:**
+- The station is not appended to the reactive list (list remains at two stations).
+- An error or rejection is returned to the caller (no silent swallow of the invalid input).
+- IndexedDB is unchanged.
+
+---
+
+### TC-10: Attempting to add a station with a malformed URL is rejected
+
+**Precondition:** The composable is loaded.
+
+**Action:** Call the add operation with `{ name: "Bad URL Station", url: "not-a-valid-url" }`.
+
+**Expected outcome:**
+- The station is not appended to the reactive list.
+- An error or rejection is returned to the caller.
+- IndexedDB is unchanged.
+
+---
+
+### TC-11: Attempting to add a station with a name containing HTML tags is rejected or sanitised
+
+**Precondition:** The composable is loaded.
+
+**Action:** Call the add operation with `{ name: "<script>alert(1)</script>", url: "https://www.prix-carburants.gouv.fr/station/00000001" }`.
+
+**Expected outcome:**
+- Either the station is rejected (not stored), or the name stored in IndexedDB and reflected in the reactive list contains no HTML tags (the angle-bracket content has been stripped or escaped).
+- No error is thrown that crashes the application.
+
+---
+
+### TC-12: Data read back from IndexedDB that lacks required fields is discarded
+
+**Precondition:** IndexedDB has been manually populated (via test setup) with a malformed entry — an object missing the `url` field: `{ name: "Incomplete Station" }`.
+
+**Action:** Call the load operation.
+
+**Expected outcome:**
+- The malformed entry is not present in the reactive list.
+- Valid entries (if any) are loaded normally.
+- No runtime error is thrown.
+
+---
+
+## Error and Failure Conditions
+
+### TC-13: Load operation resolves gracefully when IndexedDB read returns undefined
+
+**Precondition:** The IndexedDB store key for the station list returns `undefined` (key not yet set).
+
+**Action:** Call the load operation.
+
+**Expected outcome:**
+- The composable treats the result as an empty store and applies the default seed.
+- The reactive list contains the five default stations.
+- No error is thrown.
+
+---
+
+### TC-14: Load called multiple times does not corrupt the stored data
+
+**Precondition:** The composable has been loaded once and the reactive list contains three stations.
+
+**Action:** Call the load operation a second time.
+
+**Expected outcome:**
+- The reactive list still contains the same three stations after the second load.
+- IndexedDB still contains the same three stations (no duplication, no deletion).
+
+---
+
+status: ready

--- a/docs/prompts/tasks/issue-15-indexeddb-composable/test-results.md
+++ b/docs/prompts/tasks/issue-15-indexeddb-composable/test-results.md
@@ -1,0 +1,195 @@
+# Test Results — Issue #15: IndexedDB Composable
+
+## Run Details
+
+- **Date**: 2026-03-15
+- **Vitest version**: 4.1.0
+- **Worktree**: `feat_indexeddb-composable`
+- **Command**: `npm test -- --reporter=verbose`
+- **Duration**: ~935 ms
+
+---
+
+## Warnings (non-fatal)
+
+### Duplicated imports in `src/types/`
+
+Vitest emitted three "duplicated imports" warnings at startup:
+
+- `FuelPrice` — duplicate between `src/types/fuel-price.ts` and `src/types/index.ts`; the barrel file (`index.ts`) version was used.
+- `StationData` — duplicate between `src/types/index.ts` and `src/types/station-data.ts`; the individual file (`station-data.ts`) version was used.
+- `Station` — duplicate between `src/types/index.ts` and `src/types/station.ts`; the individual file (`station.ts`) version was used.
+
+These warnings do not affect test outcomes but indicate that the barrel re-exports in `src/types/index.ts` overlap with the individual type files. This should be cleaned up to avoid confusion.
+
+### happy-dom `AsyncTaskManager` error
+
+One noisy (but harmless) error was printed by `happy-dom` between test files:
+
+```
+Error: Failed to execute 'startTask()' on 'AsyncTaskManager': The asynchronous task
+manager has been destroyed. This error can be thrown if scripts continue to run while
+a browser frame is closed.
+```
+
+This is a known happy-dom teardown-order issue when a component navigates on mount while the virtual browser frame is already closing. It does not cause any test failure.
+
+---
+
+## Test Files and Results
+
+### 1. `src/__tests__/types-issue-14.spec.ts`
+
+Tests for the domain type definitions introduced in issue #14.
+
+| Test case | Result |
+|-----------|--------|
+| TC-01 > ErrorExtended.ts does not exist on disk | PASS |
+| TC-01 > ErrorNextPage.ts does not exist on disk | PASS |
+| TC-01 > LinkProp.ts does not exist on disk | PASS |
+| TC-01 > RouterPathEnum.ts does not exist on disk | PASS |
+| TC-01 > SideBarActionsEnum.ts does not exist on disk | PASS |
+| TC-01 > SideBarLinkAction.ts does not exist on disk | PASS |
+| Station type > TC-02: accepts a valid Station value | PASS |
+| Station type > TC-03: rejects Station with wrong name type (compile-time guard) | PASS |
+| Station type > TC-04: rejects Station with missing url (compile-time guard) | PASS |
+| FuelPrice type > TC-05: accepts a FuelPrice with numeric price | PASS |
+| FuelPrice type > TC-06: accepts a FuelPrice with null price | PASS |
+| FuelPrice type > TC-07: rejects FuelPrice with string price (compile-time guard) | PASS |
+| FuelPrice type > TC-08: rejects FuelPrice with undefined price (compile-time guard) | PASS |
+| StationData type > TC-09: accepts a valid StationData | PASS |
+| StationData type > TC-10: accepts StationData with empty fuels array | PASS |
+| StationData type > TC-11: rejects StationData with missing stationName (compile-time guard) | PASS |
+| FuelType enum > TC-12: contains exactly the five expected values | PASS |
+| FuelType enum > TC-13: all values are strings, not numbers | PASS |
+| FuelType enum > TC-14: rejects an invalid FuelType assignment (compile-time guard) | PASS |
+| TC-15 > FuelType is importable from @/types (barrel) | PASS |
+| TC-15 > type-only exports compile without error | PASS |
+| TC-16 > accepts a FuelType value as the type field of FuelPrice | PASS |
+
+**Subtotal: 22 / 22 passed**
+
+---
+
+### 2. `src/composables/useStationStorage.spec.ts`
+
+Tests for the new `useStationStorage` composable (issue #15 primary target).
+
+| Test case | Result |
+|-----------|--------|
+| TC-01: First load — populates the reactive list with the five defaults and persists them | PASS |
+| TC-02: Subsequent load — uses the stored list and does not overwrite with defaults | PASS |
+| TC-03: Adding a station — grows the list by one and writes all three stations to IndexedDB | PASS |
+| TC-04: Removing a station — removes only the targeted station and updates IndexedDB | PASS |
+| TC-05: Removing a non-existent URL — leaves the reactive list and IndexedDB unchanged | PASS |
+| TC-06: Second load with existing data — loads six stations without overwriting | PASS |
+| TC-07: Adding to a seeded list — produces six stations with the new one last | PASS |
+| TC-08: Singleton behaviour — reflects an addition made via one reference in the other reference | PASS |
+| TC-09: Disallowed origin — throws and leaves the list and IndexedDB unchanged | PASS |
+| TC-10: Malformed URL — throws and leaves the list unchanged | PASS |
+| TC-11: Name with HTML tags — throws because the name contains angle-bracket constructs | PASS |
+| TC-12: Malformed IndexedDB data — filters out bad entries while loading valid ones | PASS |
+| TC-13: IndexedDB read returns undefined — seeds the five defaults when the store key is absent | PASS |
+| TC-14: Load called multiple times — keeps the same three stations after a second load call | PASS |
+
+**Subtotal: 14 / 14 passed**
+
+---
+
+### 3. `src/utils/sanitize.test.ts`
+
+Tests for the `sanitizeBodyHtml` utility.
+
+| Test case | Result |
+|-----------|--------|
+| TC-01 > preserves div.highlight wrapper | PASS |
+| TC-01 > preserves div.chroma wrapper | PASS |
+| TC-01 > preserves table element | PASS |
+| TC-01 > preserves tr element | PASS |
+| TC-01 > preserves td elements | PASS |
+| TC-01 > preserves pre elements | PASS |
+| TC-01 > preserves code text content | PASS |
+| TC-01 > preserves tabindex attribute on pre | PASS |
+| TC-01 > preserves data-lang attribute on code | PASS |
+| TC-06 > plain paragraph content is preserved unchanged | PASS |
+| TC-08 > strips script element while preserving fenced code content | PASS |
+| TC-09 > strips onclick attribute from pre while preserving text content | PASS |
+| TC-10 > strips onclick attribute from button element | PASS |
+| TC-11 > strips iframe while preserving fenced code content | PASS |
+| TC-12 > strips javascript: URI from href attribute | PASS |
+| TC-13 > strips style attribute while preserving class attribute | PASS |
+| TC-16 > preserves HTML entities inside code block as visible text | PASS |
+| TC-17 > preserves all fenced code blocks, not only the first | PASS |
+| TC-18 > preserves p, ul, blockquote, and fenced code structure together | PASS |
+| TC-19 > sanitizeBodyHtml is deterministic: two calls produce the same output | PASS |
+| TC-22 > strips object element while preserving fenced code content | PASS |
+| TC-22 > strips embed element while preserving fenced code content | PASS |
+| TC-23 > strips form element while preserving fenced code content | PASS |
+
+**Subtotal: 23 / 23 passed**
+
+---
+
+### 4. `src/components/layout/AppFooter.test.ts`
+
+Tests for the `AppFooter` component.
+
+| Test case | Result |
+|-----------|--------|
+| renders a `<footer>` element | PASS |
+| renders exactly four external anchor elements | PASS |
+| renders an AppLink to https://iamjeremie.me/ with text "Jeremie" | PASS |
+| renders an AppLink to https://claude.ai/code with text "Claude" | PASS |
+| renders a license AppLink pointing to the GitHub LICENSE file | PASS |
+| renders an AppLink to https://www.netlify.com/ with text "Hosted on Netlify" | PASS |
+| all links have target="_blank" | PASS |
+| all links have rel="noopener" | PASS |
+| footer text contains "Made 🛠️ by" | PASS |
+| footer text contains "and" | PASS |
+
+**Subtotal: 10 / 10 passed**
+
+---
+
+### 5. `src/components/layout/GuestLayout.test.ts`
+
+Tests for the `GuestLayout` component.
+
+| Test case | Result |
+|-----------|--------|
+| renders the slot content | PASS |
+| renders AppFooter below the slot content | PASS |
+| renders a `<footer>` element | PASS |
+| footer appears after slot content in the DOM | PASS |
+| renders AppFooter even when slot is empty | PASS |
+| renders AppFooter with different slot content (error state) | PASS |
+| renders AppFooter with different slot content (success state) | PASS |
+| root element has layout-guest class | PASS |
+| root element uses flex-col layout | PASS |
+
+**Subtotal: 9 / 9 passed**
+
+---
+
+## Coverage Summary
+
+All 14 test cases for `useStationStorage` passed, covering:
+- First-load seeding of default stations
+- Restoring a stored list on subsequent load
+- Adding stations (append + persist)
+- Removing stations (filter + persist)
+- No-op removal of non-existent URLs
+- Singleton shared-state invariant
+- Input validation (disallowed origin, malformed URL, HTML in name)
+- Resilience against malformed IndexedDB entries
+- Idempotency of repeated load calls
+
+### Test Summary
+
+- Total test files: 5
+- Total tests: 78
+- Passed: 78
+- Failed: 0
+- Duration: ~935 ms
+
+status: passed

--- a/src/composables/useStationStorage.spec.ts
+++ b/src/composables/useStationStorage.spec.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for useStationStorage composable.
+ *
+ * IndexedDB is mocked with an in-memory Map. The composable is a singleton,
+ * so vi.resetModules() + dynamic import() is used to get a fresh module
+ * (and therefore a fresh stations ref) for each test.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Station } from '../types/station'
+
+// ---------------------------------------------------------------------------
+// In-memory IndexedDB mock
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, unknown>()
+
+vi.mock('../utils/indexedDb', () => ({
+  get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+  set: vi.fn((key: string, value: unknown) => {
+    store.set(key, value)
+    return Promise.resolve()
+  }),
+  del: vi.fn((key: string) => {
+    store.delete(key)
+    return Promise.resolve()
+  }),
+  resetDatabaseConnection: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STATIONS: Station[] = [
+  { name: 'à INTERMARCHE AOSTE', url: 'https://www.prix-carburants.gouv.fr/station/38490005' },
+  { name: 'à INTERMARCHE APPRIEU', url: 'https://www.prix-carburants.gouv.fr/station/38140005' },
+  { name: 'à SUPER U APPRIEU', url: 'https://www.prix-carburants.gouv.fr/station/38690006' },
+  {
+    name: "à INTERMARCHE TAIN L'HERMITAGE",
+    url: 'https://www.prix-carburants.gouv.fr/station/26600007',
+  },
+  { name: 'à SUPER U SAINT-DONAT', url: 'https://www.prix-carburants.gouv.fr/station/26260001' },
+]
+
+async function freshComposable() {
+  vi.resetModules()
+  const mod = await import('./useStationStorage')
+  return mod.useStationStorage()
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  store.clear()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Happy Path
+// ---------------------------------------------------------------------------
+
+describe('TC-01: First load with empty database seeds the five default stations', () => {
+  it('populates the reactive list with the five defaults and persists them', async () => {
+    const { stations, loadStations } = await freshComposable()
+
+    await loadStations()
+
+    expect(stations.value).toHaveLength(5)
+    expect(stations.value).toEqual(DEFAULT_STATIONS)
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toEqual(DEFAULT_STATIONS)
+  })
+})
+
+describe('TC-02: Subsequent load with populated database restores the stored list', () => {
+  it('uses the stored list and does not overwrite with defaults', async () => {
+    const threeStations: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+      { name: 'Station C', url: 'https://www.prix-carburants.gouv.fr/station/33333333' },
+    ]
+    store.set('stations', threeStations)
+
+    const { stations, loadStations } = await freshComposable()
+    await loadStations()
+
+    expect(stations.value).toHaveLength(3)
+    expect(stations.value).toEqual(threeStations)
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toEqual(threeStations)
+  })
+})
+
+describe('TC-03: Adding a station appends it to the reactive list and persists it', () => {
+  it('grows the list by one and writes all three stations to IndexedDB', async () => {
+    const initial: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+    ]
+    store.set('stations', initial)
+
+    const { stations, loadStations, addStation } = await freshComposable()
+    await loadStations()
+
+    const newStation: Station = {
+      name: 'Test Station',
+      url: 'https://www.prix-carburants.gouv.fr/station/12345678',
+    }
+    await addStation(newStation)
+
+    expect(stations.value).toHaveLength(3)
+    expect(stations.value[2]).toEqual(newStation)
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toHaveLength(3)
+    expect(storedInDb[2]).toEqual(newStation)
+  })
+})
+
+describe('TC-04: Removing a station by URL shrinks the list and persists the removal', () => {
+  it('removes only the targeted station and updates IndexedDB', async () => {
+    const threeStations: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+      { name: 'Station C', url: 'https://www.prix-carburants.gouv.fr/station/33333333' },
+    ]
+    store.set('stations', threeStations)
+
+    const { stations, loadStations, removeStation } = await freshComposable()
+    await loadStations()
+
+    await removeStation('https://www.prix-carburants.gouv.fr/station/22222222')
+
+    expect(stations.value).toHaveLength(2)
+    expect(stations.value.find((s) => s.url === 'https://www.prix-carburants.gouv.fr/station/22222222')).toBeUndefined()
+    expect(stations.value[0]).toEqual(threeStations[0])
+    expect(stations.value[1]).toEqual(threeStations[2])
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toHaveLength(2)
+    expect(storedInDb.find((s) => s.url === 'https://www.prix-carburants.gouv.fr/station/22222222')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Edge Cases
+// ---------------------------------------------------------------------------
+
+describe('TC-05: Removing a URL that does not exist in the list is a no-op', () => {
+  it('leaves the reactive list and IndexedDB unchanged', async () => {
+    const twoStations: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+    ]
+    store.set('stations', twoStations)
+
+    const { stations, loadStations, removeStation } = await freshComposable()
+    await loadStations()
+
+    const setCallsBefore = (store.get('stations') as Station[]).length
+
+    await expect(
+      removeStation('https://www.prix-carburants.gouv.fr/station/99999999'),
+    ).resolves.toBeUndefined()
+
+    expect(stations.value).toHaveLength(2)
+    expect(store.get('stations')).toEqual(twoStations)
+
+    // The set call count should not have increased (no write on no-op)
+    const { set } = await import('../utils/indexedDb')
+    // set was called once during loadStations? No — loadStations with existing data does no write.
+    // set was not called at all after removeStation no-op, so mock call count should be 0.
+    expect(set).not.toHaveBeenCalled()
+
+    void setCallsBefore // suppress unused warning
+  })
+})
+
+describe('TC-06: Second load when database already has data does not re-apply defaults', () => {
+  it('loads six stations (five defaults plus one user station) without overwriting', async () => {
+    const sixStations: Station[] = [
+      ...DEFAULT_STATIONS,
+      { name: 'User Station', url: 'https://www.prix-carburants.gouv.fr/station/99999999' },
+    ]
+    store.set('stations', sixStations)
+
+    const { stations, loadStations } = await freshComposable()
+    await loadStations()
+
+    expect(stations.value).toHaveLength(6)
+    expect(stations.value).toEqual(sixStations)
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toEqual(sixStations)
+  })
+})
+
+describe('TC-07: Adding a station to an empty list (after first-load seed) results in six stations', () => {
+  it('produces six stations with the new one last', async () => {
+    const { stations, loadStations, addStation } = await freshComposable()
+    await loadStations()
+
+    expect(stations.value).toHaveLength(5)
+
+    const sixth: Station = {
+      name: 'Sixth Station',
+      url: 'https://www.prix-carburants.gouv.fr/station/66666666',
+    }
+    await addStation(sixth)
+
+    expect(stations.value).toHaveLength(6)
+    expect(stations.value[5]).toEqual(sixth)
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toHaveLength(6)
+    expect(storedInDb[5]).toEqual(sixth)
+  })
+})
+
+describe('TC-08: All consumers of the composable share the same reactive state (singleton)', () => {
+  it('reflects an addition made via one reference in the other reference', async () => {
+    const twoStations: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+    ]
+    store.set('stations', twoStations)
+
+    // Reset modules once, then import the module twice to get two call-site references
+    vi.resetModules()
+    const mod = await import('./useStationStorage')
+
+    const ref1 = mod.useStationStorage()
+    const ref2 = mod.useStationStorage()
+
+    await ref1.loadStations()
+
+    const newStation: Station = {
+      name: 'Station C',
+      url: 'https://www.prix-carburants.gouv.fr/station/33333333',
+    }
+    await ref1.addStation(newStation)
+
+    // Both references must see the updated list
+    expect(ref2.stations.value).toHaveLength(3)
+    expect(ref2.stations.value[2]).toEqual(newStation)
+    expect(ref1.stations.value).toBe(ref2.stations.value)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security-Derived Scenarios
+// ---------------------------------------------------------------------------
+
+describe('TC-09: Attempting to add a station with a URL from a disallowed origin is rejected', () => {
+  it('throws and leaves the list and IndexedDB unchanged', async () => {
+    const twoStations: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+    ]
+    store.set('stations', twoStations)
+
+    const { stations, loadStations, addStation } = await freshComposable()
+    await loadStations()
+
+    await expect(
+      addStation({ name: 'Evil Station', url: 'https://evil.example.com/station/1' }),
+    ).rejects.toThrow()
+
+    expect(stations.value).toHaveLength(2)
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toEqual(twoStations)
+  })
+})
+
+describe('TC-10: Attempting to add a station with a malformed URL is rejected', () => {
+  it('throws and leaves the list unchanged', async () => {
+    const { stations, loadStations, addStation } = await freshComposable()
+    await loadStations()
+
+    await expect(
+      addStation({ name: 'Bad URL Station', url: 'not-a-valid-url' }),
+    ).rejects.toThrow()
+
+    // List remains at five defaults
+    expect(stations.value).toHaveLength(5)
+  })
+})
+
+describe('TC-11: Attempting to add a station with a name containing HTML tags is rejected', () => {
+  it('throws because the name contains angle-bracket constructs', async () => {
+    const { stations, loadStations, addStation } = await freshComposable()
+    await loadStations()
+
+    await expect(
+      addStation({
+        name: '<script>alert(1)</script>',
+        url: 'https://www.prix-carburants.gouv.fr/station/00000001',
+      }),
+    ).rejects.toThrow()
+
+    expect(stations.value).toHaveLength(5)
+
+    const storedInDb = store.get('stations') as Station[]
+    // IndexedDB was written once (the seed); no additional write for the rejected station
+    expect(storedInDb).toHaveLength(5)
+    expect(
+      storedInDb.some((s) => s.name.includes('<script>')),
+    ).toBe(false)
+  })
+})
+
+describe('TC-12: Data read back from IndexedDB that lacks required fields is discarded', () => {
+  it('filters out malformed entries while loading valid ones normally', async () => {
+    const mixedData = [
+      { name: 'Incomplete Station' }, // missing url — invalid
+      { name: 'Valid Station', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+    ]
+    store.set('stations', mixedData)
+
+    const { stations, loadStations } = await freshComposable()
+
+    await expect(loadStations()).resolves.toBeUndefined()
+
+    expect(stations.value).toHaveLength(1)
+    expect(stations.value[0]).toEqual({
+      name: 'Valid Station',
+      url: 'https://www.prix-carburants.gouv.fr/station/11111111',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error and Failure Conditions
+// ---------------------------------------------------------------------------
+
+describe('TC-13: Load operation resolves gracefully when IndexedDB read returns undefined', () => {
+  it('seeds the five defaults when the store key is absent', async () => {
+    // store is empty — get('stations') returns undefined
+
+    const { stations, loadStations } = await freshComposable()
+
+    await expect(loadStations()).resolves.toBeUndefined()
+
+    expect(stations.value).toHaveLength(5)
+    expect(stations.value).toEqual(DEFAULT_STATIONS)
+  })
+})
+
+describe('TC-14: Load called multiple times does not corrupt the stored data', () => {
+  it('keeps the same three stations after a second load call', async () => {
+    const threeStations: Station[] = [
+      { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+      { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+      { name: 'Station C', url: 'https://www.prix-carburants.gouv.fr/station/33333333' },
+    ]
+    store.set('stations', threeStations)
+
+    const { stations, loadStations } = await freshComposable()
+    await loadStations()
+    await loadStations()
+
+    expect(stations.value).toHaveLength(3)
+    expect(stations.value).toEqual(threeStations)
+
+    const storedInDb = store.get('stations') as Station[]
+    expect(storedInDb).toEqual(threeStations)
+  })
+})

--- a/src/composables/useStationStorage.ts
+++ b/src/composables/useStationStorage.ts
@@ -1,0 +1,111 @@
+/**
+ * Singleton composable for persisting the user's gas station list.
+ *
+ * The reactive station list is declared at module level so all consumers
+ * share the same reference (ADR-002 singleton pattern).
+ *
+ * Persistence is handled via a thin IndexedDB wrapper (ADR-008).
+ * All input is validated before being stored (security-guidelines.md).
+ *
+ * Object Calisthenics exception: the composable function body exceeds
+ * five lines because Vue composable conventions require grouping all
+ * returned reactive state and operations in one function — this is a
+ * documented framework exception.
+ */
+
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import type { Station } from '@/types/station'
+import { get, set } from '@/utils/indexedDb'
+
+const STATIONS_KEY = 'stations'
+const MAX_NAME_LENGTH = 200
+const ALLOWED_ORIGIN = 'https://www.prix-carburants.gouv.fr'
+
+const DEFAULT_STATIONS: readonly Station[] = [
+  { name: 'à INTERMARCHE AOSTE', url: 'https://www.prix-carburants.gouv.fr/station/38490005' },
+  { name: 'à INTERMARCHE APPRIEU', url: 'https://www.prix-carburants.gouv.fr/station/38140005' },
+  { name: 'à SUPER U APPRIEU', url: 'https://www.prix-carburants.gouv.fr/station/38690006' },
+  {
+    name: "à INTERMARCHE TAIN L'HERMITAGE",
+    url: 'https://www.prix-carburants.gouv.fr/station/26600007',
+  },
+  { name: 'à SUPER U SAINT-DONAT', url: 'https://www.prix-carburants.gouv.fr/station/26260001' },
+]
+
+const stations: Ref<Station[]> = ref([])
+
+function isValidUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl)
+    return parsed.origin === ALLOWED_ORIGIN
+  } catch {
+    return false
+  }
+}
+
+function stripHtmlTags(text: string): string {
+  return text.replace(/<[^>]*>/g, '')
+}
+
+function isValidName(name: string): boolean {
+  const stripped = stripHtmlTags(name)
+  return stripped === name && name.length > 0 && name.length <= MAX_NAME_LENGTH
+}
+
+function isStation(value: unknown): value is Station {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.name === 'string' && typeof candidate.url === 'string'
+}
+
+function filterValidStations(raw: unknown): Station[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter(isStation)
+}
+
+async function seedDefaults(): Promise<void> {
+  const seedList = [...DEFAULT_STATIONS]
+  await set(STATIONS_KEY, seedList)
+  stations.value = seedList
+}
+
+async function loadStations(): Promise<void> {
+  const stored = await get<unknown>(STATIONS_KEY)
+  const validStations = filterValidStations(stored)
+  if (validStations.length > 0) {
+    stations.value = validStations
+    return
+  }
+  await seedDefaults()
+}
+
+async function addStation(station: Station): Promise<void> {
+  if (!isValidUrl(station.url)) throw new Error(`Invalid station URL: ${station.url}`)
+  if (!isValidName(station.name)) throw new Error(`Invalid station name: ${station.name}`)
+  const updated = [...stations.value, station]
+  await set(STATIONS_KEY, updated)
+  stations.value = updated
+}
+
+async function removeStation(url: string): Promise<void> {
+  const filtered = stations.value.filter((station) => station.url !== url)
+  const hasChanged = filtered.length !== stations.value.length
+  if (!hasChanged) return
+  await set(STATIONS_KEY, filtered)
+  stations.value = filtered
+}
+
+export function useStationStorage(): {
+  stations: Ref<Station[]>
+  loadStations: () => Promise<void>
+  addStation: (station: Station) => Promise<void>
+  removeStation: (url: string) => Promise<void>
+} {
+  return {
+    stations,
+    loadStations,
+    addStation,
+    removeStation,
+  }
+}

--- a/src/utils/indexedDb.ts
+++ b/src/utils/indexedDb.ts
@@ -1,0 +1,74 @@
+/**
+ * Thin Promise-based wrapper around the native IndexedDB API.
+ *
+ * Exposes three operations: get, set, del.
+ * The IDBDatabase connection is cached at module level so it is opened
+ * once per page load and reused on every subsequent call (ADR-008).
+ *
+ * Known limitations (documented in ADR-008):
+ * - No onblocked handler for schema upgrade across tabs.
+ * - No cursor or index support — keyed get/set/delete only.
+ */
+
+const DB_NAME = 'french-gas-stations'
+const DB_VERSION = 1
+const STORE_NAME = 'keyval'
+
+let cachedDatabase: IDBDatabase | null = null
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (cachedDatabase !== null) return Promise.resolve(cachedDatabase)
+  return new Promise((resolve, reject) => {
+    const openRequest = indexedDB.open(DB_NAME, DB_VERSION)
+    openRequest.onupgradeneeded = () => {
+      openRequest.result.createObjectStore(STORE_NAME)
+    }
+    openRequest.onsuccess = () => {
+      cachedDatabase = openRequest.result
+      resolve(cachedDatabase)
+    }
+    openRequest.onerror = () => reject(openRequest.error)
+  })
+}
+
+function runTransaction(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest,
+): Promise<unknown> {
+  return openDatabase().then((database) => {
+    return new Promise((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, mode)
+      const store = transaction.objectStore(STORE_NAME)
+      const request = operation(store)
+      if (mode === 'readonly') {
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+        return
+      }
+      let requestResult: unknown
+      request.onsuccess = () => {
+        requestResult = request.result
+      }
+      transaction.oncomplete = () => resolve(requestResult)
+      transaction.onerror = () => reject(transaction.error)
+      transaction.onabort = () => reject(transaction.error)
+    })
+  })
+}
+
+export function get<T>(key: string): Promise<T | undefined> {
+  return runTransaction('readonly', (store) => store.get(key)) as Promise<T | undefined>
+}
+
+export function set(key: string, value: unknown): Promise<void> {
+  return runTransaction('readwrite', (store) => store.put(value, key)) as Promise<void>
+}
+
+export function del(key: string): Promise<void> {
+  return runTransaction('readwrite', (store) => store.delete(key)) as Promise<void>
+}
+
+/** Reset the cached connection — used in tests that need a fresh database. */
+export function resetDatabaseConnection(): void {
+  cachedDatabase = null
+}


### PR DESCRIPTION
## Summary
- Add `src/utils/indexedDb.ts` — Promise-based `get`/`set`/`del` wrapper with cached connection and `resetDatabaseConnection()` for test isolation
- Add `src/composables/useStationStorage.ts` — singleton composable (ADR-002, ADR-008) with reactive `stations` ref, `loadStations` (seeds 5 defaults on empty DB), `addStation` (URL origin + name validation), `removeStation` (no-op if not found)
- Write durability via `transaction.oncomplete` for all writes

## Test plan
- [x] 14 new composable tests with `vi.mock` IndexedDB — all pass
- [x] Full suite: 78 tests across 5 files — all pass
- [x] `npm run type-check` exits 0

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)