### PR TITLE
ci: fix worktree path and post-merge pull in fix-pipeline skill

### DIFF
--- a/.claude/commands/fix-pipeline.md
+++ b/.claude/commands/fix-pipeline.md
@@ -24,7 +24,7 @@ The session runs from `develop/`. The bare repo root is `..`.
 
 ```bash
 git -C .. fetch origin
-git -C .. worktree add ../ci_<slug> -b ci/<slug> origin/develop
+git -C .. worktree add ci_<slug> -b ci/<slug> origin/develop
 ```
 
 Record the resulting worktree absolute path as `[worktree]`.
@@ -83,5 +83,5 @@ git -C .. branch -D ci/<slug>
 Then pull latest into `develop/`:
 
 ```bash
-git pull origin develop
+git pull --rebase origin develop
 ```


### PR DESCRIPTION
## Summary

- Fix worktree created outside bare repo: drop `../` prefix from `worktree add` so it lands inside `french-gas-stations-scraper.git/`
- Fix post-merge pull failing on divergent branches: use `git pull --rebase origin develop`

## Test plan

- [ ] Run `/fix-pipeline` and confirm worktree is created at `french-gas-stations-scraper.git/ci_<slug>`
- [ ] Confirm `git pull --rebase` succeeds after merge when local `develop` has unpushed commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #44