### PR TITLE
ci: remove worktree before gh pr merge --delete-branch

### DIFF
--- a/.claude/commands/fix-pipeline.md
+++ b/.claude/commands/fix-pipeline.md
@@ -65,19 +65,13 @@ Show the user the PR URL and ask for approval to merge.
 
 ## Step 6 — Merge and clean up
 
-Once approved, run from the bare repo root (not from inside any worktree) to avoid `gh` attempting a local branch switch:
+Once approved, remove the worktree first (so the branch is free), then merge from the bare repo root:
 
 ```bash
-cd .. && gh pr merge <pr-url> --rebase --delete-branch
-```
-
-Then clean up from the bare repo root:
-
-```bash
-git -C .. fetch origin
 git -C .. worktree remove --force ci_<slug>
 git -C .. worktree prune
-git -C .. branch -D ci/<slug>
+cd .. && gh pr merge <pr-url> --rebase --delete-branch
+git -C .. fetch origin
 ```
 
 Then pull latest into `develop/`:


### PR DESCRIPTION
## Summary

Reorder Step 6 so the worktree is removed before `gh pr merge --delete-branch` runs. This frees the local branch and prevents the "cannot delete branch used by worktree" error.

New order:
1. `git worktree remove --force ci_<slug>`
2. `git worktree prune`
3. `gh pr merge <pr-url> --rebase --delete-branch`
4. `git fetch origin`

## Test plan

- [ ] Run `/fix-pipeline`, approve the PR, and confirm merge + branch deletion succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #46