### PR TITLE
ci(agent): enforce Tailwind CSS utility classes for styling

### DIFF
--- a/.claude/agents/agent-2-coder.md
+++ b/.claude/agents/agent-2-coder.md
@@ -153,10 +153,6 @@ Composables must never self-trigger data fetching on init. The caller component 
 
 Never call a composable inside a plain or async function within another composable. Composables must only be called at the top level of `setup()`. If a composable needs data from another, the caller component calls both in `setup()` and passes the data as a parameter to the action that needs it.
 
-## Tailwind CSS Styling
-
-Always use Tailwind CSS utility classes for styling. Do not write custom CSS (inline `style` attributes, `<style>` blocks, or external `.css` files) unless no Tailwind utility class covers the need. When a custom CSS rule is unavoidable, add an inline comment explaining why Tailwind is insufficient.
-
 ## Shell Command Retry Limit
 
 Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/.claude/agents/agent-2-coder.md
+++ b/.claude/agents/agent-2-coder.md
@@ -153,6 +153,10 @@ Composables must never self-trigger data fetching on init. The caller component 
 
 Never call a composable inside a plain or async function within another composable. Composables must only be called at the top level of `setup()`. If a composable needs data from another, the caller component calls both in `setup()` and passes the data as a parameter to the action that needs it.
 
+## Tailwind CSS Styling
+
+Always use Tailwind CSS utility classes for styling. Do not write custom CSS (inline `style` attributes, `<style>` blocks, or external `.css` files) unless no Tailwind utility class covers the need. When a custom CSS rule is unavoidable, add an inline comment explaining why Tailwind is insufficient.
+
 ## Shell Command Retry Limit
 
 Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ IndexedDB (client-side only) stores the list of station objects `{ name, url }`.
 - Vue 3 Composition API with `<script setup lang="ts">` always
 - Composables in `src/composables/` prefixed with `use`
 - Utility functions in `src/utils/` — pure functions, no Vue dependencies
-- **Styling**: always use Tailwind CSS utility classes. Write custom CSS (inline `style` attributes, `<style>` blocks, or `.css` files) only when no Tailwind utility class covers the need — and add a comment explaining why
+- **Styling** *(coder: write; reviewer: enforce)*: always use Tailwind CSS utility classes. Write custom CSS (inline `style` attributes, `<style>` blocks, or `.css` files) only when no Tailwind utility class covers the need — and add a comment explaining why
 
 ## Naming Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ IndexedDB (client-side only) stores the list of station objects `{ name, url }`.
 - Vue 3 Composition API with `<script setup lang="ts">` always
 - Composables in `src/composables/` prefixed with `use`
 - Utility functions in `src/utils/` — pure functions, no Vue dependencies
-- **Styling** *(coder: write; reviewer: enforce)*: always use Tailwind CSS utility classes. Write custom CSS (inline `style` attributes, `<style>` blocks, or `.css` files) only when no Tailwind utility class covers the need — and add a comment explaining why
+- **Styling** *(coder agent: write; reviewer agent: enforce)*: always use Tailwind CSS utility classes. Write custom CSS (inline `style` attributes, `<style>` blocks, or `.css` files) only when no Tailwind utility class covers the need — and add a comment explaining why
 
 ## Naming Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ IndexedDB (client-side only) stores the list of station objects `{ name, url }`.
 - Vue 3 Composition API with `<script setup lang="ts">` always
 - Composables in `src/composables/` prefixed with `use`
 - Utility functions in `src/utils/` — pure functions, no Vue dependencies
+- **Styling**: always use Tailwind CSS utility classes. Write custom CSS (inline `style` attributes, `<style>` blocks, or `.css` files) only when no Tailwind utility class covers the need — and add a comment explaining why
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Summary

- Add Tailwind CSS styling rule to `CLAUDE.md` Code Conventions section
- Add `## Tailwind CSS Styling` section to `agent-2-coder.md` with the same enforcement rule
- Custom CSS is allowed only when no Tailwind utility covers the need, and must be documented with a comment

## Test plan

- [ ] Verify `CLAUDE.md` Code Conventions lists the Tailwind rule
- [ ] Verify `agent-2-coder.md` contains the new `## Tailwind CSS Styling` section
- [ ] Trigger the pipeline on a new issue and confirm generated component code uses Tailwind classes exclusively

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #41