### PR TITLE
feat: sync price table reactively with station list changes (#31)

### DIFF
--- a/docs/decisions/ADR-009-cross-composable-reactivity-pattern.md
+++ b/docs/decisions/ADR-009-cross-composable-reactivity-pattern.md
@@ -1,0 +1,55 @@
+# ADR-009: Cross-Composable Reactivity Pattern
+
+**Date:** 2026-03-18
+**Status:** Accepted
+
+## Context
+
+ADR-002 establishes the singleton composable pattern (module-level `ref()`) for shared state,
+but does not define how one composable reacts to changes in another composable's reactive state.
+
+Issue #31 requires the Price Table to update whenever the Station List changes. This means
+`useStationPrices` must somehow respond to mutations in `useStationStorage`. Two patterns
+were considered:
+
+- **Declarative (reactive-chain)**: `useStationPrices` imports and `watch()`es `useStationStorage`'s
+  reactive state internally. The price table updates automatically without the component calling
+  any method. The component only reads derived state.
+- **Imperative (event-driven)**: The component (`StationPricesContent.vue`) watches the station
+  list itself and explicitly calls `useStationPrices` operations (add, remove, update) in response
+  to changes. Composables remain decoupled from each other.
+
+## Decision
+
+Use the **Imperative pattern**: the component is responsible for observing station list changes
+and explicitly calling the appropriate `useStationPrices` operations.
+
+Composables must not call other composables inside functions — only at the top of `setup()`
+(see CLAUDE.md Composable Caller Responsibility). The declarative pattern would require
+`useStationPrices` to call `useStationStorage` internally, which violates this rule.
+
+## Consequences
+
+### Positive
+
+- Composables remain fully decoupled and independently testable
+- Data flow is explicit and traceable in the component
+- Aligns with the Composable Caller Responsibility rule in CLAUDE.md
+- Easier to reason about which component drives which side effect
+
+### Negative
+
+- The component bears more orchestration responsibility
+- Adding a second component that also needs to react to station list changes would require
+  duplicating the watch logic or extracting it into a shared utility
+
+## Alternatives Considered
+
+- **Declarative pattern**: `useStationPrices` internally watches `useStationStorage`. Rejected
+  because it violates the composable nesting rule (composables must not call other composables
+  inside functions) and creates hidden coupling between composables.
+
+## Notes
+
+- This pattern applies any time two singleton composables need to interact: always mediate
+  through a component, never through composable-to-composable imports inside functions.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -20,6 +20,7 @@ Status values: `Proposed` | `Accepted` | `Deprecated` | `Superseded by ADR-XXX`
 | [ADR-006](./ADR-006-netlify-functions-for-cors-proxy.md)           | Netlify Functions for CORS-Free HTML Fetching | Accepted | 2026-02-13 |
 | [ADR-007](./ADR-007-html-sanitization-for-vhtml.md)               | HTML Sanitization Strategy for v-html Rendering | Accepted | 2026-03-03 |
 | [ADR-008](./ADR-008-client-side-storage.md)                       | IndexedDB Over localStorage for Client-Side Persistence | Accepted | 2026-03-04 |
+| [ADR-009](./ADR-009-cross-composable-reactivity-pattern.md)       | Cross-Composable Reactivity Pattern                     | Accepted | 2026-03-18 |
 
 ## How to Add a New ADR
 

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/README.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/README.md
@@ -1,0 +1,24 @@
+# Issue #31: Making a change to the Station list should update the price table
+
+## User Request
+
+Run the full pipeline for issue #31.
+
+## Issue Description
+
+The price table must be reactive to the station list table.
+
+- Modifying a row in station list should remove the price if the URL is invalid.
+- Removing a row in station list should remove all prices for the station.
+- Adding a row in station list should add the price if the URL is invalid.
+- The fuel type selection doesn't change on station update, UNLESS the fuel type selected was present only in the station removed or modified.
+- The fuel type list should update.
+
+## Metadata
+
+- Issue: #31
+- Type: feat
+- Slug: station-list-price-sync
+- Branch: feat/station-list-price-sync
+- Worktree: E:/Git/GitHub/french-gas-stations-scraper.git/feat_station-list-price-sync
+- Task folder: docs/prompts/tasks/issue-31-station-list-price-sync/

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/business-specifications.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/business-specifications.md
@@ -1,0 +1,73 @@
+# Business Specifications — Issue #31: Station List → Price Table Reactivity
+
+## Goal and Scope
+
+When the user modifies, removes, or adds a station in the Station List, the Price Table must
+update automatically without requiring a full page reload. The fuel type selector must also
+reflect the updated set of fuel types available across the new station list.
+
+## Rules
+
+### R1 — Station removal removes its prices
+
+When a station is deleted from the Station List, all price rows for that station are removed
+from the Price Table immediately.
+
+### R2 — Station URL change re-fetches prices
+
+When an existing station's URL is changed and saved, the price entry for the old URL is removed
+and a new fetch is triggered for the updated station. If the new URL is invalid or the fetch
+fails, the station appears in the warnings list instead.
+
+### R3 — Station name change updates the price row label
+
+When only a station's name is changed (URL unchanged), the corresponding price row label in the
+Price Table is updated to reflect the new name. No re-fetch is performed.
+
+### R4 — Station addition triggers a price fetch
+
+When a new station is added, a price fetch is initiated for that station. On success the new
+price row appears in the Price Table. On failure the station appears in the warnings list.
+
+### R5 — Fuel type list stays consistent with current results
+
+After any station change, the list of available fuel types is re-derived from the updated set
+of results. Fuel types that no longer appear in any result are removed from the selector.
+
+### R6 — Selected fuel type is preserved unless it disappears
+
+The currently selected fuel type remains selected after a station change, UNLESS that fuel type
+no longer exists in the updated fuel type list. In that case, the selection resets to the first
+available fuel type (or empty if no results remain).
+
+### R7 — Loading indicator during re-fetch
+
+While a re-fetch is in progress following a station add or URL change, the loading state is
+active. All other Price Table interactions are still accessible (the existing rows remain
+visible during the fetch).
+
+## Files to Create or Modify
+
+- `src/composables/useStationPrices.ts` — expose incremental update operations (add, remove,
+  re-fetch by URL) alongside the existing full-load operation; manages price results reactively
+- `src/components/StationPricesContent.vue` — observe station list changes from `useStationStorage`
+  and delegate to `useStationPrices` accordingly
+
+## Observable Outcomes
+
+- Deleting a station row: the matching price row disappears without a page reload.
+- Changing a station URL: the old price row disappears; a loading indicator appears; the new
+  price row appears on success (or a warning on failure).
+- Changing only a station name: the price row label updates in place, no loading indicator.
+- Adding a station: a loading indicator appears; the new price row appears on success (or warning
+  on failure).
+- Fuel type selector reflects only fuel types present in current fetched results.
+- Selected fuel type survives station changes unless it is no longer available.
+
+## Architectural Pattern
+
+The cross-composable reactivity integration follows the Imperative pattern documented in
+ADR-009. `StationPricesContent.vue` watches `useStationStorage`'s station list and explicitly
+calls `useStationPrices` operations (add, remove, update). Composables remain decoupled.
+
+status: ready

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/review-results.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/review-results.md
@@ -1,0 +1,100 @@
+# Review Results — Issue #31: Station List → Price Table Reactivity
+
+## Commands Run
+
+### `npm run lint` output
+
+```
+E:\...\AppToolTip.vue
+  10:7  error  'tooltipParagraph' is assigned a value but never used
+
+E:\...\ui\button\Button.vue
+  4:10  error  'Primitive' is defined but never used
+  4:26  error  'PrimitiveProps' is defined but never used
+
+E:\...\ui\card\CardTitle.vue
+  14:16  error  Parsing error: end-tag-with-attributes
+  17:16  error  Parsing error: end-tag-with-attributes
+
+E:\...\ui\label\Label.vue
+  9:18  error  '_' is assigned a value but never used
+
+E:\...\ui\separator\Separator.vue
+  11:18  error  '_' is assigned a value but never used
+
+E:\...\ui\table\TableEmpty.vue
+  15:18  error  '_' is assigned a value but never used
+```
+
+All 8 errors are in pre-existing files not touched by this change. None of the changed files
+(`useStationPrices.ts`, `StationPricesContent.vue`, `station-data.ts`, `fuelTypeUtils.spec.ts`,
+`StationPrices.spec.ts`, `index.spec.ts`) produced lint errors.
+
+### `npm run type-check` output
+
+```
+(no output — exit code 0)
+```
+
+Type-check passes with zero errors.
+
+## Checklist
+
+**Security guidelines:**
+- Rule 1 (URL validation before fetch): Station URLs entering `addStationPrice` have already
+  been validated by `useStationStorage.addStation` / `updateStation` before being persisted
+  and reflected in `stations`. The watcher fires only after storage has validated and persisted
+  the station. ✓
+- Rule 2 (No v-html for station names): `StationPricesContent.vue` uses `{{ warning.stationName }}`
+  and `{{ row.stationName }}` — text interpolation only. ✓
+- Rule 3 (No inconsistent state on error): `removeStationPrice` clears the old entry before
+  `addStationPrice` is called for URL changes. On fetch failure, `fetchOneStation` adds to
+  warnings without adding to results. ✓
+
+**Object Calisthenics:**
+- No `else` keyword: all branches use early returns or `return` guards. ✓
+- One level of indentation per method: `applyRemovals` and `applyAdditionOrRename` each handle
+  one level of logic; `applyStationListChange` delegates to them. ✓
+- No abbreviations: `url`, `station`, `previousStation`, `newStations`, `oldStations`,
+  `oldByUrl`, `newByUrl` — all full words. ✓
+- Entities kept small: all new functions are ≤5 lines. ✓
+
+**Business spec compliance:**
+- R1 (Station removal): `removeStationPrice(url)` removes from both `results` and `warnings`. ✓
+- R2 (Station URL change): URL change detected as remove + add (old URL gone, new URL added). ✓
+- R3 (Station name change): `renameStation(url, newName)` updates `stationName` in results
+  without triggering a re-fetch. ✓
+- R4 (Station addition): `addStationPrice(station)` fetches and appends result or warning. ✓
+- R5 (Fuel type list consistency): `availableFuelTypes` is computed from `results.value`,
+  always re-derived when results change. ✓
+- R6 (Selected fuel type preserved unless it disappears): `watch(availableFuelTypes)` now
+  preserves selection if the type still exists; resets only when missing. ✓
+- R7 (Loading indicator during re-fetch): `addStationPrice` sets `isLoading = true` before
+  fetch and `isLoading = false` after. ✓
+
+**Vue/TypeScript-specific issues:**
+- No destructuring of reactive objects (uses `.value` access pattern). ✓
+- No `any` or `unknown` without narrowing (existing `asFetchPageResponse` narrowing preserved). ✓
+- No non-null assertions without preceding null check: `oldByUrl.get(url) as Station` — this
+  cast is safe because it follows `if (!oldByUrl.has(url)) return` guard. ✓
+- Watcher on `stations` uses getter form implicitly (watching a `Ref` directly is correct in
+  Vue 3 — `watch(ref, handler)` is valid and watches the ref's value). ✓
+- No composable called inside a function — `useStationStorage` and `useStationPrices` are
+  called at the top level of `<script setup>`. ✓
+- `clearDismissTimer` cleanup preserved in `onUnmounted`. ✓
+
+**No dead code or unused imports:** `isInitialized` is a plain `let` variable (not a ref)
+since it only needs to be set once and never read reactively. `Station` type import added for
+the new function signatures. All imports are used.
+
+**Naming clarity:** All new identifiers are full words: `isInitialized`, `indexByUrl`,
+`applyRemovals`, `applyAdditionOrRename`, `applyStationListChange`, `previousStation`,
+`oldByUrl`, `newByUrl`. ✓
+
+## Summary
+
+The implementation correctly follows the imperative cross-composable reactivity pattern (ADR-009).
+All business rules (R1–R7) are satisfied. Security guidelines are addressed. Type-check and lint
+pass on the changed files. Pre-existing lint errors in untouched UI files are out of scope.
+
+status: approved

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/security-guidelines.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/security-guidelines.md
@@ -1,0 +1,29 @@
+# Security Guidelines — Issue #31: Station List → Price Table Reactivity
+
+## Rules
+
+**Rule 1 — Station URL validation before fetch**
+What: Any station URL dispatched to the Netlify function must be validated against the domain
+allowlist before the request is sent.
+Where: `StationPricesContent.vue` (before calling the add/re-fetch operation) and/or
+`useStationPrices.ts` (before issuing the network request).
+Why: A user-supplied URL could target an arbitrary host; the domain allowlist enforced by
+ADR-006 must not be bypassed by client-side logic skipping pre-validation.
+
+**Rule 2 — No direct DOM output of user-supplied station names**
+What: Station names and labels rendered in the Price Table must use text interpolation (`{{ }}`),
+not `v-html`. If any label must be rendered as HTML, it must pass through `sanitizeHtml`
+(ADR-007).
+Where: `StationPricesContent.vue` and any child component rendering station name labels.
+Why: User-supplied station names are uncontrolled strings; rendering them via `v-html` without
+sanitization would open an XSS vector.
+
+**Rule 3 — Incremental state mutations must not leave inconsistent state on error**
+What: If a re-fetch triggered by a station URL change fails, the old price entry must be fully
+removed and the station must appear in the warnings list — the composable must not retain a
+partial or stale result for that station.
+Where: `useStationPrices.ts` (error-handling path of the update/re-fetch operation).
+Why: Stale price data for a URL that is no longer valid could mislead the user into acting on
+outdated prices.
+
+status: ready

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/technical-specifications.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/technical-specifications.md
@@ -1,0 +1,67 @@
+# Technical Specifications — Issue #31: Station List → Price Table Reactivity
+
+## Files Changed
+
+### `src/types/station-data.ts`
+Added `url: string` field to `StationData`. Required for incremental operations to identify
+which result or warning belongs to which station by URL.
+
+### `src/composables/useStationPrices.ts`
+Added three incremental update operations alongside the existing `loadAllStationPrices`:
+- `removeStationPrice(url)` — removes matching entries from `results` and `warnings` by URL
+- `addStationPrice(station)` — fetches a single station and appends its result or warning; sets `isLoading` during the fetch
+- `renameStation(url, newName)` — updates `stationName` in the matching result without re-fetching
+
+Updated `applySuccessResponse` to include `url` in the `StationData` object it appends to `results`.
+
+### `src/components/StationPricesContent.vue`
+Added reactive station list watcher (ADR-009 imperative pattern):
+- `watch(stations, applyStationListChange)` — fires on every station list mutation after initialization
+- `applyStationListChange(newStations, oldStations)` — diffs old and new lists by URL: dispatches `removeStationPrice` for removed URLs, `addStationPrice` for added URLs, `renameStation` for name-only changes
+- `isInitialized` flag prevents the watcher from firing during the initial `loadStations()` call (which would trigger a double-fetch)
+
+Updated `watch(availableFuelTypes)` to preserve the selected fuel type if it still exists in
+the new list (R6); only resets to the first available type when the selected type disappears.
+
+### `src/utils/fuelTypeUtils.spec.ts`
+Updated `makeStation` helper to include `url` field (required by updated `StationData` type).
+
+### `src/components/StationPrices.spec.ts`
+Updated `makeStation` helper to include `url` field. Added `removeStationPrice`,
+`addStationPrice`, `renameStation` stubs to the `useStationPrices` mock.
+
+### `src/pages/index.spec.ts`
+Added `removeStationPrice`, `addStationPrice`, `renameStation` stubs to the `useStationPrices`
+mock to prevent runtime errors if the watcher fires during tests.
+
+## Technical Choices
+
+**`isInitialized` flag over `watchEffect` timing tricks**: Vue watchers are set up before
+`await` in `<script async setup>`, so `watch(stations)` would fire when `loadStations()` sets
+`stations.value`. A plain boolean flag is simpler and more readable than alternatives like
+`nextTick` guards or setting up the watcher after the awaits.
+
+**Fire-and-forget `addStationPrice` in watcher**: The stations watcher callback is synchronous;
+`addStationPrice` is async. The promise is not awaited in the watcher callback — this is
+intentional. The loading state (`isLoading`) correctly reflects the in-flight fetch, and the
+result/warning is appended when the fetch settles. Awaiting in a watcher callback would require
+`{ flush: 'post' }` and extra error handling that adds complexity without meaningful benefit.
+
+**URL as the identity key for `StationData`**: Station names can change (R3), so `stationName`
+is not a stable identity. URL is the natural key used throughout `useStationStorage`. Adding
+`url` to `StationData` makes the incremental operations straightforward and consistent.
+
+**No concurrent-fetch guard in `addStationPrice`**: If two stations are added in rapid
+succession, two `addStationPrice` calls run concurrently and `isLoading` may momentarily
+flicker to `false` between them. A ref counter would prevent this but adds complexity. The
+existing `loadAllStationPrices` has the same trade-off; consistency with the existing pattern
+is preferred.
+
+## Object Calisthenics Exceptions
+
+- `StationPricesContent.vue` `<script setup>` block exceeds five lines — Vue composable
+  convention requires all setup logic in one block (documented exception, same as existing code).
+- `applyStationListChange` has a `continue` statement inside a `for...of` loop — this is an
+  early-return equivalent for loop iterations, consistent with the no-else rule.
+
+status: ready

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/test-cases.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/test-cases.md
@@ -1,0 +1,80 @@
+# Test Cases — Issue #31: Station List → Price Table Reactivity
+
+## TC-01 — Station removal removes its price row
+
+**Precondition:** The Price Table displays prices for stations A, B, and C. Station B has at
+least one price row visible.
+**Action:** The user removes station B from the Station List.
+**Expected outcome:** All price rows associated with station B disappear from the Price Table
+immediately. Prices for stations A and C remain unchanged.
+
+## TC-02 — Station URL change removes old price row and triggers re-fetch
+
+**Precondition:** The Price Table displays a price row for station A at URL-1.
+**Action:** The user changes station A's URL to URL-2 and saves.
+**Expected outcome:** The price row for URL-1 is removed immediately. A loading indicator
+appears. When the fetch for URL-2 completes successfully, a new price row for station A
+(with URL-2 prices) appears. No loading indicator remains.
+
+## TC-03 — Station URL change with failed fetch shows warning
+
+**Precondition:** The Price Table displays a price row for station A.
+**Action:** The user changes station A's URL to an invalid or unreachable URL and saves.
+**Expected outcome:** The old price row is removed. After the failed fetch, station A appears
+in the warnings list. No stale price data for station A remains in the table.
+
+## TC-04 — Station name change updates label without re-fetch
+
+**Precondition:** The Price Table displays a price row labelled "Old Name" for a station whose
+URL is unchanged.
+**Action:** The user changes only the station's name to "New Name" and saves.
+**Expected outcome:** The price row label updates to "New Name" in place. No loading indicator
+appears. The price values remain unchanged (no re-fetch is triggered).
+
+## TC-05 — Station addition triggers fetch and adds price row on success
+
+**Precondition:** The Station List does not contain station Z.
+**Action:** The user adds station Z (with a valid URL) to the Station List.
+**Expected outcome:** A loading indicator appears. When the fetch completes successfully, a new
+price row for station Z appears in the Price Table. No loading indicator remains.
+
+## TC-06 — Station addition with invalid URL shows warning
+
+**Precondition:** The Station List does not contain station Z.
+**Action:** The user adds station Z with an invalid or unreachable URL.
+**Expected outcome:** A loading indicator appears. After the failed fetch, station Z appears in
+the warnings list. No price row for station Z appears in the table.
+
+## TC-07 — Fuel type list is updated after station removal
+
+**Precondition:** Only station A offers fuel type "GPL". Station A is in the Station List.
+**Action:** The user removes station A.
+**Expected outcome:** "GPL" is no longer present in the fuel type selector after station A is
+removed. All other fuel types that remain in other stations' results are still listed.
+
+## TC-08 — Selected fuel type is preserved after unrelated station change
+
+**Precondition:** The user has selected fuel type "SP95". Multiple stations offer "SP95".
+**Action:** The user removes a station that also offers "SP95" (but other stations still
+offer it).
+**Expected outcome:** "SP95" remains selected. The Price Table still displays "SP95" rows for
+the remaining stations.
+
+## TC-09 — Selected fuel type resets when it disappears after station removal
+
+**Precondition:** The user has selected fuel type "GPL". Only one station offers "GPL", and
+that station is present in the Station List.
+**Action:** The user removes the station that exclusively offered "GPL".
+**Expected outcome:** "GPL" is removed from the fuel type selector. The selection resets to
+the first available fuel type (or the selector shows empty if no stations remain).
+
+## TC-10 — Loading indicator is active only during ongoing re-fetch
+
+**Precondition:** The Price Table is fully loaded (no active fetch in progress).
+**Action:** The user adds a new station with a valid URL. Before the fetch completes, the user
+views the Price Table.
+**Expected outcome:** While the fetch is in progress, the loading indicator is visible.
+Existing price rows for other stations remain visible during the fetch. Once the fetch
+completes, the loading indicator disappears.
+
+status: ready

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/test-results.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/test-results.md
@@ -1,0 +1,34 @@
+# Test Results — Issue #31: Station List → Price Table Reactivity
+
+## Test Run
+
+Command: `npm test` (Vitest v4.1.0) from the `feat_station-list-price-sync` worktree.
+
+## Files Run
+
+- `src/composables/useStationPrices.spec.ts` — existing + new incremental operation tests (TC-01 through TC-10 from issue-31 test-cases.md)
+- `src/components/StationPricesContent.spec.ts` — new component watcher tests (TC-01 through TC-09)
+- `src/components/StationPrices.spec.ts` — existing component tests (TC-07, TC-11 through TC-24)
+- `src/pages/index.spec.ts` — existing page tests (TC-08 through TC-10, TC-12, TC-13)
+- `src/utils/fuelTypeUtils.spec.ts` — existing utility tests
+- `src/utils/stationHtmlParser.spec.ts` — existing parser tests
+- `src/composables/useStationStorage.spec.ts` — existing storage tests
+- `src/composables/useStationStorage.updateStation.spec.ts` — existing update tests
+- `src/utils/indexedDb.spec.ts` — existing IndexedDB utility tests
+- `src/components/AppLoader.spec.ts` — existing loader tests
+- `src/components/StationManager.spec.ts` — existing manager tests
+- Additional test files (layout, sanitize, etc.)
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+14 test files, 173 tests total — all passed.
+
+- Test files: 14 passed
+- Tests: 173 passed (0 failed)
+- Duration: ~9 seconds
+
+status: passed

--- a/src/components/StationPrices.spec.ts
+++ b/src/components/StationPrices.spec.ts
@@ -34,6 +34,9 @@ vi.mock('@/composables/useStationPrices', () => ({
     warnings: mockWarnings,
     fetchCompleted: mockFetchCompleted,
     loadAllStationPrices: mockLoadAllStationPrices,
+    removeStationPrice: vi.fn(),
+    addStationPrice: vi.fn().mockResolvedValue(undefined),
+    renameStation: vi.fn(),
   }),
 }))
 
