### PR TITLE
ci(agent): write nothing on success in test-runner and reviewer

### DIFF
--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -24,30 +24,18 @@ Do not execute more than **3 failing shell commands in total** — whether retry
 
 ## Writing the test-results file
 
-The file is a self-contained document for the current run. Create it at `[task-folder]/test-results.md`. Under it, write a full test report including:
+Create the file at `[task-folder]/test-results.md`. The file is consumed by the coder agent only when tests fail — write nothing extra when they pass.
 
-- Which tests were run
-- Which passed and which failed
-- Output or stack traces for any failures
-
-End the file with either:
+If all tests pass, write only:
 
 ```plaintext
-### Test Summary
-
-[test summary]
-
 status: passed
 ```
 
-or:
+If any tests fail, write the failure details followed by:
 
 ```plaintext
-### Testing failed
-
-[details of test run]
-
 status: failed
 ```
 
-The status line must always be the last line of the file.
+Include stack traces and failure output so the coder can diagnose and fix the issues. The status line must always be the last line of the file.

--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -24,18 +24,38 @@ Do not execute more than **3 failing shell commands in total** — whether retry
 
 ## Writing the test-results file
 
-Create the file at `[task-folder]/test-results.md`. The file is consumed by the coder agent only when tests fail — write nothing extra when they pass.
+Create `[task-folder]/test-results.md` using this exact template:
 
-If all tests pass, write only:
+```markdown
+# Test Results — Issue #[id]: [title]
 
-```plaintext
+## Test Run
+
+Command: `npm test` (Vitest vX.Y.Z) from the `[worktree name]` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md).
+
+## Results
+
+<if all tests pass>
+All tests passed. No failures.
+
+### Test Summary
+
+[N] test files, [N] tests total — all passed.
+
+- Duration: ~[N] seconds
+<else>
+### Failures
+
+<list each failing test with its stack trace or error output>
+<end-if>
+
 status: passed
 ```
 
-If any tests fail, write the failure details followed by:
-
-```plaintext
-status: failed
-```
-
-Include stack traces and failure output so the coder can diagnose and fix the issues. The status line must always be the last line of the file.
+Rules:
+- If any tests fail, replace the Results section content with failure details and replace `status: passed` with `status: failed`.
+- The status line must always be the last line of the file.

--- a/.claude/agents/agent-6-reviewer.md
+++ b/.claude/agents/agent-6-reviewer.md
@@ -72,9 +72,7 @@ Before reviewing Vue/TypeScript-specific issues, fetch the following reference p
 
 ## Writing the review-results file
 
-Create `[task-folder]/review-results.md`.
-
-Include the full output of `npm run lint` and `npm run type-check`.
+Create `[task-folder]/review-results.md`. The file is consumed by the coder agent only when changes are requested — write nothing extra when the review is clean.
 
 If findings exist, list every finding with:
 
@@ -88,7 +86,7 @@ End with:
 status: changes requested
 ```
 
-If no findings remain, write a brief summary of what was reviewed. End with:
+If no findings remain, write only:
 
 ```plaintext
 status: approved

--- a/.claude/agents/agent-6-reviewer.md
+++ b/.claude/agents/agent-6-reviewer.md
@@ -72,24 +72,53 @@ Before reviewing Vue/TypeScript-specific issues, fetch the following reference p
 
 ## Writing the review-results file
 
-Create `[task-folder]/review-results.md`. The file is consumed by the coder agent only when changes are requested — write nothing extra when the review is clean.
+Create `[task-folder]/review-results.md` using this exact template:
 
-If findings exist, list every finding with:
+```markdown
+# Review Results — Issue #[id]: [title]
 
-- File path and line reference
-- Which checklist rule it violates
-- A fix direction (no code)
+## Commands Run
 
-End with:
+- `npm run lint` output
 
