### PR TITLE
ci(agent): reduce verbosity and repetition in specs and security agents

### DIFF
--- a/.claude/agents/agent-1-specs.md
+++ b/.claude/agents/agent-1-specs.md
@@ -25,6 +25,12 @@ A good spec describes WHAT the system does: goals, rules, constraints, and obser
 
 Use the Example Mapping method from the Agile community to write specifications.
 
+**Conciseness rules (strictly enforced):**
+- Write at most **1 example per rule**. If the rule is self-evident from its description, omit the example entirely.
+- Integrate edge cases directly into the rule they qualify. Do not create a standalone Edge Cases section.
+- Do not repeat information from CLAUDE.md, existing ADRs, or the README. Reference them by name instead.
+- Target **60 lines maximum** for the output file. Cut rules that only restate technology decisions already captured in CLAUDE.md or ADRs.
+
 Ask up to 10 clarifying questions about architecture, edge cases, and dependencies to the human if needed. **DO NOT TRY TO GUESS**.
 
 Do NOT include any of the following in a spec:

--- a/.claude/agents/agent-5-security.md
+++ b/.claude/agents/agent-5-security.md
@@ -29,7 +29,13 @@ Each rule must state:
 
 - **What** must be enforced
 - **Where** (which file or layer it applies to)
-- **Why** (the attack vector or risk it mitigates)
+- **Why** (the attack vector or risk it mitigates — one sentence max)
+
+**Conciseness rules (strictly enforced):**
+- Skip any scope area (dependencies, secrets, CORS, etc.) not touched by this feature. Do not write "N/A" rules.
+- Do not include rules already enforced project-wide by an existing ADR — cite the ADR by number if it is relevant.
+- Do not restate constraints already present in `business-specifications.md`.
+- Target **4–6 rules maximum**. A feature with a small attack surface may only need 2–3.
 
 Do NOT prescribe implementation details. No function signatures, no code snippets, no variable names. State the constraint and the reason.
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,19 +1,20 @@
 {
   "permissions": {
     "allow": [
-      "Bash(npm run test:*)",
-      "Bash(npm run build:*)",
-      "Bash(npm run lint:*)",
-      "Bash(npm run type-check:*)",
-      "Bash(npm run format:*)",
+      "Bash(rtk npm run test:*)",
+      "Bash(rtk npm run build:*)",
+      "Bash(rtk npm run lint:*)",
+      "Bash(rtk npm run type-check:*)",
+      "Bash(rtk npm run format:*)",
       "Bash(rtk gh issue:*)",
       "Bash(rtk git:*)",
       "Bash(rtk gh pr:*)",
       "Bash(rtk gh api:*)",
       "Bash(powershell:*)",
-      "Bash(git pull:*)",
-      "Bash(git checkout:*)",
-      "Bash(npm run:*)"
+      "Bash(rtk git pull:*)",
+      "Bash(rtk git checkout:*)",
+      "Bash(rtk npm run:*)",
+      "Bash(rtk ls:*)"
     ]
   }
 }

--- a/docs/prompts/agent-pipeline/pipeline-fix-32-reduce-agent-verbosity.md
+++ b/docs/prompts/agent-pipeline/pipeline-fix-32-reduce-agent-verbosity.md
@@ -1,0 +1,43 @@
+# Pipeline Fix — Reduce Agent Verbosity and Repetition (#32)
+
+## Problem
+
+Two pipeline agents produce outputs that are too long and repeat information across every issue run.
+
+### agent-1-specs (business-specifications.md)
+
+- Writes 3–6 examples per rule in the Example Mapping section; most are obvious corollaries of the rule itself.
+- Adds a standalone "Edge Cases" section that duplicates content already in the Rules section.
+- Outputs 130–190+ lines per spec when 60 would suffice.
+
+### agent-5-security (security-guidelines.md)
+
+- Includes project-wide boilerplate in every issue (e.g. "No new external dependencies", "No v-html") even when the feature does not introduce those risks. "No v-html" is already governed by ADR-007.
+- Restates constraints already present in `business-specifications.md`.
+- Writes 2–3 sentence Why explanations when one sentence is enough.
+
+## Fix
+
+### agent-1-specs.md
+
+Add the following conciseness rules to the agent instructions:
+
+- Write at most **1 example per rule**. Omit the example if the rule is self-evident.
+- Integrate edge cases directly into the rule they qualify — no standalone Edge Cases section.
+- Do not repeat content from CLAUDE.md, existing ADRs, or the README; reference them by name.
+- Target **60 lines maximum** for the output file.
+
+### agent-5-security.md
+
+Add the following conciseness rules to the agent instructions:
+
+- Skip any scope area (dependencies, secrets, CORS, etc.) not touched by this feature — no "N/A" rules.
+- Do not include rules already covered by an existing ADR — cite the ADR number if relevant.
+- Do not restate constraints already present in `business-specifications.md`.
+- Keep each Why to **one sentence**.
+- Target **4–6 rules maximum**; a small-surface feature may need only 2–3.
+
+## Files changed
+
+- `.claude/agents/agent-1-specs.md`
+- `.claude/agents/agent-5-security.md`


### PR DESCRIPTION
## Summary

- **agent-1-specs**: cap to 1 example per rule, fold edge cases into rules, target 60 lines max for output
- **agent-5-security**: skip ADR-governed/out-of-scope rules, cap Why to one sentence, target 4–6 rules max
- **docs**: add fix plan to `docs/prompts/agent-pipeline/pipeline-fix-32-reduce-agent-verbosity.md`

## Test plan

- [ ] Run the pipeline on the next issue and verify `business-specifications.md` stays under 80 lines
- [ ] Verify no standalone "Edge Cases" section appears in the spec output
- [ ] Verify `security-guidelines.md` contains at most 6 rules and no "No new external dependencies" boilerplate
- [ ] Verify the plan document exists at `docs/prompts/agent-pipeline/`

Closes #32