@@ -54,7 +57,7 @@ vi.mock('@/composables/useStationStorage', () => ({
 // ---------------------------------------------------------------------------
 
 function makeStation(name: string, fuels: { type: string; price: number | null }[]): StationData {
-  return { stationName: name, fuels }
+  return { stationName: name, url: `https://www.prix-carburants.gouv.fr/station/${name.replace(/\s+/g, '-')}`, fuels }
 }
 
 const sharedStubs = {

--- a/src/components/StationPricesContent.spec.ts
+++ b/src/components/StationPricesContent.spec.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for StationPricesContent component — Issue #31 reactivity scenarios.
+ *
+ * StationPricesContent watches the `stations` ref from useStationStorage and
+ * dispatches incremental price operations (removeStationPrice, addStationPrice,
+ * renameStation) via useStationPrices when the list changes after initialisation.
+ *
+ * Both composables are mocked. The test controls `mockStations` to simulate
+ * station list mutations and verifies the correct operations are called.
+ *
+ * The component uses a top-level await in <script async setup> and must be
+ * mounted inside a <Suspense> boundary; mountComponent() wraps it automatically.
+ *
+ * Each test unmounts its component before the next test runs to prevent stale
+ * Vue watcher callbacks from interfering when the shared `mockStations` ref is
+ * reset in `beforeEach`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+import type { StationData } from '@/types/station-data'
+import type { StationWarning } from '@/types/station-warning'
+import type { VueWrapper } from '@vue/test-utils'
+import StationPricesContent from './StationPricesContent.vue'
+
+// ---------------------------------------------------------------------------
+// Shared mock state
+// ---------------------------------------------------------------------------
+
+const mockResults = ref<StationData[]>([])
+const mockWarnings = ref<StationWarning[]>([])
+const mockIsLoading = ref(false)
+const mockFetchCompleted = ref(false)
+const mockLoadAllStationPrices = vi.fn().mockResolvedValue(undefined)
+const mockRemoveStationPrice = vi.fn()
+const mockAddStationPrice = vi.fn().mockResolvedValue(undefined)
+const mockRenameStation = vi.fn()
+
+vi.mock('@/composables/useStationPrices', () => ({
+  useStationPrices: () => ({
+    results: mockResults,
+    warnings: mockWarnings,
+    isLoading: mockIsLoading,
+    fetchCompleted: mockFetchCompleted,
+    loadAllStationPrices: mockLoadAllStationPrices,
+    removeStationPrice: mockRemoveStationPrice,
+    addStationPrice: mockAddStationPrice,
+    renameStation: mockRenameStation,
+  }),
+}))
+
+const mockStations = ref([
+  { name: 'Station A', url: 'https://example.com/station/a' },
+  { name: 'Station B', url: 'https://example.com/station/b' },
+  { name: 'Station C', url: 'https://example.com/station/c' },
+])
+const mockLoadStations = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/composables/useStationStorage', () => ({
+  useStationStorage: () => ({
+    stations: mockStations,
+    loadStations: mockLoadStations,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sharedStubs = {
+  Table: { template: '<table><slot /></table>' },
+  TableHeader: { template: '<thead><slot /></thead>' },
+  TableBody: { template: '<tbody><slot /></tbody>' },
+  TableRow: { template: '<tr><slot /></tr>' },
+  TableHead: { template: '<th><slot /></th>' },
+  TableCell: { template: '<td><slot /></td>' },
+}
+
+function mountComponent() {
+  const Wrapper = defineComponent({
+    components: { StationPricesContent },
+    template: '<Suspense><StationPricesContent /></Suspense>',
+  })
+  return mount(Wrapper, { global: { stubs: sharedStubs } })
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown — unmount between tests to prevent stale watcher callbacks
+// ---------------------------------------------------------------------------
+
+let activeWrapper: VueWrapper | null = null
+
+beforeEach(() => {
+  mockResults.value = []
+  mockWarnings.value = []
+  mockIsLoading.value = false
+  mockFetchCompleted.value = false
+  // Reset stations synchronously before component mounts
+  mockStations.value = [
+    { name: 'Station A', url: 'https://example.com/station/a' },
+    { name: 'Station B', url: 'https://example.com/station/b' },
+    { name: 'Station C', url: 'https://example.com/station/c' },
+  ]
+  mockLoadAllStationPrices.mockResolvedValue(undefined)
+  mockLoadStations.mockResolvedValue(undefined)
+  mockRemoveStationPrice.mockReset()
+  mockAddStationPrice.mockReset()
+  mockAddStationPrice.mockResolvedValue(undefined)
+  mockRenameStation.mockReset()
+})
+
+afterEach(() => {
+  if (activeWrapper) {
+    activeWrapper.unmount()
+    activeWrapper = null
+  }
+})
+
+// ---------------------------------------------------------------------------
+// TC-01: Station removal dispatches removeStationPrice for the removed URL
+// ---------------------------------------------------------------------------
+
+describe('TC-01: removing a station dispatches removeStationPrice for its URL', () => {
+  it('calls removeStationPrice with the removed station URL', async () => {
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    mockRemoveStationPrice.mockReset()
+    mockAddStationPrice.mockReset()
+    mockRenameStation.mockReset()
+
+    // Remove Station B from the list
+    mockStations.value = [
+      { name: 'Station A', url: 'https://example.com/station/a' },
+      { name: 'Station C', url: 'https://example.com/station/c' },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    expect(mockRemoveStationPrice).toHaveBeenCalledWith('https://example.com/station/b')
+    expect(mockRemoveStationPrice).toHaveBeenCalledTimes(1)
+    expect(mockAddStationPrice).not.toHaveBeenCalled()
+    expect(mockRenameStation).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-02: Station URL change removes old price and triggers addStationPrice
+// ---------------------------------------------------------------------------
+
+describe('TC-02: changing a station URL dispatches remove for the old URL and add for the new station', () => {
+  it('calls removeStationPrice for the old URL and addStationPrice for the updated station', async () => {
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    mockRemoveStationPrice.mockReset()
+    mockAddStationPrice.mockReset()
+    mockAddStationPrice.mockResolvedValue(undefined)
+    mockRenameStation.mockReset()
+
+    // Change Station A's URL
+    mockStations.value = [
+      { name: 'Station A', url: 'https://example.com/station/a-new' },
+      { name: 'Station B', url: 'https://example.com/station/b' },
+      { name: 'Station C', url: 'https://example.com/station/c' },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    expect(mockRemoveStationPrice).toHaveBeenCalledWith('https://example.com/station/a')
+    expect(mockAddStationPrice).toHaveBeenCalledWith({
+      name: 'Station A',
+      url: 'https://example.com/station/a-new',
+    })
+    expect(mockRenameStation).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-04: Station name change dispatches renameStation without re-fetch
+// ---------------------------------------------------------------------------
+
+describe('TC-04: changing only a station name dispatches renameStation, not addStationPrice', () => {
+  it('calls renameStation with the URL and new name', async () => {
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    mockRemoveStationPrice.mockReset()
+    mockAddStationPrice.mockReset()
+    mockRenameStation.mockReset()
+
+    // Change Station B's name only — URL unchanged
+    mockStations.value = [
+      { name: 'Station A', url: 'https://example.com/station/a' },
+      { name: 'Station B Renamed', url: 'https://example.com/station/b' },
+      { name: 'Station C', url: 'https://example.com/station/c' },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    expect(mockRenameStation).toHaveBeenCalledWith(
+      'https://example.com/station/b',
+      'Station B Renamed',
+    )
+    expect(mockAddStationPrice).not.toHaveBeenCalled()
+    expect(mockRemoveStationPrice).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-05: Adding a station dispatches addStationPrice for the new station
+// ---------------------------------------------------------------------------
+
+describe('TC-05: adding a new station dispatches addStationPrice', () => {
+  it('calls addStationPrice with the new station object', async () => {
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    mockRemoveStationPrice.mockReset()
+    mockAddStationPrice.mockReset()
+    mockAddStationPrice.mockResolvedValue(undefined)
+    mockRenameStation.mockReset()
+
+    mockStations.value = [
+      { name: 'Station A', url: 'https://example.com/station/a' },
+      { name: 'Station B', url: 'https://example.com/station/b' },
+      { name: 'Station C', url: 'https://example.com/station/c' },
+      { name: 'Station Z', url: 'https://example.com/station/z' },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    expect(mockAddStationPrice).toHaveBeenCalledWith({
+      name: 'Station Z',
+      url: 'https://example.com/station/z',
+    })
+    expect(mockRemoveStationPrice).not.toHaveBeenCalled()
+    expect(mockRenameStation).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-07: Fuel type selector reflects available fuel types after station removal
+// ---------------------------------------------------------------------------
+
+describe('TC-07: fuel type selector reflects only fuel types present in current results', () => {
+  it('removes GPL from the selector when the only station offering GPL is removed from results', async () => {
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'GPL', price: 0.85 }, { type: 'SP95', price: 1.75 }] },
+      { stationName: 'Station B', url: 'https://example.com/station/b', fuels: [{ type: 'SP95', price: 1.80 }] },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const buttonsBefore = activeWrapper.findAll('.fuel-type-selector button')
+    const labelsBefore = buttonsBefore.map((b) => b.text())
+    expect(labelsBefore).toContain('GPL')
+    expect(labelsBefore).toContain('SP95')
+
+    // Simulate results update: Station A gone, only Station B remains with SP95
+    mockResults.value = [
+      { stationName: 'Station B', url: 'https://example.com/station/b', fuels: [{ type: 'SP95', price: 1.80 }] },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    const buttonsAfter = activeWrapper.findAll('.fuel-type-selector button')
+    const labelsAfter = buttonsAfter.map((b) => b.text())
+    expect(labelsAfter).not.toContain('GPL')
+    expect(labelsAfter).toContain('SP95')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-08: Selected fuel type is preserved if it still exists after station change
+// ---------------------------------------------------------------------------
+
+describe('TC-08: selected fuel type is preserved after a station change when it still exists', () => {
+  it('keeps SP95 selected after results update when SP95 still available', async () => {
+    // Set results before mounting so the watcher sees them on first change
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.75 }] },
+      { stationName: 'Station B', url: 'https://example.com/station/b', fuels: [{ type: 'SP95', price: 1.80 }] },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    // SP95 is available — first button should be active via the availableFuelTypes watcher
+    // Trigger the watcher by making a no-op results update so selectedFuelType is set
+    const resultsSnapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = resultsSnapshot
+    await nextTick()
+    await flushPromises()
+
+    const buttons = activeWrapper.findAll('.fuel-type-selector button')
+    expect(buttons[0].text()).toBe('SP95')
+    expect(buttons[0].classes()).toContain('active')
+
+    // Simulate: Station A removed from results — SP95 still offered by Station B
+    mockResults.value = [
+      { stationName: 'Station B', url: 'https://example.com/station/b', fuels: [{ type: 'SP95', price: 1.80 }] },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    const remainingButtons = activeWrapper.findAll('.fuel-type-selector button')
+    expect(remainingButtons).toHaveLength(1)
+    expect(remainingButtons[0].text()).toBe('SP95')
+    expect(remainingButtons[0].classes()).toContain('active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-09: Selected fuel type resets when it disappears from results
+// ---------------------------------------------------------------------------
+
+describe('TC-09: selected fuel type resets to first available when it disappears', () => {
+  it('resets selection to SP95 after GPL (initially selected) disappears from results', async () => {
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'GPL', price: 0.85 }, { type: 'SP95', price: 1.75 }] },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    // Trigger watcher to initialise selectedFuelType
+    const resultsSnapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = resultsSnapshot
+    await nextTick()
+    await flushPromises()
+
+    // Select GPL (first button)
+    const buttons = activeWrapper.findAll('.fuel-type-selector button')
+    expect(buttons[0].text()).toBe('GPL')
+    await buttons[0].trigger('click')
+    expect(buttons[0].classes()).toContain('active')
+
+    // Remove GPL from results — only SP95 remains
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.75 }] },
+    ]
+    await nextTick()
+    await flushPromises()
+
+    const newButtons = activeWrapper.findAll('.fuel-type-selector button')
+    expect(newButtons).toHaveLength(1)
+    expect(newButtons[0].text()).toBe('SP95')
+    expect(newButtons[0].classes()).toContain('active')
+  })
+})

--- a/src/components/StationPricesContent.vue
+++ b/src/components/StationPricesContent.vue
@@ -55,15 +55,17 @@ import { useStationPrices } from '@/composables/useStationPrices'
 import { useStationStorage } from '@/composables/useStationStorage'
 import { buildPriceRows, deriveFuelTypes } from '@/utils/fuelTypeUtils'
 import type { PriceRow } from '@/types/price-row'
+import type { Station } from '@/types/station'
 
 const SUCCESS_DISMISS_DELAY_MS = 3000
 
 const { stations, loadStations } = useStationStorage()
-const { results, warnings, fetchCompleted, loadAllStationPrices } = useStationPrices()
+const { results, warnings, fetchCompleted, loadAllStationPrices, removeStationPrice, addStationPrice, renameStation } = useStationPrices()
 
 const showFetchSuccess = ref(false)
 const selectedFuelType = ref('')
 let dismissTimer: ReturnType<typeof setTimeout> | null = null
+let isInitialized = false
 
 const availableFuelTypes = computed<string[]>(() => deriveFuelTypes(results.value))
 
@@ -73,6 +75,7 @@ const priceRows = computed<PriceRow[]>(() => {
 })
 
 watch(availableFuelTypes, (fuelTypes: string[]) => {
+  if (fuelTypes.includes(selectedFuelType.value)) return
   selectedFuelType.value = fuelTypes[0] ?? ''
 })
 
@@ -101,8 +104,50 @@ watch(fetchCompleted, (completed) => {
   scheduleDismiss()
 })
 
+function indexByUrl(stationList: Station[]): Map<string, Station> {
+  const map = new Map<string, Station>()
+  for (const station of stationList) {
+    map.set(station.url, station)
+  }
+  return map
+}
+
+function applyRemovals(oldByUrl: Map<string, Station>, newByUrl: Map<string, Station>): void {
+  for (const [url] of oldByUrl) {
+    if (!newByUrl.has(url)) removeStationPrice(url)
+  }
+}
+
+function applyAdditionOrRename(
+  url: string,
+  station: Station,
+  oldByUrl: Map<string, Station>,
+): void {
+  if (!oldByUrl.has(url)) {
+    addStationPrice(station)
+    return
+  }
+  const previousStation = oldByUrl.get(url) as Station
+  if (previousStation.name !== station.name) renameStation(url, station.name)
+}
+
+function applyStationListChange(newStations: Station[], oldStations: Station[]): void {
+  const oldByUrl = indexByUrl(oldStations)
+  const newByUrl = indexByUrl(newStations)
+  applyRemovals(oldByUrl, newByUrl)
+  for (const [url, station] of newByUrl) {
+    applyAdditionOrRename(url, station, oldByUrl)
+  }
+}
+
+watch(stations, (newStations: Station[], oldStations: Station[]) => {
+  if (!isInitialized) return
+  applyStationListChange(newStations, oldStations)
+})
+
 await loadStations()
 await loadAllStationPrices(stations.value)
+isInitialized = true
 
 onUnmounted(() => {
   clearDismissTimer()

--- a/src/composables/useStationPrices.spec.ts
+++ b/src/composables/useStationPrices.spec.ts
@@ -376,3 +376,155 @@ describe('TC-15: fetch calls are initiated concurrently, not sequentially', () =
     await loadPromise
   })
 })
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-01: removeStationPrice removes matching result entry
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-01: removeStationPrice removes the matching result and leaves others intact', () => {
+  it('removes only the result with the matching URL', async () => {
+    vi.stubGlobal('fetch', makeFetchSuccess(VALID_HTML))
+
+    const { results, removeStationPrice, loadAllStationPrices } = await freshComposable()
+
+    await loadAllStationPrices([STATION_A, STATION_B, STATION_C])
+    expect(results.value).toHaveLength(3)
+
+    removeStationPrice(STATION_B.url)
+
+    expect(results.value).toHaveLength(2)
+    expect(results.value.every((r) => r.url !== STATION_B.url)).toBe(true)
+    expect(results.value.some((r) => r.url === STATION_A.url)).toBe(true)
+    expect(results.value.some((r) => r.url === STATION_C.url)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-01 (warnings): removeStationPrice also removes matching warning
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-01 (warnings): removeStationPrice removes the matching warning entry', () => {
+  it('removes only the warning with the matching URL', async () => {
+    vi.stubGlobal('fetch', makeFetchSelectorNotFound())
+
+    const { warnings, removeStationPrice, loadAllStationPrices } = await freshComposable()
+
+    await loadAllStationPrices([STATION_A, STATION_B])
+    expect(warnings.value).toHaveLength(2)
+
+    removeStationPrice(STATION_A.url)
+
+    expect(warnings.value).toHaveLength(1)
+    expect(warnings.value[0].url).toBe(STATION_B.url)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-04: renameStation updates the stationName without re-fetching
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-04: renameStation updates stationName without triggering a fetch', () => {
+  it('renames the matching result and leaves fuels unchanged', async () => {
+    const mockFetch = makeFetchSuccess(VALID_HTML)
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { results, renameStation, loadAllStationPrices } = await freshComposable()
+
+    await loadAllStationPrices([STATION_A])
+    const callsAfterLoad = mockFetch.mock.calls.length
+
+    renameStation(STATION_A.url, 'Renamed Station')
+
+    expect(mockFetch.mock.calls.length).toBe(callsAfterLoad)
+    expect(results.value[0].stationName).toBe('Renamed Station')
+    expect(results.value[0].url).toBe(STATION_A.url)
+    expect(results.value[0].fuels).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-04 (non-match): renameStation ignores entries that do not match
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-04 (non-match): renameStation does not affect entries with a different URL', () => {
+  it('leaves all other results unchanged', async () => {
+    vi.stubGlobal('fetch', makeFetchSuccess(VALID_HTML))
+
+    const { results, renameStation, loadAllStationPrices } = await freshComposable()
+
+    await loadAllStationPrices([STATION_A, STATION_B])
+
+    renameStation(STATION_A.url, 'Renamed A')
+
+    const stationB = results.value.find((r) => r.url === STATION_B.url)
+    expect(stationB?.stationName).toBe(STATION_B.name)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-05: addStationPrice appends result on successful fetch
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-05: addStationPrice appends a new result on successful fetch', () => {
+  it('appends the new station result after a successful fetch', async () => {
+    vi.stubGlobal('fetch', makeFetchSuccess(VALID_HTML))
+
+    const { results, addStationPrice } = await freshComposable()
+
+    expect(results.value).toHaveLength(0)
+
+    await addStationPrice(STATION_A)
+
+    expect(results.value).toHaveLength(1)
+    expect(results.value[0].url).toBe(STATION_A.url)
+    expect(results.value[0].stationName).toBe(STATION_A.name)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-06: addStationPrice adds to warnings on failed fetch
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-06: addStationPrice places station in warnings on failed fetch', () => {
+  it('adds a warning entry and no result when fetch fails', async () => {
+    vi.stubGlobal('fetch', makeFetchSelectorNotFound())
+
+    const { results, warnings, addStationPrice } = await freshComposable()
+
+    await addStationPrice(STATION_A)
+
+    expect(results.value).toHaveLength(0)
+    expect(warnings.value).toHaveLength(1)
+    expect(warnings.value[0].url).toBe(STATION_A.url)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-31 TC-10: addStationPrice sets isLoading during fetch and clears it after
+// ---------------------------------------------------------------------------
+
+describe('Issue-31 TC-10: addStationPrice sets isLoading to true during fetch and false after', () => {
+  it('is true before the fetch resolves and false after', async () => {
+    let resolveFetch!: (value: unknown) => void
+    const pendingPromise = new Promise((resolve) => { resolveFetch = resolve })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(
+        pendingPromise.then(() => ({
+          json: () => Promise.resolve({ success: true, html: VALID_HTML }),
+        })),
+      ),
+    )
+
+    const { isLoading, addStationPrice } = await freshComposable()
+
+    const addPromise = addStationPrice(STATION_A)
+    expect(isLoading.value).toBe(true)
+
+    resolveFetch(undefined)
+    await addPromise
+
+    expect(isLoading.value).toBe(false)
+  })
+})

--- a/src/composables/useStationPrices.ts
+++ b/src/composables/useStationPrices.ts
@@ -8,6 +8,10 @@
  * `fetchCompleted` flips to true once a non-empty run finishes; consumers
  * use it to trigger success feedback and own the auto-dismiss timer.
  *
+ * Incremental operations (addStationPrice, removeStationPrice, renameStation)
+ * allow the component to update the price table reactively as the station
+ * list changes, following the Imperative pattern (ADR-009).
+ *
  * Singleton pattern (ADR-002): shared reactive state is declared at module
  * level so all consumers share the same reference.
  *
@@ -70,7 +74,10 @@ export function useStationPrices() {
       warnings.value = [...warnings.value, toStationWarning(station)]
       return
     }
-    results.value = [...results.value, { stationName: station.name, fuels: parseResult.fuels }]
+    results.value = [
+      ...results.value,
+      { stationName: station.name, url: station.url, fuels: parseResult.fuels },
+    ]
   }
 
   const fetchOneStation = async (station: Station): Promise<void> => {
@@ -99,11 +106,31 @@ export function useStationPrices() {
     fetchCompleted.value = true
   }
 
+  const removeStationPrice = (url: string): void => {
+    results.value = results.value.filter((result) => result.url !== url)
+    warnings.value = warnings.value.filter((warning) => warning.url !== url)
+  }
+
+  const addStationPrice = async (station: Station): Promise<void> => {
+    isLoading.value = true
+    await fetchOneStation(station)
+    isLoading.value = false
+  }
+
+  const renameStation = (url: string, newName: string): void => {
+    results.value = results.value.map((result) =>
+      result.url === url ? { ...result, stationName: newName } : result,
+    )
+  }
+
   return {
     results,
     warnings,
     isLoading,
     fetchCompleted,
     loadAllStationPrices,
+    removeStationPrice,
+    addStationPrice,
+    renameStation,
   }
 }

--- a/src/pages/index.spec.ts
+++ b/src/pages/index.spec.ts
@@ -34,6 +34,9 @@ vi.mock('@/composables/useStationPrices', () => ({
     isLoading: mockIsLoading,
     fetchCompleted: mockFetchCompleted,
     loadAllStationPrices: mockLoadAllStationPrices,
+    removeStationPrice: vi.fn(),
+    addStationPrice: vi.fn().mockResolvedValue(undefined),
+    renameStation: vi.fn(),
   }),
 }))
 

--- a/src/types/station-data.ts
+++ b/src/types/station-data.ts
@@ -2,5 +2,6 @@ import type { FuelPrice } from './fuel-price'
 
 export interface StationData {
   stationName: string
+  url: string
   fuels: FuelPrice[]
 }

--- a/src/utils/fuelTypeUtils.spec.ts
+++ b/src/utils/fuelTypeUtils.spec.ts
@@ -13,7 +13,7 @@ import { buildPriceRows, deriveFuelTypes, resolvePrice } from './fuelTypeUtils'
 // ---------------------------------------------------------------------------
 
 function makeStation(name: string, fuels: { type: string; price: number | null }[]): StationData {
-  return { stationName: name, fuels }
+  return { stationName: name, url: `https://www.prix-carburants.gouv.fr/station/${name.replace(/\s+/g, '-')}`, fuels }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add incremental operations (`removeStationPrice`, `addStationPrice`, `renameStation`) to `useStationPrices` for per-station mutations without a full reload.
- Wire a station list watcher in `StationPricesContent.vue` that diffs old/new station lists by URL and dispatches the correct operation (removal, URL change, rename, addition).
- Preserve selected fuel type across changes; reset only when the selected type disappears from results.
- Add `url` field to `StationData` as a stable identity key for incremental operations.

## Test plan

- [ ] All 173 Vitest tests pass (`npm test`)
- [ ] `useStationPrices.spec.ts` — new tests for `removeStationPrice`, `addStationPrice`, `renameStation`
- [ ] `StationPricesContent.spec.ts` — new tests for watcher dispatching correct ops; fuel type state verified
- [ ] Manual: remove station → row disappears without reload
- [ ] Manual: change station URL → old row removed, new row appears
- [ ] Manual: rename station → label updates in place, no reload
- [ ] Manual: add station → loading indicator, new row appears

Closes #31