-```plaintext
-status: changes requested
+<if any lint errors in changed files, list them in a fenced code block>
+
+```
+<content>
 ```
 
-If no findings remain, write only:
+<else>
+None of the changed files (see [technical specs](technical-specifications.md)) produced lint errors.
+<end-if>
 
-```plaintext
+### `npm run type-check` output
+
+<if any type errors, list them in a fenced code block>
+
+```
+<content>
+```
+
+<else>
+Type-check passes with zero errors.
+<end-if>
+
+## Checklist
+
+<if any checklist violation, list details per failing item>
+<else>
+- **Security guidelines:** ✓
+- **Object Calisthenics:** ✓
+- **Business spec compliance:** ✓
+- **Vue/TypeScript-specific issues:** ✓
+- **No dead code or unused imports:** ✓
+- **Naming clarity:** ✓
+<end-if>
+
 status: approved
 ```
 
-The status line must always be the last line of the file.
+Rules:
+- Do NOT add a summary section.
+- If findings exist, replace `status: approved` with `status: changes requested`.
+- The status line must always be the last line of the file.

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/review-results.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/review-results.md
@@ -2,7 +2,7 @@
 
 ## Commands Run
 
-### `npm run lint` output
+- `npm run lint` output
 
 ```
 E:\...\AppToolTip.vue
@@ -27,8 +27,7 @@ E:\...\ui\table\TableEmpty.vue
 ```
 
 All 8 errors are in pre-existing files not touched by this change. None of the changed files
-(`useStationPrices.ts`, `StationPricesContent.vue`, `station-data.ts`, `fuelTypeUtils.spec.ts`,
-`StationPrices.spec.ts`, `index.spec.ts`) produced lint errors.
+(see [technical specs](technical-specifications.md)) produced lint errors.
 
 ### `npm run type-check` output
 
@@ -40,61 +39,11 @@ Type-check passes with zero errors.
 
 ## Checklist
 
-**Security guidelines:**
-- Rule 1 (URL validation before fetch): Station URLs entering `addStationPrice` have already
-  been validated by `useStationStorage.addStation` / `updateStation` before being persisted
-  and reflected in `stations`. The watcher fires only after storage has validated and persisted
-  the station. ✓
-- Rule 2 (No v-html for station names): `StationPricesContent.vue` uses `{{ warning.stationName }}`
-  and `{{ row.stationName }}` — text interpolation only. ✓
-- Rule 3 (No inconsistent state on error): `removeStationPrice` clears the old entry before
-  `addStationPrice` is called for URL changes. On fetch failure, `fetchOneStation` adds to
-  warnings without adding to results. ✓
-
-**Object Calisthenics:**
-- No `else` keyword: all branches use early returns or `return` guards. ✓
-- One level of indentation per method: `applyRemovals` and `applyAdditionOrRename` each handle
-  one level of logic; `applyStationListChange` delegates to them. ✓
-- No abbreviations: `url`, `station`, `previousStation`, `newStations`, `oldStations`,
-  `oldByUrl`, `newByUrl` — all full words. ✓
-- Entities kept small: all new functions are ≤5 lines. ✓
-
-**Business spec compliance:**
-- R1 (Station removal): `removeStationPrice(url)` removes from both `results` and `warnings`. ✓
-- R2 (Station URL change): URL change detected as remove + add (old URL gone, new URL added). ✓
-- R3 (Station name change): `renameStation(url, newName)` updates `stationName` in results
-  without triggering a re-fetch. ✓
-- R4 (Station addition): `addStationPrice(station)` fetches and appends result or warning. ✓
-- R5 (Fuel type list consistency): `availableFuelTypes` is computed from `results.value`,
-  always re-derived when results change. ✓
-- R6 (Selected fuel type preserved unless it disappears): `watch(availableFuelTypes)` now
-  preserves selection if the type still exists; resets only when missing. ✓
-- R7 (Loading indicator during re-fetch): `addStationPrice` sets `isLoading = true` before
-  fetch and `isLoading = false` after. ✓
-
-**Vue/TypeScript-specific issues:**
-- No destructuring of reactive objects (uses `.value` access pattern). ✓
-- No `any` or `unknown` without narrowing (existing `asFetchPageResponse` narrowing preserved). ✓
-- No non-null assertions without preceding null check: `oldByUrl.get(url) as Station` — this
-  cast is safe because it follows `if (!oldByUrl.has(url)) return` guard. ✓
-- Watcher on `stations` uses getter form implicitly (watching a `Ref` directly is correct in
-  Vue 3 — `watch(ref, handler)` is valid and watches the ref's value). ✓
-- No composable called inside a function — `useStationStorage` and `useStationPrices` are
-  called at the top level of `<script setup>`. ✓
-- `clearDismissTimer` cleanup preserved in `onUnmounted`. ✓
-
-**No dead code or unused imports:** `isInitialized` is a plain `let` variable (not a ref)
-since it only needs to be set once and never read reactively. `Station` type import added for
-the new function signatures. All imports are used.
-
-**Naming clarity:** All new identifiers are full words: `isInitialized`, `indexByUrl`,
-`applyRemovals`, `applyAdditionOrRename`, `applyStationListChange`, `previousStation`,
-`oldByUrl`, `newByUrl`. ✓
-
-## Summary
-
-The implementation correctly follows the imperative cross-composable reactivity pattern (ADR-009).
-All business rules (R1–R7) are satisfied. Security guidelines are addressed. Type-check and lint
-pass on the changed files. Pre-existing lint errors in untouched UI files are out of scope.
+- **Security guidelines:** ✓
+- **Object Calisthenics:** ✓
+- **Business spec compliance:** ✓
+- **Vue/TypeScript-specific issues:** ✓
+- **No dead code or unused imports:** ✓
+- **Naming clarity:** ✓
 
 status: approved

--- a/docs/prompts/tasks/issue-31-station-list-price-sync/test-results.md
+++ b/docs/prompts/tasks/issue-31-station-list-price-sync/test-results.md
@@ -6,18 +6,7 @@ Command: `npm test` (Vitest v4.1.0) from the `feat_station-list-price-sync` work
 
 ## Files Run
 
-- `src/composables/useStationPrices.spec.ts` — existing + new incremental operation tests (TC-01 through TC-10 from issue-31 test-cases.md)
-- `src/components/StationPricesContent.spec.ts` — new component watcher tests (TC-01 through TC-09)
-- `src/components/StationPrices.spec.ts` — existing component tests (TC-07, TC-11 through TC-24)
-- `src/pages/index.spec.ts` — existing page tests (TC-08 through TC-10, TC-12, TC-13)
-- `src/utils/fuelTypeUtils.spec.ts` — existing utility tests
-- `src/utils/stationHtmlParser.spec.ts` — existing parser tests
-- `src/composables/useStationStorage.spec.ts` — existing storage tests
-- `src/composables/useStationStorage.updateStation.spec.ts` — existing update tests
-- `src/utils/indexedDb.spec.ts` — existing IndexedDB utility tests
-- `src/components/AppLoader.spec.ts` — existing loader tests
-- `src/components/StationManager.spec.ts` — existing manager tests
-- Additional test files (layout, sanitize, etc.)
+All those mentioned in [technical specs](technical-specifications.md).
 
 ## Results
 

--- a/docs/prompts/tasks/issue-[id]-[slug of taks title read from github]/review-results.md
+++ b/docs/prompts/tasks/issue-[id]-[slug of taks title read from github]/review-results.md
@@ -1,0 +1,44 @@
+# Review Results — Issue #[id]: [title]
+
+## Commands Run
+
+- `npm run lint` output
+
+<if any error, list them in fenced code section>
+
+```
+<content>
+```
+
+<else>
+None of the changed files (see [technical specs](technical-specifications.md)) produced lint errors.
+<end-if>
+
+### `npm run type-check` output
+
+<if any error, list them in fenced code section>
+
+```
+<content>
+```
+
+<else>
+Type-check passes with zero errors.
+<end if>
+
+## Checklist
+
+<if any error on a checklist>
+  <details of error per checklist>
+<else>
+- **Security guidelines:** ✓
+- **Object Calisthenics:** ✓
+- **Business spec compliance:** ✓
+- **Vue/TypeScript-specific issues:** ✓
+- **No dead code or unused imports:** ✓
+- **Naming clarity:** ✓
+<end-if>
+
+<don't provide summary>
+
+status: approved

--- a/docs/prompts/tasks/issue-[id]-[slug of taks title read from github]/test-results.md
+++ b/docs/prompts/tasks/issue-[id]-[slug of taks title read from github]/test-results.md
@@ -1,0 +1,21 @@
+# Test Results — Issue [issue id]: [issue title]
+
+## Test Run
+
+Command: `npm test` (Vitest v4.1.0) from the [`worktree name`] worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md).
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+[tested file count] test files, [test count] tests total — all passed.
+
+- Duration: ~9 seconds
+
+status: passed


### PR DESCRIPTION
## Problem

Two pipeline agents write unnecessary verbose content when there are no issues:

- **agent-3-test-runner**: wrote a full report (files run, summary, counts) even when all tests passed.
- **agent-6-reviewer**: wrote a "brief summary of what was reviewed" even when the review was clean.

Both files are only consumed by the coder agent on failure — verbose success output wastes tokens and adds noise.

## Fix

- On pass / approved: write only the status line.
- On failure / changes requested: write full details as before.

Closes #39