### PR TITLE
feat: add default fuel type selection with persistence (#28)

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -89,6 +89,7 @@ declare global {
   const useAttrs: typeof import('vue').useAttrs
   const useCssModule: typeof import('vue').useCssModule
   const useCssVars: typeof import('vue').useCssVars
+  const useDefaultFuelType: typeof import('./src/composables/useDefaultFuelType').useDefaultFuelType
   const useId: typeof import('vue').useId
   const useModel: typeof import('vue').useModel
   const useRoute: typeof import('vue-router').useRoute

--- a/docs/prompts/tasks/issue-28-default-fuel-type/README.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/README.md
@@ -1,0 +1,15 @@
+# Issue #28 — Default fuel type
+
+## User Request
+
+The user can save a fuel type by default after a selection in the list.
+It must be persisted to IndexedDB.
+If the default exists, it should be used, otherwise, the logic isn't changed.
+
+An action should allow user to update his default, only if the default exists and if the fuel type selected is différent.
+
+The list of fuel types should be ordered by the default fuel type, if exists, otherwise, it is ordered as the code already does.
+
+## GitHub Issue
+
+https://github.com/JeremieLitzler/french-gas-stations-scraper/issues/28

--- a/docs/prompts/tasks/issue-28-default-fuel-type/business-specifications.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/business-specifications.md
@@ -1,0 +1,53 @@
+# Business Specifications — Issue #28: Default Fuel Type
+
+## Goal and Scope
+
+Allow the user to designate one fuel type as their personal default. The default is persisted to IndexedDB (ADR-008) so it survives page reloads. When the price view loads, it selects the default fuel type automatically instead of the first type in the derived list. The user can update the default at any time by selecting a different fuel type and triggering an explicit "Save as default" action; they can also clear it.
+
+## Stories
+
+### Story 1 — Save a default fuel type
+
+**Rule:** When the user clicks "Save as default" on the currently selected fuel type, that type is stored in IndexedDB under a dedicated key.
+
+**Rule:** The action is only available after at least one fuel type is selected (i.e. the price table is visible).
+
+**Rule:** After saving, the UI reflects that this type is the current default (e.g. a visual indicator on the button).
+
+### Story 2 — Load and apply the default on startup
+
+**Rule:** When the price view initialises and a default is stored, the selected fuel type is set to the stored default instead of the first available type.
+
+**Rule:** If the stored default fuel type is not present in the derived list (e.g. the station list changed), the selection falls back to the current first-available logic and the stored default is left unchanged.
+
+**Rule:** If no default is stored, behaviour is unchanged — the first derived fuel type is selected.
+
+### Story 3 — Update the default
+
+**Rule:** An "Update default" action is visible only when a default already exists AND the currently selected fuel type is different from the stored default.
+
+**Example:** Default is "SP95", user selects "Gasoil" → "Update default" appears. User clicks it → default becomes "Gasoil".
+
+### Story 4 — Ordered fuel type list
+
+**Rule:** The fuel type list is reordered so the default type always appears first, followed by the remaining types in their existing first-encountered order.
+
+**Rule:** If no default exists, the order is unchanged.
+
+## Files to Create or Modify
+
+- `src/utils/indexedDb.ts` — no change needed; existing `get`/`set` API is sufficient.
+- `src/composables/useDefaultFuelType.ts` — **new** singleton composable; owns the default fuel type reactive state and its IndexedDB persistence. Follows ADR-002 singleton pattern and ADR-008 storage approach.
+- `src/utils/fuelTypeUtils.ts` — add a pure function that, given the derived list and an optional default, returns the reordered list (default first, rest unchanged).
+- `src/components/StationPricesContent.vue` — integrate the new composable; render the save/update action; pass the default to the ordering function.
+- `src/utils/fuelTypeUtils.spec.ts` — extend with tests for the new ordering function.
+- `src/composables/useDefaultFuelType.spec.ts` — **new** test file for the composable.
+
+## Constraints
+
+- No new external dependency.
+- The default is stored as a plain string (the fuel type label) under a new IndexedDB key distinct from the stations key.
+- All reads/writes to IndexedDB are async; the UI must not block while persisting.
+- The save/update action must be keyboard accessible (a standard `<button>` element).
+
+status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/business-specifications.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/business-specifications.md
@@ -2,17 +2,19 @@
 
 ## Goal and Scope
 
-Allow the user to designate one fuel type as their personal default. The default is persisted to IndexedDB (ADR-008) so it survives page reloads. When the price view loads, it selects the default fuel type automatically instead of the first type in the derived list. The user can update the default at any time by selecting a different fuel type and triggering an explicit "Save as default" action; they can also clear it.
+Allow the user to designate one fuel type as their personal default. The default is persisted to IndexedDB (ADR-008) so it survives page reloads. When the price view loads, it selects the default fuel type automatically instead of the first type in the derived list. The user can update or clear the default at any time via explicit actions.
 
 ## Stories
 
 ### Story 1 — Save a default fuel type
 
-**Rule:** When the user clicks "Save as default" on the currently selected fuel type, that type is stored in IndexedDB under a dedicated key.
+**Rule:** "Save as default" is visible only when NO default is currently stored.
 
 **Rule:** The action is only available after at least one fuel type is selected (i.e. the price table is visible).
 
-**Rule:** After saving, the UI reflects that this type is the current default (e.g. a visual indicator on the button).
+**Rule:** When the user clicks "Save as default", the currently selected fuel type is stored in IndexedDB under a dedicated key. After saving, the button is hidden (a default now exists) and a visual indicator confirms the active default near the fuel selector or on the currently selected type row.
+
+**Example:** No default is stored. User selects "SP95". "Save as default" is visible. User clicks it → "SP95" is stored as default → "Save as default" disappears → a "Default" indicator appears near "SP95".
 
 ### Story 2 — Load and apply the default on startup
 
@@ -24,30 +26,70 @@ Allow the user to designate one fuel type as their personal default. The default
 
 ### Story 3 — Update the default
 
-**Rule:** An "Update default" action is visible only when a default already exists AND the currently selected fuel type is different from the stored default.
+**Rule:** "Update default" is visible only when a default is already stored AND the currently selected fuel type differs from the stored default.
 
-**Example:** Default is "SP95", user selects "Gasoil" → "Update default" appears. User clicks it → default becomes "Gasoil".
+**Rule:** When the user clicks "Update default", the stored default is replaced with the currently selected fuel type.
 
-### Story 4 — Ordered fuel type list
+**Example:** Default is "SP95", user selects "Gasoil" → "Update default" appears. User clicks it → default becomes "Gasoil" → "Update default" disappears → the "Default" indicator moves to "Gasoil".
+
+**Example:** Default is "SP95", user selects "SP95" (same as stored default) → "Update default" is hidden.
+
+### Story 4 — Clear the default
+
+**Rule:** "Clear default" is visible whenever a default is stored, regardless of which fuel type is currently selected.
+
+**Rule:** When the user clicks "Clear default", the stored default is removed from IndexedDB and the default state is reset to null.
+
+**Rule:** After clearing, the fuel type list returns to its natural (first-encountered) order — no reordering is applied.
+
+**Rule:** After clearing, "Save as default" becomes visible again and the "Default" indicator is removed.
+
+**Example:** Default is "SP95". User clicks "Clear default" → default removed → fuel list reverts to natural order → "Save as default" reappears → no "Default" indicator shown.
+
+### Story 5 — Ordered fuel type list
 
 **Rule:** The fuel type list is reordered so the default type always appears first, followed by the remaining types in their existing first-encountered order.
 
-**Rule:** If no default exists, the order is unchanged.
+**Rule:** If no default exists (never set or cleared), the order is unchanged.
+
+## Button Visibility Matrix
+
+| Condition | "Save as default" | "Update default" | "Clear default" |
+|---|---|---|---|
+| No default stored | visible | hidden | hidden |
+| Default stored, current selection = default | hidden | hidden | visible |
+| Default stored, current selection ≠ default | hidden | visible | visible |
+
+## Active State — "Default" Indicator
+
+When `isCurrentDefault` is true (the currently selected fuel type matches the stored default), a visual indicator is shown near the fuel selector or on the currently selected type row. This indicator is NOT the "Save as default" button (which is hidden whenever a default exists).
+
+## Button Styling
+
+All three action buttons ("Save as default", "Update default", "Clear default") must use the following CSS custom properties:
+
+```css
+--accent: var(--color-stone-200);
+--accent-foreground: var(--color-stone-800);
+```
+
+These variables must be applied consistently across all three buttons (e.g. as background and text colour respectively).
 
 ## Files to Create or Modify
 
-- `src/utils/indexedDb.ts` — no change needed; existing `get`/`set` API is sufficient.
-- `src/composables/useDefaultFuelType.ts` — **new** singleton composable; owns the default fuel type reactive state and its IndexedDB persistence. Follows ADR-002 singleton pattern and ADR-008 storage approach.
-- `src/utils/fuelTypeUtils.ts` — add a pure function that, given the derived list and an optional default, returns the reordered list (default first, rest unchanged).
-- `src/components/StationPricesContent.vue` — integrate the new composable; render the save/update action; pass the default to the ordering function.
-- `src/utils/fuelTypeUtils.spec.ts` — extend with tests for the new ordering function.
-- `src/composables/useDefaultFuelType.spec.ts` — **new** test file for the composable.
+- `src/utils/indexedDb.ts` — add a `remove` (or `delete`) helper if not already present, to support clearing the stored default key.
+- `src/composables/useDefaultFuelType.ts` — **new** singleton composable; owns the default fuel type reactive state and its IndexedDB persistence. Exposes `saveDefault`, `updateDefault`, `clearDefault`, and `isCurrentDefault`. Follows ADR-002 singleton pattern and ADR-008 storage approach.
+- `src/utils/fuelTypeUtils.ts` — add a pure function that, given the derived list and an optional default, returns the reordered list (default first, rest unchanged); when default is null, returns the list unchanged.
+- `src/components/StationPricesContent.vue` — integrate the new composable; render save/update/clear actions per the visibility matrix; show the "Default" indicator; pass the default to the ordering function; apply the specified button styling.
+- `src/utils/fuelTypeUtils.spec.ts` — extend with tests for the new ordering function (including the null/no-default case).
+- `src/composables/useDefaultFuelType.spec.ts` — **new** test file covering save, update, clear, load-on-startup, and fallback behaviours.
 
 ## Constraints
 
 - No new external dependency.
 - The default is stored as a plain string (the fuel type label) under a new IndexedDB key distinct from the stations key.
 - All reads/writes to IndexedDB are async; the UI must not block while persisting.
-- The save/update action must be keyboard accessible (a standard `<button>` element).
+- All three action buttons must be keyboard accessible (standard `<button>` elements).
+- "Clear default" must remove the key from IndexedDB entirely (not set it to an empty string or null string).
 
 status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/review-results.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/review-results.md
@@ -1,0 +1,42 @@
+# Review Results — Issue #28: Default Fuel Type
+
+## Commands Run
+
+- `npm run lint` output
+
+None of the changed files produced lint errors.
+
+### `npm run type-check` output
+
+Type-check passes with zero errors.
+
+## Checklist
+
+- [x] **Security rule 1 — validate stored value before use**: `loadDefaultFuelType` in `useDefaultFuelType.ts` uses `isNonEmptyString` to reject non-string and empty-string values from IndexedDB. The component's `validatedDefaultFuelType` computed cross-checks the accepted string against `derivedFuelTypes` before treating it as valid — returning `null` when absent from the live list. Two-layer validation is in place.
+- [x] **Security rule 2 — no `v-html`**: All fuel type label rendering uses `{{ }}` text interpolation throughout `StationPricesContent.vue`. No `v-html` usage in any changed file.
+- [x] **Security rule 3 — plain string storage only**: `saveDefaultFuelType(label: string)` passes the label directly to `set(DEFAULT_FUEL_TYPE_KEY, label)`. No object serialisation.
+- [x] **Security rule 4 — input array not mutated**: `orderFuelTypes` accepts `readonly string[]`, returns `[...fuelTypes]` or `[defaultFuelType, ...remaining]` via spread and `filter`. The input is never mutated.
+- [x] **Object Calisthenics**: All functions are small and single-purpose. The composable body exception is documented inline with a framework-convention rationale.
+- [x] **Business spec — Story 1 (save default)**: "Save as default" button is inside `v-if="availableFuelTypes.length > 0"`, calls `onSaveDefault()` which guards against empty selection, and applies the `default-fuel-button--saved` modifier class via `isCurrentDefault`.
+- [x] **Business spec — Story 2 (load and apply on startup)**: `loadDefaultFuelType()` is awaited before `loadAllStationPrices`; `resolveInitialSelection` uses `validatedDefaultFuelType` to prefer the stored default over the first available item.
+- [x] **Business spec — Story 2 fallback (stored default absent from derived list)**: `validatedDefaultFuelType` returns `null` when the stored value is not in `derivedFuelTypes`; `resolveInitialSelection` falls back to `fuelTypes[0]`. The persisted IndexedDB value is left intact (TC-11).
+- [x] **Business spec — Story 3 (update default)**: `showUpdateDefault` is `true` only when a validated default exists and the current selection differs. "Update default" button is rendered conditionally and calls `onSaveDefault()`.
+- [x] **Business spec — Story 4 (ordered list)**: `availableFuelTypes` computed applies `orderFuelTypes(derivedFuelTypes.value, validatedDefaultFuelType.value)` reactively.
+- [x] **Keyboard accessibility**: Both "Save as default" and "Update default" are `<button type="button">` elements.
+- [x] **No new external dependency** introduced.
+- [x] **Watch target is `derivedFuelTypes` not `availableFuelTypes`**: Prevents spurious re-seeding of `selectedFuelType` when only ordering changes (TC-09 / TC-11).
+- [x] **`isCurrentDefault` computed**: Uses `validatedDefaultFuelType.value` (not raw `defaultFuelType.value`) — false when no default is set or when the stored default is absent from the live list.
+- [x] **`showUpdateDefault` computed**: Guards on `selectedFuelType.value !== ''` in addition to the default/selection mismatch check — prevents the button showing when no fuel type is selected.
+- [x] **Singleton composable pattern (ADR-002)**: Module-level `Ref<string | null>` declared outside the function body; all consumers share the same reactive reference.
+- [x] **IndexedDB key distinct from stations key**: Key is `"defaultFuelType"`, separate from `"stations"`.
+- [x] **No dead code or unused imports**: All imported symbols are used. No unreachable branches.
+- [x] **No `any` / `unknown` without narrowing**: `get<unknown>` result is narrowed by `isNonEmptyString` before assignment.
+- [x] **No unguarded non-null assertions**: `oldByUrl.get(url) as Station` at line 189 is preceded by a passing `oldByUrl.has(url)` check — the assertion is safe.
+- [x] **All exported functions have explicit return types**: `deriveFuelTypes`, `resolvePrice`, `buildPriceRows`, `orderFuelTypes` all carry explicit return types. Composable functions `loadDefaultFuelType` and `saveDefaultFuelType` are typed `Promise<void>`.
+- [x] **Composable prefixed with `use`**: `useDefaultFuelType`. Correct.
+- [x] **No reactive arg accepted by composable** — `toValue()`/`toRef()` not applicable.
+- [x] **Side effect cleanup**: `useDefaultFuelType` registers no timers or listeners. The `dismissTimer` side effect in `StationPricesContent.vue` is cleaned up in `onUnmounted`.
+- [x] **Styling — CSS comments present**: All three new rule sets (`.default-fuel-actions`, `.default-fuel-button`, `.default-fuel-button--saved`) include an explanatory comment stating why Tailwind arbitrary values for design tokens are avoided.
+- [x] **Naming clarity**: All identifiers are unambiguous and consistent with project conventions (`validatedDefaultFuelType`, `derivedFuelTypes`, `resolveInitialSelection`, `onSaveDefault`, `isCurrentDefault`, `showUpdateDefault`).
+
+status: approved

--- a/docs/prompts/tasks/issue-28-default-fuel-type/review-results.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/review-results.md
@@ -2,41 +2,39 @@
 
 ## Commands Run
 
-- `npm run lint` output
-
-None of the changed files produced lint errors.
+### `npm run lint` output
+No lint errors in changed files.
 
 ### `npm run type-check` output
-
 Type-check passes with zero errors.
 
 ## Checklist
 
-- [x] **Security rule 1 — validate stored value before use**: `loadDefaultFuelType` in `useDefaultFuelType.ts` uses `isNonEmptyString` to reject non-string and empty-string values from IndexedDB. The component's `validatedDefaultFuelType` computed cross-checks the accepted string against `derivedFuelTypes` before treating it as valid — returning `null` when absent from the live list. Two-layer validation is in place.
-- [x] **Security rule 2 — no `v-html`**: All fuel type label rendering uses `{{ }}` text interpolation throughout `StationPricesContent.vue`. No `v-html` usage in any changed file.
-- [x] **Security rule 3 — plain string storage only**: `saveDefaultFuelType(label: string)` passes the label directly to `set(DEFAULT_FUEL_TYPE_KEY, label)`. No object serialisation.
-- [x] **Security rule 4 — input array not mutated**: `orderFuelTypes` accepts `readonly string[]`, returns `[...fuelTypes]` or `[defaultFuelType, ...remaining]` via spread and `filter`. The input is never mutated.
-- [x] **Object Calisthenics**: All functions are small and single-purpose. The composable body exception is documented inline with a framework-convention rationale.
-- [x] **Business spec — Story 1 (save default)**: "Save as default" button is inside `v-if="availableFuelTypes.length > 0"`, calls `onSaveDefault()` which guards against empty selection, and applies the `default-fuel-button--saved` modifier class via `isCurrentDefault`.
-- [x] **Business spec — Story 2 (load and apply on startup)**: `loadDefaultFuelType()` is awaited before `loadAllStationPrices`; `resolveInitialSelection` uses `validatedDefaultFuelType` to prefer the stored default over the first available item.
-- [x] **Business spec — Story 2 fallback (stored default absent from derived list)**: `validatedDefaultFuelType` returns `null` when the stored value is not in `derivedFuelTypes`; `resolveInitialSelection` falls back to `fuelTypes[0]`. The persisted IndexedDB value is left intact (TC-11).
-- [x] **Business spec — Story 3 (update default)**: `showUpdateDefault` is `true` only when a validated default exists and the current selection differs. "Update default" button is rendered conditionally and calls `onSaveDefault()`.
-- [x] **Business spec — Story 4 (ordered list)**: `availableFuelTypes` computed applies `orderFuelTypes(derivedFuelTypes.value, validatedDefaultFuelType.value)` reactively.
-- [x] **Keyboard accessibility**: Both "Save as default" and "Update default" are `<button type="button">` elements.
+- [x] **Security rule 1 — validate stored value before use**: `loadDefaultFuelType` calls `get<unknown>` and passes the result through `isNonEmptyString()` before assigning to reactive state. `validatedDefaultFuelType` further cross-checks against `derivedFuelTypes` before the value drives any UI logic. Two-layer validation is in place.
+- [x] **Security rule 2 — no `v-html`**: Absent from the entire component. The `Default` indicator renders a static string literal; no fuel label is ever passed to `v-html`.
+- [x] **Security rule 3 — store plain string only**: `saveDefaultFuelType(label: string)` and `updateDefaultFuelType(label: string)` call `set(DEFAULT_FUEL_TYPE_KEY, label)` with the string directly — no structured payload.
+- [x] **Security rule 4 — input array not mutated**: `orderFuelTypes` accepts `readonly string[]` and returns `[...fuelTypes]` or `[defaultFuelType, ...remaining]` via spread and `filter`. The input is never written to.
+- [x] **Security rule 5 — `del()` not overwrite**: `clearDefaultFuelType` calls `del(DEFAULT_FUEL_TYPE_KEY)` and resets the in-memory ref to `null`. No empty-string or null overwrite.
+- [x] **Button visibility matrix — all 3 conditions × 3 buttons**:
+  - No default stored: `showSaveDefault = !hasStoredDefault` → visible; `showUpdateDefault` → false (hasStoredDefault false); `showClearDefault = hasStoredDefault` → false. Correct.
+  - Default stored, selection = default: `showSaveDefault` → false; `showUpdateDefault` → false (`selectedFuelType === validatedDefaultFuelType`); `showClearDefault` → true. Correct.
+  - Default stored, selection ≠ default: `showSaveDefault` → false; `showUpdateDefault` → true; `showClearDefault` → true. Correct.
+- [x] **"Default" indicator is separate from buttons**: `<span class="default-indicator">Default</span>` with `v-if="isCurrentDefault"` is a distinct element — not a modifier on any button, not conditioned on `showSaveDefault`.
+- [x] **Object Calisthenics**: All functions are small and single-purpose. Composable body exception is documented with a framework-convention rationale comment.
+- [x] **No dead code, unused imports, or unreachable branches**: All imports are used. `updateDefaultFuelType` and `saveDefaultFuelType` have identical storage operations but are exposed as distinct named actions — intentional per spec. No unreachable branches.
+- [x] **Naming clarity, no abbreviations**: All identifiers are fully spelled out (`validatedDefaultFuelType`, `hasStoredDefault`, `clearDefaultFuelType`, `resolveInitialSelection`, etc.).
+- [x] **No destructuring reactivity loss**: `defaultFuelType` ref is returned as-is from the composable and accessed via `.value` everywhere — reactivity is preserved.
+- [x] **Watch targets correct**: `watch(derivedFuelTypes, ...)` targets a `ComputedRef<string[]>` directly, which is valid in Vue 3. Watching `derivedFuelTypes` (not `availableFuelTypes`) correctly limits re-seeding to when the set of available types changes, not on every save/update/clear (documented in technical spec).
+- [x] **No `any`/`unknown` without narrowing**: `get<unknown>` result is narrowed by `isNonEmptyString()` before assignment. No other unguarded `unknown` usage.
+- [x] **No non-null assertions without null check**: The single `as Station` assertion (line 224) is guarded by the `oldByUrl.has(url)` check on line 219.
+- [x] **Explicit return types on exported functions**: All exported functions in `fuelTypeUtils.ts`, `indexedDb.ts`, and `useDefaultFuelType.ts` carry explicit return type annotations (`string[]`, `Promise<void>`, `Promise<T | undefined>`, etc.).
+- [x] **Side effects cleaned up with `onUnmounted`**: The dismiss timer is cleared in `onUnmounted(() => { clearDismissTimer() })`. The composable registers no lifecycle hooks, so no composable-level cleanup is needed.
+- [x] **`async setup` + `<Suspense>`**: `StationPricesContent.vue` uses top-level awaits; its parent `StationPrices.vue` wraps it in `<Suspense>` with an `AppLoader` fallback.
+- [x] **`hasStoredDefault` uses raw `defaultFuelType.value`**: Correctly bases button visibility on the raw ref, not `validatedDefaultFuelType`, so "Clear default" remains visible when the stored default is temporarily absent from the derived list (TC-15).
+- [x] **`loadDefaultFuelType` ordered before `loadAllStationPrices`**: Ensures `defaultFuelType` is populated before `derivedFuelTypes` first emits, preventing a spurious fallback to first-item selection.
+- [x] **Singleton pattern (ADR-002)**: Module-level `Ref<string | null>` is declared outside the composable function body; all consumers share the same reactive instance.
+- [x] **Keyboard accessibility**: All three action buttons are standard `<button type="button">` elements — natively keyboard accessible.
 - [x] **No new external dependency** introduced.
-- [x] **Watch target is `derivedFuelTypes` not `availableFuelTypes`**: Prevents spurious re-seeding of `selectedFuelType` when only ordering changes (TC-09 / TC-11).
-- [x] **`isCurrentDefault` computed**: Uses `validatedDefaultFuelType.value` (not raw `defaultFuelType.value`) — false when no default is set or when the stored default is absent from the live list.
-- [x] **`showUpdateDefault` computed**: Guards on `selectedFuelType.value !== ''` in addition to the default/selection mismatch check — prevents the button showing when no fuel type is selected.
-- [x] **Singleton composable pattern (ADR-002)**: Module-level `Ref<string | null>` declared outside the function body; all consumers share the same reactive reference.
-- [x] **IndexedDB key distinct from stations key**: Key is `"defaultFuelType"`, separate from `"stations"`.
-- [x] **No dead code or unused imports**: All imported symbols are used. No unreachable branches.
-- [x] **No `any` / `unknown` without narrowing**: `get<unknown>` result is narrowed by `isNonEmptyString` before assignment.
-- [x] **No unguarded non-null assertions**: `oldByUrl.get(url) as Station` at line 189 is preceded by a passing `oldByUrl.has(url)` check — the assertion is safe.
-- [x] **All exported functions have explicit return types**: `deriveFuelTypes`, `resolvePrice`, `buildPriceRows`, `orderFuelTypes` all carry explicit return types. Composable functions `loadDefaultFuelType` and `saveDefaultFuelType` are typed `Promise<void>`.
-- [x] **Composable prefixed with `use`**: `useDefaultFuelType`. Correct.
-- [x] **No reactive arg accepted by composable** — `toValue()`/`toRef()` not applicable.
-- [x] **Side effect cleanup**: `useDefaultFuelType` registers no timers or listeners. The `dismissTimer` side effect in `StationPricesContent.vue` is cleaned up in `onUnmounted`.
-- [x] **Styling — CSS comments present**: All three new rule sets (`.default-fuel-actions`, `.default-fuel-button`, `.default-fuel-button--saved`) include an explanatory comment stating why Tailwind arbitrary values for design tokens are avoided.
-- [x] **Naming clarity**: All identifiers are unambiguous and consistent with project conventions (`validatedDefaultFuelType`, `derivedFuelTypes`, `resolveInitialSelection`, `onSaveDefault`, `isCurrentDefault`, `showUpdateDefault`).
+- [x] **CSS comments present**: All new rule sets (`.default-fuel-actions`, `.default-indicator`, `.default-fuel-button`) include a comment explaining why Tailwind arbitrary-value syntax for design tokens is avoided.
 
 status: approved

--- a/docs/prompts/tasks/issue-28-default-fuel-type/security-guidelines.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/security-guidelines.md
@@ -1,0 +1,25 @@
+# Security Guidelines — Issue #28: Default Fuel Type
+
+## Rules
+
+**1. Validate the stored value before use**
+- **What:** When reading the default fuel type from IndexedDB, treat the retrieved value as untrusted. Accept it only if it is a non-empty string and matches one of the fuel type labels present in the currently derived list.
+- **Where:** `src/composables/useDefaultFuelType.ts`, on every read from IndexedDB.
+- **Why:** A corrupted or tampered IndexedDB entry could inject an unexpected value into reactive state, silently distorting UI behaviour or serving as an injection vector if the value is later embedded in a rendered context.
+
+**2. Do not render the stored fuel type label with `v-html`**
+- **What:** The default fuel type label must be rendered as plain text only (text interpolation `{{ }}` or `:value` / `:textContent` bindings). `v-html` is prohibited for this value.
+- **Where:** `src/components/StationPricesContent.vue` and any component that displays the label.
+- **Why:** Fuel type labels originate from scraped HTML and pass through IndexedDB; binding them with `v-html` without sanitization would expose the app to stored XSS. ADR-007 governs all `v-html` usage.
+
+**3. Store only the fuel type label string — no structured payload**
+- **What:** The IndexedDB entry for the default fuel type must be a plain string. Do not serialise an object or embed additional metadata in this value.
+- **Where:** `src/composables/useDefaultFuelType.ts`, on every write to IndexedDB.
+- **Why:** A plain string narrows the attack surface; a structured payload would expand what can be injected if the stored value were ever misused downstream.
+
+**4. Guard the ordering function against prototype-pollution-style inputs**
+- **What:** The pure function that reorders the fuel type list must treat both its input list and the default string as read-only; it must not mutate the input array or assign properties to its elements.
+- **Where:** `src/utils/fuelTypeUtils.ts`, in the new ordering function.
+- **Why:** Mutating shared reactive state from a utility function can propagate unexpected side effects across composables that hold a reference to the same array.
+
+status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/security-guidelines.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/security-guidelines.md
@@ -22,4 +22,9 @@
 - **Where:** `src/utils/fuelTypeUtils.ts`, in the new ordering function.
 - **Why:** Mutating shared reactive state from a utility function can propagate unexpected side effects across composables that hold a reference to the same array.
 
+**5. Use a proper key deletion — never overwrite with empty or null**
+- **What:** `clearDefault` must call the IndexedDB `del(key)` operation to remove the key entirely; setting the key to an empty string, `null`, or `undefined` is prohibited.
+- **Where:** `src/composables/useDefaultFuelType.ts`, in the `clearDefault` action; `src/utils/indexedDb.ts`, which must expose a `del` helper.
+- **Why:** A sentinel value left in storage could be read back by validation logic and treated as a valid-but-empty default, bypassing the non-empty-string guard and leaving the store in an ambiguous state.
+
 status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/technical-specifications.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/technical-specifications.md
@@ -1,0 +1,60 @@
+# Technical Specifications — Issue #28: Default Fuel Type
+
+## Files Created or Changed
+
+### `src/utils/fuelTypeUtils.ts` — modified
+Added the `orderFuelTypes(fuelTypes, defaultFuelType)` pure function. Returns a new array with the default fuel type moved to index 0 when it is present in the list; otherwise returns an unchanged copy. The input array is never mutated (security-guidelines.md rule 4). Handles `null`, `undefined`, and absent-default cases identically (return unchanged copy).
+
+### `src/composables/useDefaultFuelType.ts` — created
+New singleton composable following ADR-002. Declares a module-level `Ref<string | null>` so all consumers share reactive state. Exposes:
+- `defaultFuelType` — reactive reference to the stored label (or `null`)
+- `loadDefaultFuelType()` — reads from IndexedDB; rejects non-string and empty-string values before assigning to state (security-guidelines.md rule 1)
+- `saveDefaultFuelType(label)` — writes a plain string to IndexedDB under a dedicated key `"defaultFuelType"`, distinct from the `"stations"` key (security-guidelines.md rule 3)
+
+### `src/components/StationPricesContent.vue` — modified
+- Imports `useDefaultFuelType` and `orderFuelTypes`.
+- Adds `derivedFuelTypes` computed (raw derived list from results).
+- Adds `validatedDefaultFuelType` computed: cross-checks `defaultFuelType.value` against `derivedFuelTypes.value` and returns `null` when the stored value is absent from the live list (security-guidelines.md rule 1). The persisted value in IndexedDB is never cleared — only the component-level view of it is nulled (TC-11).
+- Replaces the former `availableFuelTypes` computed with one that applies `orderFuelTypes(derivedFuelTypes, validatedDefaultFuelType)` so the list is reactively reordered whenever the validated default changes.
+- Changes the `watch` target from `availableFuelTypes` to `derivedFuelTypes` to avoid spurious re-seeding of `selectedFuelType` on default changes; uses `resolveInitialSelection` to prefer the validated default over the first item when applicable (TC-09, TC-11).
+- `resolveInitialSelection` uses `validatedDefaultFuelType` (not raw `defaultFuelType`) ensuring a stored value absent from the live list is never selected.
+- Adds `isCurrentDefault` computed (boolean): true when `validatedDefaultFuelType` is non-null and equals `selectedFuelType` — drives the "Default saved" active state on the save button.
+- Adds `showUpdateDefault` computed (boolean): true when `validatedDefaultFuelType` is non-null and the selection differs — controls the "Update default" button.
+- Adds `onSaveDefault()` async function: guard against empty selection, then calls `saveDefaultFuelType`.
+- Adds "Save as default" `<button>` and conditional "Update default" `<button>` inside `v-if="availableFuelTypes.length > 0"` — both are plain `<button>` elements for keyboard accessibility (TC-19, TC-20).
+- All label rendering uses `{{ }}` text interpolation — `v-html` is not used (security-guidelines.md rule 2).
+- Awaits `loadDefaultFuelType()` between `loadStations()` and `loadAllStationPrices()` so the default is known before the derived list is built.
+- All three new custom CSS rule sets (`.default-fuel-actions`, `.default-fuel-button`, `.default-fuel-button--saved`) include an explanatory comment in `<style scoped>` stating why Tailwind arbitrary values were not used (CLAUDE.md styling rule).
+
+## Technical Choice Explanations
+
+### Watch `derivedFuelTypes` instead of `availableFuelTypes` for selection seeding
+`availableFuelTypes` is recomputed whenever `defaultFuelType` changes (because it applies `orderFuelTypes`). If the watch targeted `availableFuelTypes`, saving a new default would trigger the watcher, which would re-evaluate `resolveInitialSelection` and potentially reset `selectedFuelType` to the new default even when the user had explicitly picked a different type. Watching `derivedFuelTypes` instead means selection is only re-seeded when the actual set of available fuel types changes (stations added/removed), not when ordering changes.
+
+### `defaultIndex <= 0` guard in `orderFuelTypes`
+Handles both "not found" (`indexOf` returns `-1`) and "already first" (`indexOf` returns `0`) in a single condition, avoiding a second branch. When index is 0, returning a copy without reordering is both correct and avoids an unnecessary `filter` pass.
+
+### `loadDefaultFuelType` called before `loadAllStationPrices`
+The default must be in reactive state before `derivedFuelTypes` first emits a non-empty value. If it were loaded after, the `watch(derivedFuelTypes)` callback would fire with an empty `defaultFuelType.value` and fall back to first-item selection, requiring additional logic to correct afterward.
+
+### "Save as default" button always visible when fuel types are shown
+The spec (Story 1, TC-14) makes "Save as default" the baseline action available whenever a fuel type is selected. "Update default" is an additional contextual action. Hiding "Save as default" when a default already matches would require the user to know they need "Update default" — keeping "Save as default" visible as the primary CTA with a visual active state is simpler and aligns with TC-06/TC-13 expectations.
+
+## Self-Code Review
+
+### Potential issue 1: Startup race between `loadDefaultFuelType` and the `watch(derivedFuelTypes)` trigger
+If `loadAllStationPrices` returns synchronously (e.g. empty station list), `derivedFuelTypes` stays empty and the watch never fires — no selection is made. This is correct behaviour (table stays hidden). If prices resolve asynchronously, `defaultFuelType` is already loaded by the time the watch fires. `validatedDefaultFuelType` returns `null` when `derivedFuelTypes` is still empty, which is correct — when the watch fires after prices load, `validatedDefaultFuelType` recomputes against the populated list and `resolveInitialSelection` picks the stored default if present. No race exists.
+
+**Resolution:** The ordering of awaits (`loadDefaultFuelType` before `loadAllStationPrices`) is the fix. No further change needed.
+
+### Potential issue 2: `showUpdateDefault` and "Save as default" both visible simultaneously
+When a default exists and the selection differs, both "Save as default" and "Update default" render at the same time. Both call the same `onSaveDefault()` handler. This is intentional per the spec but could confuse users. A cleaner UX would hide "Save as default" when "Update default" is shown — however the spec explicitly states TC-14 ("only Save as default") implying "Save as default" is always present. The current implementation follows the spec exactly.
+
+**Resolution:** No change; spec-compliant. A follow-up UX improvement could be tracked separately.
+
+### Potential issue 3: `orderFuelTypes` allocates a new array on every computed evaluation
+Every time `defaultFuelType` or `derivedFuelTypes` changes, `availableFuelTypes` recomputes and `orderFuelTypes` returns a fresh array. For typical fuel type lists (5–10 items), this is negligible. If the list were large, memoisation could help, but that would conflict with the no-external-dependency constraint.
+
+**Resolution:** Acceptable for the expected data size. No change needed.
+
+status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/technical-specifications.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/technical-specifications.md
@@ -2,59 +2,86 @@
 
 ## Files Created or Changed
 
+### `src/utils/indexedDb.ts` — unchanged
+No modifications required. The `del(key)` helper already exists and is exported; `clearDefaultFuelType` imports it directly.
+
 ### `src/utils/fuelTypeUtils.ts` — modified
 Added the `orderFuelTypes(fuelTypes, defaultFuelType)` pure function. Returns a new array with the default fuel type moved to index 0 when it is present in the list; otherwise returns an unchanged copy. The input array is never mutated (security-guidelines.md rule 4). Handles `null`, `undefined`, and absent-default cases identically (return unchanged copy).
 
-### `src/composables/useDefaultFuelType.ts` — created
-New singleton composable following ADR-002. Declares a module-level `Ref<string | null>` so all consumers share reactive state. Exposes:
+### `src/composables/useDefaultFuelType.ts` — created / updated
+Singleton composable following ADR-002. Declares a module-level `Ref<string | null>` so all consumers share reactive state. Exposes:
 - `defaultFuelType` — reactive reference to the stored label (or `null`)
 - `loadDefaultFuelType()` — reads from IndexedDB; rejects non-string and empty-string values before assigning to state (security-guidelines.md rule 1)
-- `saveDefaultFuelType(label)` — writes a plain string to IndexedDB under a dedicated key `"defaultFuelType"`, distinct from the `"stations"` key (security-guidelines.md rule 3)
+- `saveDefaultFuelType(label)` — writes a plain string to IndexedDB under `"defaultFuelType"` key (security-guidelines.md rule 3); used when no default exists
+- `updateDefaultFuelType(label)` — same storage operation as save; semantically distinct action exposed for "Update default" button
+- `clearDefaultFuelType()` — calls `del(DEFAULT_FUEL_TYPE_KEY)` to remove the key entirely; resets `defaultFuelType.value` to `null` (security-guidelines.md rule 5; never overwrites with empty/null)
 
 ### `src/components/StationPricesContent.vue` — modified
-- Imports `useDefaultFuelType` and `orderFuelTypes`.
-- Adds `derivedFuelTypes` computed (raw derived list from results).
-- Adds `validatedDefaultFuelType` computed: cross-checks `defaultFuelType.value` against `derivedFuelTypes.value` and returns `null` when the stored value is absent from the live list (security-guidelines.md rule 1). The persisted value in IndexedDB is never cleared — only the component-level view of it is nulled (TC-11).
-- Replaces the former `availableFuelTypes` computed with one that applies `orderFuelTypes(derivedFuelTypes, validatedDefaultFuelType)` so the list is reactively reordered whenever the validated default changes.
-- Changes the `watch` target from `availableFuelTypes` to `derivedFuelTypes` to avoid spurious re-seeding of `selectedFuelType` on default changes; uses `resolveInitialSelection` to prefer the validated default over the first item when applicable (TC-09, TC-11).
-- `resolveInitialSelection` uses `validatedDefaultFuelType` (not raw `defaultFuelType`) ensuring a stored value absent from the live list is never selected.
-- Adds `isCurrentDefault` computed (boolean): true when `validatedDefaultFuelType` is non-null and equals `selectedFuelType` — drives the "Default saved" active state on the save button.
-- Adds `showUpdateDefault` computed (boolean): true when `validatedDefaultFuelType` is non-null and the selection differs — controls the "Update default" button.
-- Adds `onSaveDefault()` async function: guard against empty selection, then calls `saveDefaultFuelType`.
-- Adds "Save as default" `<button>` and conditional "Update default" `<button>` inside `v-if="availableFuelTypes.length > 0"` — both are plain `<button>` elements for keyboard accessibility (TC-19, TC-20).
-- All label rendering uses `{{ }}` text interpolation — `v-html` is not used (security-guidelines.md rule 2).
-- Awaits `loadDefaultFuelType()` between `loadStations()` and `loadAllStationPrices()` so the default is known before the derived list is built.
-- All three new custom CSS rule sets (`.default-fuel-actions`, `.default-fuel-button`, `.default-fuel-button--saved`) include an explanatory comment in `<style scoped>` stating why Tailwind arbitrary values were not used (CLAUDE.md styling rule).
+
+#### Computed properties added/updated
+
+| Name | Type | Description |
+|---|---|---|
+| `derivedFuelTypes` | `string[]` | Raw derived list from results |
+| `validatedDefaultFuelType` | `string \| null` | Cross-checks `defaultFuelType.value` against `derivedFuelTypes`; returns `null` when absent (security rule 1; TC-15 — stored value never cleared) |
+| `availableFuelTypes` | `string[]` | `orderFuelTypes(derivedFuelTypes, validatedDefaultFuelType)` |
+| `hasStoredDefault` | `boolean` | `defaultFuelType.value !== null` — source of truth for whether a default is stored |
+| `isCurrentDefault` | `boolean` | `validatedDefaultFuelType !== null && selectedFuelType === validatedDefaultFuelType` |
+| `showSaveDefault` | `boolean` | `!hasStoredDefault` — visible only when no default is stored |
+| `showUpdateDefault` | `boolean` | `hasStoredDefault && selectedFuelType !== '' && selectedFuelType !== validatedDefaultFuelType` |
+| `showClearDefault` | `boolean` | `hasStoredDefault` — visible whenever a default is stored |
+
+#### Button visibility matrix
+
+| Condition | "Save as default" | "Update default" | "Clear default" |
+|---|---|---|---|
+| No default stored | visible | hidden | hidden |
+| Default stored, selection = default | hidden | hidden | visible |
+| Default stored, selection ≠ default | hidden | visible | visible |
+
+#### "Default" indicator
+- Element: `<span class="default-indicator">Default</span>`
+- Rendered when: `isCurrentDefault === true`
+- **Separate from all three action buttons** — the indicator is not a state on the "Save as default" button, which is hidden whenever a default exists (business-specifications.md, Active State section)
+- Rendered via `{{ }}` text interpolation — `v-html` is not used (security rule 2)
+
+#### Event handlers
+
+| Handler | Action |
+|---|---|
+| `onSaveDefault()` | Guards `selectedFuelType !== ''`; calls `saveDefaultFuelType(selectedFuelType)` |
+| `onUpdateDefault()` | Guards `selectedFuelType !== ''`; calls `updateDefaultFuelType(selectedFuelType)` |
+| `onClearDefault()` | Calls `clearDefaultFuelType()` |
+
+#### Button styling
+All three buttons use a single `.default-fuel-button` class applying the spec-mandated tokens:
+- `background-color: var(--color-stone-200)` (maps to `--accent`)
+- `color: var(--color-stone-800)` (maps to `--accent-foreground`)
+
+The `.default-fuel-button--saved` modifier and the `isCurrentDefault`-based button label toggle from the previous pass are removed. The "Default" state is represented by the separate `.default-indicator` element only.
+
+Custom CSS (not Tailwind arbitrary values) is used to keep design-token references centralised in the scoped `<style>` block (CLAUDE.md styling rule).
 
 ## Technical Choice Explanations
 
 ### Watch `derivedFuelTypes` instead of `availableFuelTypes` for selection seeding
-`availableFuelTypes` is recomputed whenever `defaultFuelType` changes (because it applies `orderFuelTypes`). If the watch targeted `availableFuelTypes`, saving a new default would trigger the watcher, which would re-evaluate `resolveInitialSelection` and potentially reset `selectedFuelType` to the new default even when the user had explicitly picked a different type. Watching `derivedFuelTypes` instead means selection is only re-seeded when the actual set of available fuel types changes (stations added/removed), not when ordering changes.
+`availableFuelTypes` recomputes whenever `defaultFuelType` changes (because it applies `orderFuelTypes`). Targeting `availableFuelTypes` in the watch would fire on every save/update/clear, re-seeding `selectedFuelType` unexpectedly. Watching `derivedFuelTypes` limits re-seeding to when the actual set of available fuel types changes.
 
-### `defaultIndex <= 0` guard in `orderFuelTypes`
-Handles both "not found" (`indexOf` returns `-1`) and "already first" (`indexOf` returns `0`) in a single condition, avoiding a second branch. When index is 0, returning a copy without reordering is both correct and avoids an unnecessary `filter` pass.
+### `hasStoredDefault` based on `defaultFuelType.value`, not `validatedDefaultFuelType`
+`validatedDefaultFuelType` returns `null` when the stored default is absent from the current derived list (TC-15). If button visibility were derived from it, "Clear default" would disappear when the user's default fuel type becomes temporarily unavailable — even though the key still exists in IndexedDB. Using the raw `defaultFuelType.value` for `hasStoredDefault` keeps the clear action available whenever something is actually stored.
 
 ### `loadDefaultFuelType` called before `loadAllStationPrices`
-The default must be in reactive state before `derivedFuelTypes` first emits a non-empty value. If it were loaded after, the `watch(derivedFuelTypes)` callback would fire with an empty `defaultFuelType.value` and fall back to first-item selection, requiring additional logic to correct afterward.
-
-### "Save as default" button always visible when fuel types are shown
-The spec (Story 1, TC-14) makes "Save as default" the baseline action available whenever a fuel type is selected. "Update default" is an additional contextual action. Hiding "Save as default" when a default already matches would require the user to know they need "Update default" — keeping "Save as default" visible as the primary CTA with a visual active state is simpler and aligns with TC-06/TC-13 expectations.
+The default must be in reactive state before `derivedFuelTypes` first emits a non-empty value. Loading it after would cause the `watch(derivedFuelTypes)` callback to fire with `null` and fall back to first-item selection.
 
 ## Self-Code Review
 
 ### Potential issue 1: Startup race between `loadDefaultFuelType` and the `watch(derivedFuelTypes)` trigger
-If `loadAllStationPrices` returns synchronously (e.g. empty station list), `derivedFuelTypes` stays empty and the watch never fires — no selection is made. This is correct behaviour (table stays hidden). If prices resolve asynchronously, `defaultFuelType` is already loaded by the time the watch fires. `validatedDefaultFuelType` returns `null` when `derivedFuelTypes` is still empty, which is correct — when the watch fires after prices load, `validatedDefaultFuelType` recomputes against the populated list and `resolveInitialSelection` picks the stored default if present. No race exists.
+No race exists. The ordering of awaits (`loadDefaultFuelType` before `loadAllStationPrices`) ensures `defaultFuelType` is populated before `derivedFuelTypes` first emits a non-empty value.
 
-**Resolution:** The ordering of awaits (`loadDefaultFuelType` before `loadAllStationPrices`) is the fix. No further change needed.
+### Potential issue 2: `orderFuelTypes` allocates a new array on every computed evaluation
+Acceptable for typical fuel type list sizes (5–10 items). No change needed.
 
-### Potential issue 2: `showUpdateDefault` and "Save as default" both visible simultaneously
-When a default exists and the selection differs, both "Save as default" and "Update default" render at the same time. Both call the same `onSaveDefault()` handler. This is intentional per the spec but could confuse users. A cleaner UX would hide "Save as default" when "Update default" is shown — however the spec explicitly states TC-14 ("only Save as default") implying "Save as default" is always present. The current implementation follows the spec exactly.
-
-**Resolution:** No change; spec-compliant. A follow-up UX improvement could be tracked separately.
-
-### Potential issue 3: `orderFuelTypes` allocates a new array on every computed evaluation
-Every time `defaultFuelType` or `derivedFuelTypes` changes, `availableFuelTypes` recomputes and `orderFuelTypes` returns a fresh array. For typical fuel type lists (5–10 items), this is negligible. If the list were large, memoisation could help, but that would conflict with the no-external-dependency constraint.
-
-**Resolution:** Acceptable for the expected data size. No change needed.
+### Potential issue 3: `clearDefaultFuelType` does not reset `selectedFuelType`
+After clearing, `selectedFuelType` retains its current value. The fuel type list reverts to natural order (via `orderFuelTypes` returning an unchanged copy when `defaultFuelType.value` is `null`), but the selection itself is not forced to change. This matches TC-29 — only the list order reverts; the current selection is user-controlled.
 
 status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/test-cases.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/test-cases.md
@@ -1,0 +1,215 @@
+# Test Cases — Issue #28: Default Fuel Type
+
+## Fuel Type List Ordering
+
+### TC-01 — Default type is placed first in the list
+
+**Precondition:** The derived fuel type list is `["SP95", "Gasoil", "E10"]`. The stored default is `"Gasoil"`.
+
+**Action:** The ordering function is called with the list and the default value.
+
+**Expected outcome:** The returned list is `["Gasoil", "SP95", "E10"]` — the default appears first, the remaining types follow in their original order.
+
+---
+
+### TC-02 — No default: list order is unchanged
+
+**Precondition:** The derived fuel type list is `["SP95", "Gasoil", "E10"]`. No default is provided (undefined or null).
+
+**Action:** The ordering function is called with the list and no default.
+
+**Expected outcome:** The returned list is `["SP95", "Gasoil", "E10"]` — identical to the input order.
+
+---
+
+### TC-03 — Default is already first: list order is unchanged
+
+**Precondition:** The derived fuel type list is `["SP95", "Gasoil", "E10"]`. The stored default is `"SP95"`.
+
+**Action:** The ordering function is called with the list and the default value.
+
+**Expected outcome:** The returned list is `["SP95", "Gasoil", "E10"]` — no change in order.
+
+---
+
+### TC-04 — Default not present in the list: list order is unchanged
+
+**Precondition:** The derived fuel type list is `["SP95", "Gasoil"]`. The stored default is `"E85"` (not in the list).
+
+**Action:** The ordering function is called with the list and the default value.
+
+**Expected outcome:** The returned list is `["SP95", "Gasoil"]` — the unknown default is ignored, original order preserved.
+
+---
+
+### TC-05 — Ordering function does not mutate the input array
+
+**Precondition:** The derived fuel type list is `["SP95", "Gasoil", "E10"]`. The stored default is `"E10"`.
+
+**Action:** The ordering function is called with the list and the default value. The original list reference is inspected after the call.
+
+**Expected outcome:** The original input array is still `["SP95", "Gasoil", "E10"]` — unmodified. The reordered list is returned as a new array.
+
+---
+
+## Saving a Default Fuel Type
+
+### TC-06 — "Save as default" stores the selected fuel type
+
+**Precondition:** The price view is visible. The user has selected `"SP95"`. No default is currently stored.
+
+**Action:** The user clicks the "Save as default" button.
+
+**Expected outcome:** `"SP95"` is persisted as the default fuel type. The UI reflects that `"SP95"` is now the active default (e.g. the save button shows a confirmed/active state).
+
+---
+
+### TC-07 — "Save as default" is not available when no fuel type is selected
+
+**Precondition:** The price view has not yet loaded any fuel types (the table is not visible).
+
+**Action:** The user views the price page.
+
+**Expected outcome:** The "Save as default" button is not rendered or not accessible.
+
+---
+
+### TC-08 — After saving, the fuel type list reorders with the new default first
+
+**Precondition:** The derived list is `["SP95", "Gasoil", "E10"]`. The user selects `"Gasoil"` and clicks "Save as default".
+
+**Action:** The save completes.
+
+**Expected outcome:** The fuel type list displayed to the user now shows `"Gasoil"` first, followed by `"SP95"` and `"E10"`.
+
+---
+
+## Loading and Applying the Default on Startup
+
+### TC-09 — Stored default is pre-selected when the price view loads
+
+**Precondition:** `"Gasoil"` is stored as the default fuel type in IndexedDB. The price view initialises and the derived list includes `"Gasoil"`.
+
+**Action:** The price view loads.
+
+**Expected outcome:** `"Gasoil"` is automatically selected (the price table shows Gasoil prices) instead of the first item in the raw derived list.
+
+---
+
+### TC-10 — No stored default: first available fuel type is selected on load
+
+**Precondition:** No default is stored in IndexedDB. The price view initialises with a derived list of `["SP95", "Gasoil"]`.
+
+**Action:** The price view loads.
+
+**Expected outcome:** `"SP95"` (the first derived type) is selected. Behaviour is unchanged from before this feature.
+
+---
+
+### TC-11 — Stored default not present in derived list: fallback to first available
+
+**Precondition:** `"E85"` is stored as the default in IndexedDB. The price view initialises, but the derived list is `["SP95", "Gasoil"]` (E85 is not available from any current station).
+
+**Action:** The price view loads.
+
+**Expected outcome:** `"SP95"` (the first derived type) is selected. The stored default `"E85"` is left unchanged in IndexedDB (not cleared).
+
+---
+
+## Updating the Default
+
+### TC-12 — "Update default" is visible when selection differs from stored default
+
+**Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"` from the fuel type list.
+
+**Action:** The user views the price page with `"Gasoil"` selected.
+
+**Expected outcome:** An "Update default" button is visible.
+
+---
+
+### TC-13 — "Update default" is not visible when the selected type matches the stored default
+
+**Precondition:** `"SP95"` is the stored default. The user has `"SP95"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** The "Update default" button is not rendered.
+
+---
+
+### TC-14 — "Update default" is not visible when no default is stored
+
+**Precondition:** No default is stored in IndexedDB. The user has `"Gasoil"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** The "Update default" button is not rendered. Only the "Save as default" button is available.
+
+---
+
+### TC-15 — Clicking "Update default" replaces the stored default
+
+**Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"` and the "Update default" button is visible.
+
+**Action:** The user clicks "Update default".
+
+**Expected outcome:** `"Gasoil"` is now the stored default. The "Update default" button is no longer visible. The fuel type list reorders with `"Gasoil"` first.
+
+---
+
+## Security
+
+### TC-16 — Corrupted IndexedDB value is rejected on load
+
+**Precondition:** The IndexedDB entry for the default fuel type contains a value that is not in the current derived fuel type list (e.g. a numeric value, an empty string, or an arbitrary string not matching any known fuel type label).
+
+**Action:** The price view loads and reads the stored default.
+
+**Expected outcome:** The corrupted/invalid value is ignored. The first available fuel type is selected instead. No error is thrown to the user.
+
+---
+
+### TC-17 — Fuel type label is not rendered as raw HTML
+
+**Precondition:** The stored default fuel type label contains an HTML string (e.g. `"<b>SP95</b>"`).
+
+**Action:** The price view loads and displays the fuel type label in the UI.
+
+**Expected outcome:** The label is displayed as literal text (`<b>SP95</b>`) — no HTML is rendered, no bold tag appears. The markup is treated as plain text.
+
+---
+
+### TC-18 — Saving a default stores only a plain string, not a structured object
+
+**Precondition:** The user selects a fuel type and clicks "Save as default".
+
+**Action:** The stored IndexedDB entry is inspected.
+
+**Expected outcome:** The entry is a plain string (the fuel type label only), not a JSON object or an object with additional properties.
+
+---
+
+## Keyboard Accessibility
+
+### TC-19 — "Save as default" button is keyboard accessible
+
+**Precondition:** The price view is visible with a fuel type selected.
+
+**Action:** The user navigates to the "Save as default" control using the Tab key and activates it with Enter or Space.
+
+**Expected outcome:** The default is saved and the UI updates as if the button had been clicked with a mouse.
+
+---
+
+### TC-20 — "Update default" button is keyboard accessible
+
+**Precondition:** A default is stored and the user has selected a different fuel type, making the "Update default" button visible.
+
+**Action:** The user navigates to the "Update default" control using the Tab key and activates it with Enter or Space.
+
+**Expected outcome:** The default is updated and the UI reflects the new default.
+
+---
+
+status: ready

--- a/docs/prompts/tasks/issue-28-default-fuel-type/test-cases.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/test-cases.md
@@ -52,29 +52,71 @@
 
 ---
 
+## Button Visibility Matrix
+
+### TC-06 — No default stored: only "Save as default" is visible
+
+**Precondition:** No default is stored in IndexedDB. The price view is visible and the user has a fuel type selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** "Save as default" is visible. "Update default" is not rendered. "Clear default" is not rendered.
+
+---
+
+### TC-07 — Default stored, current selection matches stored default: only "Clear default" is visible
+
+**Precondition:** `"SP95"` is the stored default. The user currently has `"SP95"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** "Save as default" is not rendered. "Update default" is not rendered. "Clear default" is visible.
+
+---
+
+### TC-08 — Default stored, current selection differs from stored default: both "Update default" and "Clear default" are visible
+
+**Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"`.
+
+**Action:** The user views the price page with `"Gasoil"` selected.
+
+**Expected outcome:** "Save as default" is not rendered. "Update default" is visible. "Clear default" is visible.
+
+---
+
 ## Saving a Default Fuel Type
 
-### TC-06 — "Save as default" stores the selected fuel type
+### TC-09 — "Save as default" stores the selected fuel type
 
 **Precondition:** The price view is visible. The user has selected `"SP95"`. No default is currently stored.
 
 **Action:** The user clicks the "Save as default" button.
 
-**Expected outcome:** `"SP95"` is persisted as the default fuel type. The UI reflects that `"SP95"` is now the active default (e.g. the save button shows a confirmed/active state).
+**Expected outcome:** `"SP95"` is persisted as the default fuel type in IndexedDB as a plain string.
 
 ---
 
-### TC-07 — "Save as default" is not available when no fuel type is selected
+### TC-10 — After saving, "Save as default" is hidden and the "Default" indicator appears
+
+**Precondition:** No default is stored. The user has `"SP95"` selected and "Save as default" is visible.
+
+**Action:** The user clicks "Save as default".
+
+**Expected outcome:** The "Save as default" button disappears. A "Default" indicator appears near `"SP95"` in the fuel selector or price table row. "Clear default" becomes visible.
+
+---
+
+### TC-11 — "Save as default" is not available when no fuel type is selected
 
 **Precondition:** The price view has not yet loaded any fuel types (the table is not visible).
 
 **Action:** The user views the price page.
 
-**Expected outcome:** The "Save as default" button is not rendered or not accessible.
+**Expected outcome:** The "Save as default" button is not rendered.
 
 ---
 
-### TC-08 — After saving, the fuel type list reorders with the new default first
+### TC-12 — After saving, the fuel type list reorders with the new default first
 
 **Precondition:** The derived list is `["SP95", "Gasoil", "E10"]`. The user selects `"Gasoil"` and clicks "Save as default".
 
@@ -86,7 +128,7 @@
 
 ## Loading and Applying the Default on Startup
 
-### TC-09 — Stored default is pre-selected when the price view loads
+### TC-13 — Stored default is pre-selected when the price view loads
 
 **Precondition:** `"Gasoil"` is stored as the default fuel type in IndexedDB. The price view initialises and the derived list includes `"Gasoil"`.
 
@@ -96,7 +138,7 @@
 
 ---
 
-### TC-10 — No stored default: first available fuel type is selected on load
+### TC-14 — No stored default: first available fuel type is selected on load
 
 **Precondition:** No default is stored in IndexedDB. The price view initialises with a derived list of `["SP95", "Gasoil"]`.
 
@@ -106,7 +148,7 @@
 
 ---
 
-### TC-11 — Stored default not present in derived list: fallback to first available
+### TC-15 — Stored default not present in derived list: fallback to first available
 
 **Precondition:** `"E85"` is stored as the default in IndexedDB. The price view initialises, but the derived list is `["SP95", "Gasoil"]` (E85 is not available from any current station).
 
@@ -116,19 +158,29 @@
 
 ---
 
+### TC-16 — On startup with a valid stored default, the "Default" indicator is shown and "Save as default" is hidden
+
+**Precondition:** `"SP95"` is stored as the default in IndexedDB. The price view initialises and `"SP95"` is in the derived list.
+
+**Action:** The price view loads.
+
+**Expected outcome:** `"SP95"` is selected. The "Default" indicator is visible near `"SP95"`. "Save as default" is not rendered. "Clear default" is visible.
+
+---
+
 ## Updating the Default
 
-### TC-12 — "Update default" is visible when selection differs from stored default
+### TC-17 — "Update default" is visible when selection differs from stored default
 
 **Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"` from the fuel type list.
 
 **Action:** The user views the price page with `"Gasoil"` selected.
 
-**Expected outcome:** An "Update default" button is visible.
+**Expected outcome:** The "Update default" button is visible.
 
 ---
 
-### TC-13 — "Update default" is not visible when the selected type matches the stored default
+### TC-18 — "Update default" is not visible when the selected type matches the stored default
 
 **Precondition:** `"SP95"` is the stored default. The user has `"SP95"` selected.
 
@@ -138,29 +190,153 @@
 
 ---
 
-### TC-14 — "Update default" is not visible when no default is stored
+### TC-19 — "Update default" is not visible when no default is stored
 
 **Precondition:** No default is stored in IndexedDB. The user has `"Gasoil"` selected.
 
 **Action:** The user views the price page.
 
-**Expected outcome:** The "Update default" button is not rendered. Only the "Save as default" button is available.
+**Expected outcome:** The "Update default" button is not rendered. Only "Save as default" is available.
 
 ---
 
-### TC-15 — Clicking "Update default" replaces the stored default
+### TC-20 — Clicking "Update default" replaces the stored default
 
-**Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"` and the "Update default" button is visible.
+**Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"` and "Update default" is visible.
 
 **Action:** The user clicks "Update default".
 
-**Expected outcome:** `"Gasoil"` is now the stored default. The "Update default" button is no longer visible. The fuel type list reorders with `"Gasoil"` first.
+**Expected outcome:** `"Gasoil"` is now the stored default in IndexedDB. "Update default" is no longer visible. The "Default" indicator moves from `"SP95"` to `"Gasoil"`. The fuel type list reorders with `"Gasoil"` first.
+
+---
+
+### TC-21 — After updating, "Clear default" remains visible
+
+**Precondition:** `"SP95"` is the stored default. The user selects `"Gasoil"` and clicks "Update default".
+
+**Action:** The update completes.
+
+**Expected outcome:** "Clear default" is still visible (a default — now `"Gasoil"` — is still stored).
+
+---
+
+## Clearing the Default
+
+### TC-22 — "Clear default" is visible when a default is stored and the current selection matches the stored default
+
+**Precondition:** `"SP95"` is the stored default. The user has `"SP95"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** "Clear default" is visible.
+
+---
+
+### TC-23 — "Clear default" is visible when a default is stored and the current selection differs from the stored default
+
+**Precondition:** `"SP95"` is the stored default. The user has `"Gasoil"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** "Clear default" is visible alongside "Update default".
+
+---
+
+### TC-24 — "Clear default" is not visible when no default is stored
+
+**Precondition:** No default is stored in IndexedDB. The user has `"SP95"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** "Clear default" is not rendered.
+
+---
+
+### TC-25 — Clicking "Clear default" removes the key from IndexedDB
+
+**Precondition:** `"SP95"` is the stored default.
+
+**Action:** The user clicks "Clear default".
+
+**Expected outcome:** The IndexedDB key for the default fuel type is deleted entirely — it is not set to an empty string, `null`, or any sentinel value.
+
+---
+
+### TC-26 — After clearing, "Save as default" reappears
+
+**Precondition:** `"SP95"` is the stored default. The price view is visible.
+
+**Action:** The user clicks "Clear default".
+
+**Expected outcome:** The "Save as default" button becomes visible again.
+
+---
+
+### TC-27 — After clearing, "Update default" and "Clear default" are hidden
+
+**Precondition:** `"SP95"` is the stored default. The user has `"SP95"` selected and clicks "Clear default".
+
+**Action:** The clear completes.
+
+**Expected outcome:** "Update default" is not rendered. "Clear default" is not rendered.
+
+---
+
+### TC-28 — After clearing, the "Default" indicator is removed
+
+**Precondition:** `"SP95"` is the stored default and the "Default" indicator is shown near `"SP95"`.
+
+**Action:** The user clicks "Clear default".
+
+**Expected outcome:** The "Default" indicator disappears. No fuel type shows the "Default" indicator.
+
+---
+
+### TC-29 — After clearing, the fuel type list reverts to natural order
+
+**Precondition:** `"Gasoil"` is the stored default. The displayed list is `["Gasoil", "SP95", "E10"]` (Gasoil ordered first).
+
+**Action:** The user clicks "Clear default".
+
+**Expected outcome:** The fuel type list reverts to its natural first-encountered order `["SP95", "Gasoil", "E10"]`. No reordering is applied.
+
+---
+
+## "Default" Indicator (Active State)
+
+### TC-30 — "Default" indicator is shown when the selected fuel type matches the stored default
+
+**Precondition:** `"SP95"` is the stored default. The user has `"SP95"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** A "Default" indicator is visible near `"SP95"` in the fuel selector or price table. "Save as default" is not rendered (these are independent: the indicator is not the "Save as default" button).
+
+---
+
+### TC-31 — "Default" indicator is not shown when the selected fuel type differs from the stored default
+
+**Precondition:** `"SP95"` is the stored default. The user has `"Gasoil"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** No "Default" indicator is shown on `"Gasoil"`. (The indicator follows the active selection, not the stored value in isolation.)
+
+---
+
+### TC-32 — "Default" indicator is not shown when no default is stored
+
+**Precondition:** No default is stored. The user has `"SP95"` selected.
+
+**Action:** The user views the price page.
+
+**Expected outcome:** No "Default" indicator is visible anywhere in the fuel selector or price table.
 
 ---
 
 ## Security
 
-### TC-16 — Corrupted IndexedDB value is rejected on load
+### TC-33 — Corrupted IndexedDB value is rejected on load
 
 **Precondition:** The IndexedDB entry for the default fuel type contains a value that is not in the current derived fuel type list (e.g. a numeric value, an empty string, or an arbitrary string not matching any known fuel type label).
 
@@ -170,7 +346,7 @@
 
 ---
 
-### TC-17 — Fuel type label is not rendered as raw HTML
+### TC-34 — Fuel type label is not rendered as raw HTML
 
 **Precondition:** The stored default fuel type label contains an HTML string (e.g. `"<b>SP95</b>"`).
 
@@ -180,7 +356,7 @@
 
 ---
 
-### TC-18 — Saving a default stores only a plain string, not a structured object
+### TC-35 — Saving a default stores only a plain string, not a structured object
 
 **Precondition:** The user selects a fuel type and clicks "Save as default".
 
@@ -190,11 +366,21 @@
 
 ---
 
+### TC-36 — Clearing a default uses key deletion, not overwrite with empty value
+
+**Precondition:** `"SP95"` is the stored default.
+
+**Action:** The user clicks "Clear default". The IndexedDB store is inspected afterwards.
+
+**Expected outcome:** The key is absent from IndexedDB entirely — it was deleted, not set to an empty string, `null`, or `undefined`.
+
+---
+
 ## Keyboard Accessibility
 
-### TC-19 — "Save as default" button is keyboard accessible
+### TC-37 — "Save as default" button is keyboard accessible
 
-**Precondition:** The price view is visible with a fuel type selected.
+**Precondition:** The price view is visible with a fuel type selected and no default stored.
 
 **Action:** The user navigates to the "Save as default" control using the Tab key and activates it with Enter or Space.
 
@@ -202,13 +388,23 @@
 
 ---
 
-### TC-20 — "Update default" button is keyboard accessible
+### TC-38 — "Update default" button is keyboard accessible
 
-**Precondition:** A default is stored and the user has selected a different fuel type, making the "Update default" button visible.
+**Precondition:** A default is stored and the user has selected a different fuel type, making "Update default" visible.
 
 **Action:** The user navigates to the "Update default" control using the Tab key and activates it with Enter or Space.
 
 **Expected outcome:** The default is updated and the UI reflects the new default.
+
+---
+
+### TC-39 — "Clear default" button is keyboard accessible
+
+**Precondition:** A default is stored, making "Clear default" visible.
+
+**Action:** The user navigates to the "Clear default" control using the Tab key and activates it with Enter or Space.
+
+**Expected outcome:** The default is cleared and the UI updates as if the button had been clicked with a mouse.
 
 ---
 

--- a/docs/prompts/tasks/issue-28-default-fuel-type/test-results.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/test-results.md
@@ -13,9 +13,7 @@ All those mentioned in [technical specifications](technical-specifications.md).
 All tests passed. No failures.
 
 ### Test Summary
-
-16 test files, 203 tests total — all passed.
-
-- Duration: ~11.75 seconds
+16 test files, 225 tests total — all passed.
+- Duration: ~11.19 seconds (transform 3.89s, setup 0ms, import 4.68s, tests 6.62s, environment 14.17s)
 
 status: passed

--- a/docs/prompts/tasks/issue-28-default-fuel-type/test-results.md
+++ b/docs/prompts/tasks/issue-28-default-fuel-type/test-results.md
@@ -1,0 +1,21 @@
+# Test Results — Issue #28: Default Fuel Type
+
+## Test Run
+
+Command: `rtk vitest run` from the `feat_default-fuel-type` worktree.
+
+## Files Run
+
+All those mentioned in [technical specifications](technical-specifications.md).
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+16 test files, 203 tests total — all passed.
+
+- Duration: ~11.75 seconds
+
+status: passed

--- a/src/components/StationPrices.spec.ts
+++ b/src/components/StationPrices.spec.ts
@@ -53,6 +53,18 @@ vi.mock('@/composables/useStationStorage', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Mock useDefaultFuelType (required by StationPricesContent — Issue #28)
+// ---------------------------------------------------------------------------
+
+vi.mock('@/composables/useDefaultFuelType', () => ({
+  useDefaultFuelType: () => ({
+    defaultFuelType: ref(null),
+    loadDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+    saveDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/src/components/StationPrices.spec.ts
+++ b/src/components/StationPrices.spec.ts
@@ -61,6 +61,8 @@ vi.mock('@/composables/useDefaultFuelType', () => ({
     defaultFuelType: ref(null),
     loadDefaultFuelType: vi.fn().mockResolvedValue(undefined),
     saveDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+    updateDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+    clearDefaultFuelType: vi.fn().mockResolvedValue(undefined),
   }),
 }))
 

--- a/src/components/StationPricesContent.spec.ts
+++ b/src/components/StationPricesContent.spec.ts
@@ -64,6 +64,20 @@ vi.mock('@/composables/useStationStorage', () => ({
   }),
 }))
 
+const mockDefaultFuelType = ref<string | null>(null)
+const mockLoadDefaultFuelType = vi.fn().mockResolvedValue(undefined)
+const mockSaveDefaultFuelType = vi.fn().mockImplementation(async (label: string) => {
+  mockDefaultFuelType.value = label
+})
+
+vi.mock('@/composables/useDefaultFuelType', () => ({
+  useDefaultFuelType: () => ({
+    defaultFuelType: mockDefaultFuelType,
+    loadDefaultFuelType: mockLoadDefaultFuelType,
+    saveDefaultFuelType: mockSaveDefaultFuelType,
+  }),
+}))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -108,6 +122,12 @@ beforeEach(() => {
   mockAddStationPrice.mockReset()
   mockAddStationPrice.mockResolvedValue(undefined)
   mockRenameStation.mockReset()
+  mockDefaultFuelType.value = null
+  mockLoadDefaultFuelType.mockResolvedValue(undefined)
+  mockSaveDefaultFuelType.mockReset()
+  mockSaveDefaultFuelType.mockImplementation(async (label: string) => {
+    mockDefaultFuelType.value = label
+  })
 })
 
 afterEach(() => {
@@ -353,5 +373,369 @@ describe('TC-09: selected fuel type resets to first available when it disappears
     expect(newButtons).toHaveLength(1)
     expect(newButtons[0].text()).toBe('SP95')
     expect(newButtons[0].classes()).toContain('active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-06 — "Save as default" stores the selected fuel type; UI reflects
+//                  the confirmed/active state.
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-06: clicking "Save as default" stores the selection and activates the button', () => {
+  it('calls saveDefaultFuelType with the selected fuel type and shows "Default saved" label', async () => {
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    // Trigger watcher so selectedFuelType is seeded
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    const saveButton = activeWrapper.find('.default-fuel-button')
+    expect(saveButton.exists()).toBe(true)
+
+    await saveButton.trigger('click')
+    await flushPromises()
+
+    expect(mockSaveDefaultFuelType).toHaveBeenCalledWith('SP95')
+
+    // After save, mockDefaultFuelType.value === 'SP95', so isCurrentDefault should be true
+    await nextTick()
+    const updatedButton = activeWrapper.find('.default-fuel-button')
+    expect(updatedButton.text()).toBe('Default saved')
+    expect(updatedButton.classes()).toContain('default-fuel-button--saved')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-07 — "Save as default" is not rendered when no fuel types are available
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-07: "Save as default" button is not rendered when no fuel types are loaded', () => {
+  it('does not render the default-fuel-actions section when availableFuelTypes is empty', async () => {
+    mockResults.value = []
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const saveButton = activeWrapper.find('.default-fuel-button')
+    expect(saveButton.exists()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-08 — After saving, the fuel type list reorders with new default first
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-08: after saving "Gasoil" as default, it appears first in the fuel type list', () => {
+  it('places "Gasoil" at index 0 in the fuel type selector after saving', async () => {
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+          { type: 'E10', price: 1.79 },
+        ],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    // Seed selectedFuelType via watcher
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    // Select Gasoil and save as default
+    const buttons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = buttons.find((b) => b.text() === 'Gasoil')
+    expect(gasoilButton).toBeDefined()
+    await gasoilButton!.trigger('click')
+    await flushPromises()
+
+    const saveButton = activeWrapper.find('.default-fuel-button')
+    await saveButton.trigger('click')
+    await flushPromises()
+
+    // mockSaveDefaultFuelType sets mockDefaultFuelType.value = 'Gasoil'
+    await nextTick()
+    await flushPromises()
+
+    const reorderedButtons = activeWrapper.findAll('.fuel-type-selector button')
+    expect(reorderedButtons[0].text()).toBe('Gasoil')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-12 — "Update default" is visible when selection differs from stored default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-12: "Update default" button is visible when the selected type differs from the stored default', () => {
+  it('renders the "Update default" button when "Gasoil" is selected and "SP95" is the default', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    // Seed selection
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    // Select Gasoil (which differs from the stored default SP95)
+    const buttons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = buttons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const updateButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Update default')
+    expect(updateButton).toBeDefined()
+    expect(updateButton!.exists()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-13 — "Update default" is not visible when selection matches stored default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-13: "Update default" button is not rendered when the selected type matches the stored default', () => {
+  it('hides "Update default" when "SP95" is selected and "SP95" is the stored default', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    // Seed selection (SP95 is the stored default, so it seeds as SP95)
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    const allDefaultButtons = activeWrapper.findAll('.default-fuel-button')
+    const updateButton = allDefaultButtons.find((b) => b.text() === 'Update default')
+    expect(updateButton).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-14 — "Update default" is not visible when no default is stored
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-14: "Update default" button is not rendered when no default is stored', () => {
+  it('shows only "Save as default" when defaultFuelType is null', async () => {
+    mockDefaultFuelType.value = null
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [{ type: 'Gasoil', price: 1.75 }],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    const allDefaultButtons = activeWrapper.findAll('.default-fuel-button')
+    const updateButton = allDefaultButtons.find((b) => b.text() === 'Update default')
+    expect(updateButton).toBeUndefined()
+
+    const saveButton = allDefaultButtons.find((b) => b.text() === 'Save as default')
+    expect(saveButton).toBeDefined()
+    expect(saveButton!.exists()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-15 — Clicking "Update default" replaces the stored default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-15: clicking "Update default" calls saveDefaultFuelType with the current selection', () => {
+  it('saves "Gasoil" and hides "Update default" after clicking it', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    // Select Gasoil
+    const buttons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = buttons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const updateButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Update default')
+    expect(updateButton!.exists()).toBe(true)
+
+    await updateButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockSaveDefaultFuelType).toHaveBeenCalledWith('Gasoil')
+
+    // After save, mockDefaultFuelType.value === 'Gasoil' — Update default should disappear
+    await nextTick()
+    const remainingDefaultButtons = activeWrapper.findAll('.default-fuel-button')
+    const stillUpdateButton = remainingDefaultButtons.find((b) => b.text() === 'Update default')
+    expect(stillUpdateButton).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-17 — Fuel type label is not rendered as raw HTML
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-17: fuel type labels containing HTML markup are displayed as plain text', () => {
+  it('renders "<b>SP95</b>" as a literal string, not as bold markup', async () => {
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [{ type: '<b>SP95</b>', price: 1.89 }],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    // The fuel-type-selector should show the literal string, not rendered HTML
+    const selectorButtons = activeWrapper.findAll('.fuel-type-selector button')
+    expect(selectorButtons).toHaveLength(1)
+    expect(selectorButtons[0].text()).toBe('<b>SP95</b>')
+    // No <b> element should be rendered inside the button
+    expect(selectorButtons[0].find('b').exists()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-19 — "Save as default" button is keyboard accessible
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-19: "Save as default" is a plain <button> element for keyboard accessibility', () => {
+  it('renders as a <button> with type="button" so it is reachable via Tab and activatable via Enter/Space', async () => {
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    const saveButton = activeWrapper.find('.default-fuel-button')
+    expect(saveButton.element.tagName).toBe('BUTTON')
+    expect(saveButton.attributes('type')).toBe('button')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-20 — "Update default" button is keyboard accessible
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-20: "Update default" is a plain <button> element for keyboard accessibility', () => {
+  it('renders as a <button> with type="button" so it is reachable via Tab and activatable via Enter/Space', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = mountComponent()
+    await flushPromises()
+
+    const snapshot = [...mockResults.value]
+    mockResults.value = []
+    await nextTick()
+    mockResults.value = snapshot
+    await nextTick()
+    await flushPromises()
+
+    // Select Gasoil to make "Update default" visible
+    const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = fuelButtons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const updateButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Update default')
+    expect(updateButton).toBeDefined()
+    expect(updateButton!.element.tagName).toBe('BUTTON')
+    expect(updateButton!.attributes('type')).toBe('button')
   })
 })

--- a/src/components/StationPricesContent.spec.ts
+++ b/src/components/StationPricesContent.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for StationPricesContent component — Issue #31 reactivity scenarios.
+ * Tests for StationPricesContent component — Issue #31 reactivity scenarios
+ * and Issue #28 default fuel type scenarios.
  *
  * StationPricesContent watches the `stations` ref from useStationStorage and
  * dispatches incremental price operations (removeStationPrice, addStationPrice,
@@ -69,12 +70,20 @@ const mockLoadDefaultFuelType = vi.fn().mockResolvedValue(undefined)
 const mockSaveDefaultFuelType = vi.fn().mockImplementation(async (label: string) => {
   mockDefaultFuelType.value = label
 })
+const mockUpdateDefaultFuelType = vi.fn().mockImplementation(async (label: string) => {
+  mockDefaultFuelType.value = label
+})
+const mockClearDefaultFuelType = vi.fn().mockImplementation(async () => {
+  mockDefaultFuelType.value = null
+})
 
 vi.mock('@/composables/useDefaultFuelType', () => ({
   useDefaultFuelType: () => ({
     defaultFuelType: mockDefaultFuelType,
     loadDefaultFuelType: mockLoadDefaultFuelType,
     saveDefaultFuelType: mockSaveDefaultFuelType,
+    updateDefaultFuelType: mockUpdateDefaultFuelType,
+    clearDefaultFuelType: mockClearDefaultFuelType,
   }),
 }))
 
@@ -99,6 +108,25 @@ function mountComponent() {
   return mount(Wrapper, { global: { stubs: sharedStubs } })
 }
 
+/**
+ * Seed the watcher: mount, then cycle results through empty so the
+ * non-immediate watch(derivedFuelTypes) fires and sets selectedFuelType.
+ */
+async function mountAndSeedSelection(results: StationData[]) {
+  mockResults.value = results
+  const wrapper = mountComponent()
+  await flushPromises()
+
+  const snapshot = [...mockResults.value]
+  mockResults.value = []
+  await nextTick()
+  mockResults.value = snapshot
+  await nextTick()
+  await flushPromises()
+
+  return wrapper
+}
+
 // ---------------------------------------------------------------------------
 // Setup / teardown — unmount between tests to prevent stale watcher callbacks
 // ---------------------------------------------------------------------------
@@ -110,7 +138,6 @@ beforeEach(() => {
   mockWarnings.value = []
   mockIsLoading.value = false
   mockFetchCompleted.value = false
-  // Reset stations synchronously before component mounts
   mockStations.value = [
     { name: 'Station A', url: 'https://example.com/station/a' },
     { name: 'Station B', url: 'https://example.com/station/b' },
@@ -127,6 +154,14 @@ beforeEach(() => {
   mockSaveDefaultFuelType.mockReset()
   mockSaveDefaultFuelType.mockImplementation(async (label: string) => {
     mockDefaultFuelType.value = label
+  })
+  mockUpdateDefaultFuelType.mockReset()
+  mockUpdateDefaultFuelType.mockImplementation(async (label: string) => {
+    mockDefaultFuelType.value = label
+  })
+  mockClearDefaultFuelType.mockReset()
+  mockClearDefaultFuelType.mockImplementation(async () => {
+    mockDefaultFuelType.value = null
   })
 })
 
@@ -261,6 +296,28 @@ describe('TC-05: adding a new station dispatches addStationPrice', () => {
 })
 
 // ---------------------------------------------------------------------------
+// TC-06 — No default stored: only "Save as default" is visible
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-06: no default stored — only "Save as default" is visible', () => {
+  it('shows "Save as default", hides "Update default" and "Clear default"', async () => {
+    mockDefaultFuelType.value = null
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+
+    expect(labels).toContain('Save as default')
+    expect(labels).not.toContain('Update default')
+    expect(labels).not.toContain('Clear default')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // TC-07: Fuel type selector reflects available fuel types after station removal
 // ---------------------------------------------------------------------------
 
@@ -290,6 +347,36 @@ describe('TC-07: fuel type selector reflects only fuel types present in current 
     const labelsAfter = buttonsAfter.map((b) => b.text())
     expect(labelsAfter).not.toContain('GPL')
     expect(labelsAfter).toContain('SP95')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-07 (Issue-28) — Default stored, selection = stored default: only "Clear default" visible
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-07: default stored and selection matches — only "Clear default" is visible', () => {
+  it('shows "Clear default", hides "Save as default" and "Update default"', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    // The watch seeds selection to SP95 (the stored default is first in the ordered list)
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+
+    expect(labels).not.toContain('Save as default')
+    expect(labels).not.toContain('Update default')
+    expect(labels).toContain('Clear default')
   })
 })
 
@@ -336,6 +423,41 @@ describe('TC-08: selected fuel type is preserved after a station change when it 
 })
 
 // ---------------------------------------------------------------------------
+// TC-08 (Issue-28) — Default stored, selection ≠ stored default: "Update default" + "Clear default" visible
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-08: default stored, selection differs — "Update default" and "Clear default" are visible', () => {
+  it('shows "Update default" and "Clear default", hides "Save as default"', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    // Select Gasoil (differs from stored default SP95)
+    const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = fuelButtons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+
+    expect(labels).not.toContain('Save as default')
+    expect(labels).toContain('Update default')
+    expect(labels).toContain('Clear default')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // TC-09: Selected fuel type resets when it disappears from results
 // ---------------------------------------------------------------------------
 
@@ -377,64 +499,75 @@ describe('TC-09: selected fuel type resets to first available when it disappears
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-06 — "Save as default" stores the selected fuel type; UI reflects
-//                  the confirmed/active state.
+// Issue-28 TC-09 — "Save as default" stores the selected fuel type
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-06: clicking "Save as default" stores the selection and activates the button', () => {
-  it('calls saveDefaultFuelType with the selected fuel type and shows "Default saved" label', async () => {
+describe('Issue-28 TC-09: clicking "Save as default" calls saveDefaultFuelType with the selection', () => {
+  it('calls saveDefaultFuelType with "SP95" when SP95 is selected', async () => {
     mockResults.value = [
       { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
-    // Trigger watcher so selectedFuelType is seeded
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    const saveButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Save as default')
+    expect(saveButton).toBeDefined()
 
-    const saveButton = activeWrapper.find('.default-fuel-button')
-    expect(saveButton.exists()).toBe(true)
-
-    await saveButton.trigger('click')
+    await saveButton!.trigger('click')
     await flushPromises()
 
     expect(mockSaveDefaultFuelType).toHaveBeenCalledWith('SP95')
-
-    // After save, mockDefaultFuelType.value === 'SP95', so isCurrentDefault should be true
-    await nextTick()
-    const updatedButton = activeWrapper.find('.default-fuel-button')
-    expect(updatedButton.text()).toBe('Default saved')
-    expect(updatedButton.classes()).toContain('default-fuel-button--saved')
   })
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-07 — "Save as default" is not rendered when no fuel types are available
+// Issue-28 TC-10 — After saving, "Save as default" is hidden and "Default" indicator appears
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-07: "Save as default" button is not rendered when no fuel types are loaded', () => {
-  it('does not render the default-fuel-actions section when availableFuelTypes is empty', async () => {
+describe('Issue-28 TC-10: after saving, "Save as default" disappears and the "Default" indicator appears', () => {
+  it('hides "Save as default" and shows ".default-indicator" after clicking save', async () => {
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const saveButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Save as default')
+    await saveButton!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+    expect(labels).not.toContain('Save as default')
+
+    const indicator = activeWrapper.find('.default-indicator')
+    expect(indicator.exists()).toBe(true)
+    expect(indicator.text()).toBe('Default')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-11 — "Save as default" is not rendered when no fuel types are loaded
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-11: "Save as default" is not rendered when no fuel types are loaded', () => {
+  it('does not render any .default-fuel-button when availableFuelTypes is empty', async () => {
     mockResults.value = []
 
     activeWrapper = mountComponent()
     await flushPromises()
 
-    const saveButton = activeWrapper.find('.default-fuel-button')
-    expect(saveButton.exists()).toBe(false)
+    const buttons = activeWrapper.findAll('.default-fuel-button')
+    expect(buttons).toHaveLength(0)
   })
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-08 — After saving, the fuel type list reorders with new default first
+// Issue-28 TC-12 — After saving, the fuel type list reorders with new default first
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-08: after saving "Gasoil" as default, it appears first in the fuel type list', () => {
+describe('Issue-28 TC-12: after saving "Gasoil" as default, it appears first in the fuel type list', () => {
   it('places "Gasoil" at index 0 in the fuel type selector after saving', async () => {
     mockResults.value = [
       {
@@ -448,29 +581,17 @@ describe('Issue-28 TC-08: after saving "Gasoil" as default, it appears first in 
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
-
-    // Seed selectedFuelType via watcher
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
     // Select Gasoil and save as default
     const buttons = activeWrapper.findAll('.fuel-type-selector button')
     const gasoilButton = buttons.find((b) => b.text() === 'Gasoil')
-    expect(gasoilButton).toBeDefined()
     await gasoilButton!.trigger('click')
     await flushPromises()
 
-    const saveButton = activeWrapper.find('.default-fuel-button')
-    await saveButton.trigger('click')
+    const saveButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Save as default')
+    await saveButton!.trigger('click')
     await flushPromises()
-
-    // mockSaveDefaultFuelType sets mockDefaultFuelType.value = 'Gasoil'
     await nextTick()
     await flushPromises()
 
@@ -480,11 +601,35 @@ describe('Issue-28 TC-08: after saving "Gasoil" as default, it appears first in 
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-12 — "Update default" is visible when selection differs from stored default
+// Issue-28 TC-16 — On startup with a valid stored default, "Default" indicator shown and "Save as default" hidden
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-12: "Update default" button is visible when the selected type differs from the stored default', () => {
-  it('renders the "Update default" button when "Gasoil" is selected and "SP95" is the default', async () => {
+describe('Issue-28 TC-16: on startup with a valid stored default, "Default" indicator is shown and "Save as default" is hidden', () => {
+  it('shows the default indicator and hides "Save as default" when the stored default is the selected type', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const indicator = activeWrapper.find('.default-indicator')
+    expect(indicator.exists()).toBe(true)
+    expect(indicator.text()).toBe('Default')
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+    expect(labels).not.toContain('Save as default')
+    expect(labels).toContain('Clear default')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-17 — "Update default" is visible when selection differs from stored default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-17: "Update default" is visible when selection differs from stored default', () => {
+  it('renders "Update default" when "Gasoil" is selected and "SP95" is the default', async () => {
     mockDefaultFuelType.value = 'SP95'
     mockResults.value = [
       {
@@ -497,16 +642,7 @@ describe('Issue-28 TC-12: "Update default" button is visible when the selected t
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
-
-    // Seed selection
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
     // Select Gasoil (which differs from the stored default SP95)
     const buttons = activeWrapper.findAll('.fuel-type-selector button')
@@ -521,10 +657,10 @@ describe('Issue-28 TC-12: "Update default" button is visible when the selected t
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-13 — "Update default" is not visible when selection matches stored default
+// Issue-28 TC-18 — "Update default" is not visible when selection matches stored default
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-13: "Update default" button is not rendered when the selected type matches the stored default', () => {
+describe('Issue-28 TC-18: "Update default" is not rendered when the selected type matches the stored default', () => {
   it('hides "Update default" when "SP95" is selected and "SP95" is the stored default', async () => {
     mockDefaultFuelType.value = 'SP95'
     mockResults.value = [
@@ -538,17 +674,9 @@ describe('Issue-28 TC-13: "Update default" button is not rendered when the selec
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
-    // Seed selection (SP95 is the stored default, so it seeds as SP95)
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
-
+    // SP95 is seeded as selected (matches stored default)
     const allDefaultButtons = activeWrapper.findAll('.default-fuel-button')
     const updateButton = allDefaultButtons.find((b) => b.text() === 'Update default')
     expect(updateButton).toBeUndefined()
@@ -556,10 +684,10 @@ describe('Issue-28 TC-13: "Update default" button is not rendered when the selec
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-14 — "Update default" is not visible when no default is stored
+// Issue-28 TC-19 — "Update default" is not visible when no default is stored
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-14: "Update default" button is not rendered when no default is stored', () => {
+describe('Issue-28 TC-19: "Update default" is not rendered when no default is stored', () => {
   it('shows only "Save as default" when defaultFuelType is null', async () => {
     mockDefaultFuelType.value = null
     mockResults.value = [
@@ -570,15 +698,7 @@ describe('Issue-28 TC-14: "Update default" button is not rendered when no defaul
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
-
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
     const allDefaultButtons = activeWrapper.findAll('.default-fuel-button')
     const updateButton = allDefaultButtons.find((b) => b.text() === 'Update default')
@@ -591,11 +711,11 @@ describe('Issue-28 TC-14: "Update default" button is not rendered when no defaul
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-15 — Clicking "Update default" replaces the stored default
+// Issue-28 TC-20 — Clicking "Update default" replaces the stored default
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-15: clicking "Update default" calls saveDefaultFuelType with the current selection', () => {
-  it('saves "Gasoil" and hides "Update default" after clicking it', async () => {
+describe('Issue-28 TC-20: clicking "Update default" calls updateDefaultFuelType with the current selection', () => {
+  it('calls updateDefaultFuelType with "Gasoil" and hides "Update default" after clicking', async () => {
     mockDefaultFuelType.value = 'SP95'
     mockResults.value = [
       {
@@ -608,15 +728,7 @@ describe('Issue-28 TC-15: clicking "Update default" calls saveDefaultFuelType wi
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
-
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
     // Select Gasoil
     const buttons = activeWrapper.findAll('.fuel-type-selector button')
@@ -630,21 +742,330 @@ describe('Issue-28 TC-15: clicking "Update default" calls saveDefaultFuelType wi
     await updateButton!.trigger('click')
     await flushPromises()
 
-    expect(mockSaveDefaultFuelType).toHaveBeenCalledWith('Gasoil')
+    expect(mockUpdateDefaultFuelType).toHaveBeenCalledWith('Gasoil')
 
-    // After save, mockDefaultFuelType.value === 'Gasoil' — Update default should disappear
+    // After update, mockDefaultFuelType.value === 'Gasoil' — selectedFuelType matches default,
+    // so "Update default" should disappear
     await nextTick()
-    const remainingDefaultButtons = activeWrapper.findAll('.default-fuel-button')
-    const stillUpdateButton = remainingDefaultButtons.find((b) => b.text() === 'Update default')
-    expect(stillUpdateButton).toBeUndefined()
+    const remainingButtons = activeWrapper.findAll('.default-fuel-button')
+    const stillUpdate = remainingButtons.find((b) => b.text() === 'Update default')
+    expect(stillUpdate).toBeUndefined()
   })
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-17 — Fuel type label is not rendered as raw HTML
+// Issue-28 TC-21 — After updating, "Clear default" remains visible
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-17: fuel type labels containing HTML markup are displayed as plain text', () => {
+describe('Issue-28 TC-21: after updating, "Clear default" remains visible', () => {
+  it('keeps "Clear default" visible after "Update default" is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    // Select Gasoil and click "Update default"
+    const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = fuelButtons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const updateButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Update default')
+    await updateButton!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const clearButton = allButtons.find((b) => b.text() === 'Clear default')
+    expect(clearButton).toBeDefined()
+    expect(clearButton!.exists()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-22 — "Clear default" is visible when default stored and selection = default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-22: "Clear default" is visible when a default is stored and selection matches', () => {
+  it('shows "Clear default" when "SP95" is selected and is the stored default', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    expect(clearButton).toBeDefined()
+    expect(clearButton!.exists()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-23 — "Clear default" is visible when default stored and selection ≠ default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-23: "Clear default" is visible when a default is stored and selection differs', () => {
+  it('shows "Clear default" alongside "Update default" when "Gasoil" is selected and "SP95" is stored', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = fuelButtons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+    expect(labels).toContain('Clear default')
+    expect(labels).toContain('Update default')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-24 — "Clear default" is not visible when no default is stored
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-24: "Clear default" is not rendered when no default is stored', () => {
+  it('does not render "Clear default" when defaultFuelType is null', async () => {
+    mockDefaultFuelType.value = null
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const clearButton = allButtons.find((b) => b.text() === 'Clear default')
+    expect(clearButton).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-25 — Clicking "Clear default" calls clearDefaultFuelType
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-25: clicking "Clear default" calls clearDefaultFuelType', () => {
+  it('calls clearDefaultFuelType when the "Clear default" button is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    await clearButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockClearDefaultFuelType).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-26 — After clearing, "Save as default" reappears
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-26: after clearing, "Save as default" reappears', () => {
+  it('shows "Save as default" after "Clear default" is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    await clearButton!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const saveButton = allButtons.find((b) => b.text() === 'Save as default')
+    expect(saveButton).toBeDefined()
+    expect(saveButton!.exists()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-27 — After clearing, "Update default" and "Clear default" are hidden
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-27: after clearing, "Update default" and "Clear default" are hidden', () => {
+  it('hides "Update default" and "Clear default" after "Clear default" is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    await clearButton!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    const allButtons = activeWrapper.findAll('.default-fuel-button')
+    const labels = allButtons.map((b) => b.text())
+    expect(labels).not.toContain('Update default')
+    expect(labels).not.toContain('Clear default')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-28 — After clearing, the "Default" indicator is removed
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-28: after clearing, the "Default" indicator disappears', () => {
+  it('removes .default-indicator after "Clear default" is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    // Indicator should be present initially
+    expect(activeWrapper.find('.default-indicator').exists()).toBe(true)
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    await clearButton!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(activeWrapper.find('.default-indicator').exists()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-29 — After clearing, the fuel type list reverts to natural order
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-29: after clearing, the fuel type list reverts to natural order', () => {
+  it('shows ["SP95", "Gasoil", "E10"] after clearing a "Gasoil" default', async () => {
+    mockDefaultFuelType.value = 'Gasoil'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+          { type: 'E10', price: 1.79 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    // Before clearing: Gasoil is first (ordered by default)
+    const buttonsBefore = activeWrapper.findAll('.fuel-type-selector button')
+    expect(buttonsBefore[0].text()).toBe('Gasoil')
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    await clearButton!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    // After clearing: natural order restored
+    const buttonsAfter = activeWrapper.findAll('.fuel-type-selector button')
+    expect(buttonsAfter[0].text()).toBe('SP95')
+    expect(buttonsAfter[1].text()).toBe('Gasoil')
+    expect(buttonsAfter[2].text()).toBe('E10')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-30 — "Default" indicator is shown when selected type matches stored default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-30: "Default" indicator is shown when selected type matches stored default', () => {
+  it('renders .default-indicator when "SP95" is selected and is the stored default', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const indicator = activeWrapper.find('.default-indicator')
+    expect(indicator.exists()).toBe(true)
+    expect(indicator.text()).toBe('Default')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-31 — "Default" indicator is not shown when selected type differs from stored default
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-31: "Default" indicator is not shown when selected type differs from stored default', () => {
+  it('does not render .default-indicator when "Gasoil" is selected and "SP95" is the stored default', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    // Select Gasoil
+    const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = fuelButtons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    expect(activeWrapper.find('.default-indicator').exists()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-32 — "Default" indicator is not shown when no default is stored
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-32: "Default" indicator is not shown when no default is stored', () => {
+  it('does not render .default-indicator when defaultFuelType is null', async () => {
+    mockDefaultFuelType.value = null
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    expect(activeWrapper.find('.default-indicator').exists()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-34 — Fuel type label is not rendered as raw HTML
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-34: fuel type labels containing HTML markup are displayed as plain text', () => {
   it('renders "<b>SP95</b>" as a literal string, not as bold markup', async () => {
     mockResults.value = [
       {
@@ -654,15 +1075,7 @@ describe('Issue-28 TC-17: fuel type labels containing HTML markup are displayed 
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
-
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
     // The fuel-type-selector should show the literal string, not rendered HTML
     const selectorButtons = activeWrapper.findAll('.fuel-type-selector button')
@@ -674,36 +1087,29 @@ describe('Issue-28 TC-17: fuel type labels containing HTML markup are displayed 
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-19 — "Save as default" button is keyboard accessible
+// Issue-28 TC-37 — "Save as default" button is keyboard accessible
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-19: "Save as default" is a plain <button> element for keyboard accessibility', () => {
+describe('Issue-28 TC-37: "Save as default" is a plain <button> element for keyboard accessibility', () => {
   it('renders as a <button> with type="button" so it is reachable via Tab and activatable via Enter/Space', async () => {
     mockResults.value = [
       { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
-
-    const saveButton = activeWrapper.find('.default-fuel-button')
-    expect(saveButton.element.tagName).toBe('BUTTON')
-    expect(saveButton.attributes('type')).toBe('button')
+    const saveButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Save as default')
+    expect(saveButton).toBeDefined()
+    expect(saveButton!.element.tagName).toBe('BUTTON')
+    expect(saveButton!.attributes('type')).toBe('button')
   })
 })
 
 // ---------------------------------------------------------------------------
-// Issue-28 TC-20 — "Update default" button is keyboard accessible
+// Issue-28 TC-38 — "Update default" button is keyboard accessible
 // ---------------------------------------------------------------------------
 
-describe('Issue-28 TC-20: "Update default" is a plain <button> element for keyboard accessibility', () => {
+describe('Issue-28 TC-38: "Update default" is a plain <button> element for keyboard accessibility', () => {
   it('renders as a <button> with type="button" so it is reachable via Tab and activatable via Enter/Space', async () => {
     mockDefaultFuelType.value = 'SP95'
     mockResults.value = [
@@ -717,15 +1123,7 @@ describe('Issue-28 TC-20: "Update default" is a plain <button> element for keybo
       },
     ]
 
-    activeWrapper = mountComponent()
-    await flushPromises()
-
-    const snapshot = [...mockResults.value]
-    mockResults.value = []
-    await nextTick()
-    mockResults.value = snapshot
-    await nextTick()
-    await flushPromises()
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
 
     // Select Gasoil to make "Update default" visible
     const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
@@ -737,5 +1135,25 @@ describe('Issue-28 TC-20: "Update default" is a plain <button> element for keybo
     expect(updateButton).toBeDefined()
     expect(updateButton!.element.tagName).toBe('BUTTON')
     expect(updateButton!.attributes('type')).toBe('button')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-39 — "Clear default" button is keyboard accessible
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-39: "Clear default" is a plain <button> element for keyboard accessibility', () => {
+  it('renders as a <button> with type="button" so it is reachable via Tab and activatable via Enter/Space', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const clearButton = activeWrapper.findAll('.default-fuel-button').find((b) => b.text() === 'Clear default')
+    expect(clearButton).toBeDefined()
+    expect(clearButton!.element.tagName).toBe('BUTTON')
+    expect(clearButton!.attributes('type')).toBe('button')
   })
 })

--- a/src/components/StationPricesContent.vue
+++ b/src/components/StationPricesContent.vue
@@ -23,6 +23,23 @@
           {{ fuelType }}
         </button>
       </div>
+      <div class="default-fuel-actions">
+        <button
+          type="button"
+          :class="['default-fuel-button', { 'default-fuel-button--saved': isCurrentDefault }]"
+          @click="onSaveDefault"
+        >
+          {{ isCurrentDefault ? 'Default saved' : 'Save as default' }}
+        </button>
+        <button
+          v-if="showUpdateDefault"
+          type="button"
+          class="default-fuel-button"
+          @click="onSaveDefault"
+        >
+          Update default
+        </button>
+      </div>
       <Table>
         <TableHeader>
           <TableRow :disable-hover="true">
@@ -53,7 +70,8 @@ import {
 } from '@/components/ui/table'
 import { useStationPrices } from '@/composables/useStationPrices'
 import { useStationStorage } from '@/composables/useStationStorage'
-import { buildPriceRows, deriveFuelTypes } from '@/utils/fuelTypeUtils'
+import { useDefaultFuelType } from '@/composables/useDefaultFuelType'
+import { buildPriceRows, deriveFuelTypes, orderFuelTypes } from '@/utils/fuelTypeUtils'
 import type { PriceRow } from '@/types/price-row'
 import type { Station } from '@/types/station'
 
@@ -61,23 +79,64 @@ const SUCCESS_DISMISS_DELAY_MS = 3000
 
 const { stations, loadStations } = useStationStorage()
 const { results, warnings, fetchCompleted, loadAllStationPrices, removeStationPrice, addStationPrice, renameStation } = useStationPrices()
+const { defaultFuelType, loadDefaultFuelType, saveDefaultFuelType } = useDefaultFuelType()
 
 const showFetchSuccess = ref(false)
 const selectedFuelType = ref('')
 let dismissTimer: ReturnType<typeof setTimeout> | null = null
 let isInitialized = false
 
-const availableFuelTypes = computed<string[]>(() => deriveFuelTypes(results.value))
+const derivedFuelTypes = computed<string[]>(() => deriveFuelTypes(results.value))
+
+/**
+ * Cross-validates the stored default against the live derived list (security-guidelines.md rule 1).
+ * The composable accepts any non-empty string from IndexedDB; the component is responsible
+ * for checking the value against the currently available fuel types before treating it as valid.
+ * Returns null when the stored default is absent from the derived list — without clearing
+ * the persisted value (TC-11: stored default is left intact when fuel types change).
+ */
+const validatedDefaultFuelType = computed<string | null>(() => {
+  const stored = defaultFuelType.value
+  if (stored === null) return null
+  return derivedFuelTypes.value.includes(stored) ? stored : null
+})
+
+const availableFuelTypes = computed<string[]>(() =>
+  orderFuelTypes(derivedFuelTypes.value, validatedDefaultFuelType.value),
+)
 
 const priceRows = computed<PriceRow[]>(() => {
   if (selectedFuelType.value === '') return []
   return buildPriceRows(results.value, selectedFuelType.value)
 })
 
-watch(availableFuelTypes, (fuelTypes: string[]) => {
+const isCurrentDefault = computed<boolean>(
+  () => validatedDefaultFuelType.value !== null && selectedFuelType.value === validatedDefaultFuelType.value,
+)
+
+const showUpdateDefault = computed<boolean>(
+  () =>
+    validatedDefaultFuelType.value !== null &&
+    selectedFuelType.value !== '' &&
+    selectedFuelType.value !== validatedDefaultFuelType.value,
+)
+
+function resolveInitialSelection(fuelTypes: string[]): string {
+  if (fuelTypes.length === 0) return ''
+  const validDefault = validatedDefaultFuelType.value
+  if (validDefault !== null && fuelTypes.includes(validDefault)) return validDefault
+  return fuelTypes[0]
+}
+
+watch(derivedFuelTypes, (fuelTypes: string[]) => {
   if (fuelTypes.includes(selectedFuelType.value)) return
-  selectedFuelType.value = fuelTypes[0] ?? ''
+  selectedFuelType.value = resolveInitialSelection(fuelTypes)
 })
+
+async function onSaveDefault(): Promise<void> {
+  if (selectedFuelType.value === '') return
+  await saveDefaultFuelType(selectedFuelType.value)
+}
 
 function clearDismissTimer(): void {
   if (dismissTimer !== null) {
@@ -146,6 +205,7 @@ watch(stations, (newStations: Station[], oldStations: Station[]) => {
 })
 
 await loadStations()
+await loadDefaultFuelType()
 await loadAllStationPrices(stations.value)
 isInitialized = true
 
@@ -190,6 +250,48 @@ onUnmounted(() => {
 }
 
 .fuel-type-button.active {
+  background-color: var(--cta-base);
+  color: var(--cta-neutral-light);
+  border-color: var(--cta-darker);
+}
+
+/*
+ * .default-fuel-actions: Custom CSS required because Tailwind has no utility for
+ * CSS custom properties used as design-token references (e.g. var(--cta-light),
+ * var(--cta-base)). The layout itself (flex, gap, margin) could use Tailwind, but
+ * keeping all button-group styles in the same rule set avoids splitting related
+ * declarations across template attributes and the style block.
+ */
+.default-fuel-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+/*
+ * .default-fuel-button: Custom CSS required because the button appearance relies
+ * on CSS custom properties (var(--cta-light), var(--cta-lighter), etc.) defined
+ * in the global design token stylesheet. Tailwind's arbitrary-value syntax
+ * (e.g. bg-[var(--cta-lighter)]) is intentionally avoided to keep design-token
+ * references centralised in the scoped style block rather than scattered across
+ * template attributes.
+ */
+.default-fuel-button {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--cta-light);
+  border-radius: 0.375rem;
+  background-color: var(--cta-lighter);
+  color: var(--cta-neutral-dark);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+/*
+ * .default-fuel-button--saved: BEM modifier using the same CSS custom property
+ * tokens as .default-fuel-button. Same rationale applies — Tailwind arbitrary
+ * values for design tokens are avoided here for consistency.
+ */
+.default-fuel-button--saved {
   background-color: var(--cta-base);
   color: var(--cta-neutral-light);
   border-color: var(--cta-darker);

--- a/src/components/StationPricesContent.vue
+++ b/src/components/StationPricesContent.vue
@@ -24,20 +24,30 @@
         </button>
       </div>
       <div class="default-fuel-actions">
+        <span v-if="isCurrentDefault" class="default-indicator" aria-label="This is your default fuel type">Default</span>
         <button
+          v-if="showSaveDefault"
           type="button"
-          :class="['default-fuel-button', { 'default-fuel-button--saved': isCurrentDefault }]"
+          class="default-fuel-button"
           @click="onSaveDefault"
         >
-          {{ isCurrentDefault ? 'Default saved' : 'Save as default' }}
+          Save as default
         </button>
         <button
           v-if="showUpdateDefault"
           type="button"
           class="default-fuel-button"
-          @click="onSaveDefault"
+          @click="onUpdateDefault"
         >
           Update default
+        </button>
+        <button
+          v-if="showClearDefault"
+          type="button"
+          class="default-fuel-button"
+          @click="onClearDefault"
+        >
+          Clear default
         </button>
       </div>
       <Table>
@@ -79,7 +89,7 @@ const SUCCESS_DISMISS_DELAY_MS = 3000
 
 const { stations, loadStations } = useStationStorage()
 const { results, warnings, fetchCompleted, loadAllStationPrices, removeStationPrice, addStationPrice, renameStation } = useStationPrices()
-const { defaultFuelType, loadDefaultFuelType, saveDefaultFuelType } = useDefaultFuelType()
+const { defaultFuelType, loadDefaultFuelType, saveDefaultFuelType, updateDefaultFuelType, clearDefaultFuelType } = useDefaultFuelType()
 
 const showFetchSuccess = ref(false)
 const selectedFuelType = ref('')
@@ -93,7 +103,7 @@ const derivedFuelTypes = computed<string[]>(() => deriveFuelTypes(results.value)
  * The composable accepts any non-empty string from IndexedDB; the component is responsible
  * for checking the value against the currently available fuel types before treating it as valid.
  * Returns null when the stored default is absent from the derived list — without clearing
- * the persisted value (TC-11: stored default is left intact when fuel types change).
+ * the persisted value (TC-15: stored default is left intact when fuel types change).
  */
 const validatedDefaultFuelType = computed<string | null>(() => {
   const stored = defaultFuelType.value
@@ -114,12 +124,27 @@ const isCurrentDefault = computed<boolean>(
   () => validatedDefaultFuelType.value !== null && selectedFuelType.value === validatedDefaultFuelType.value,
 )
 
+/**
+ * Button visibility matrix (business-specifications.md):
+ *
+ * | Condition                                       | Save | Update | Clear |
+ * |-------------------------------------------------|------|--------|-------|
+ * | No default stored                               |  ✓   |   —    |   —   |
+ * | Default stored, selection = default             |  —   |   —    |   ✓   |
+ * | Default stored, selection ≠ default             |  —   |   ✓    |   ✓   |
+ */
+const hasStoredDefault = computed<boolean>(() => defaultFuelType.value !== null)
+
+const showSaveDefault = computed<boolean>(() => !hasStoredDefault.value)
+
 const showUpdateDefault = computed<boolean>(
   () =>
-    validatedDefaultFuelType.value !== null &&
+    hasStoredDefault.value &&
     selectedFuelType.value !== '' &&
     selectedFuelType.value !== validatedDefaultFuelType.value,
 )
+
+const showClearDefault = computed<boolean>(() => hasStoredDefault.value)
 
 function resolveInitialSelection(fuelTypes: string[]): string {
   if (fuelTypes.length === 0) return ''
@@ -136,6 +161,15 @@ watch(derivedFuelTypes, (fuelTypes: string[]) => {
 async function onSaveDefault(): Promise<void> {
   if (selectedFuelType.value === '') return
   await saveDefaultFuelType(selectedFuelType.value)
+}
+
+async function onUpdateDefault(): Promise<void> {
+  if (selectedFuelType.value === '') return
+  await updateDefaultFuelType(selectedFuelType.value)
+}
+
+async function onClearDefault(): Promise<void> {
+  await clearDefaultFuelType()
 }
 
 function clearDismissTimer(): void {
@@ -257,43 +291,49 @@ onUnmounted(() => {
 
 /*
  * .default-fuel-actions: Custom CSS required because Tailwind has no utility for
- * CSS custom properties used as design-token references (e.g. var(--cta-light),
- * var(--cta-base)). The layout itself (flex, gap, margin) could use Tailwind, but
- * keeping all button-group styles in the same rule set avoids splitting related
- * declarations across template attributes and the style block.
+ * CSS custom properties used as design-token references. The layout itself
+ * (flex, gap, margin) could use Tailwind, but keeping all button-group styles
+ * in the same rule set avoids splitting related declarations across template
+ * attributes and the style block.
  */
 .default-fuel-actions {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
 }
 
 /*
- * .default-fuel-button: Custom CSS required because the button appearance relies
- * on CSS custom properties (var(--cta-light), var(--cta-lighter), etc.) defined
- * in the global design token stylesheet. Tailwind's arbitrary-value syntax
- * (e.g. bg-[var(--cta-lighter)]) is intentionally avoided to keep design-token
- * references centralised in the scoped style block rather than scattered across
- * template attributes.
+ * .default-indicator: Custom CSS required to apply the stone-200/stone-800
+ * design tokens (var(--color-stone-200), var(--color-stone-800)) from the
+ * business spec. Tailwind arbitrary-value syntax for CSS custom properties
+ * is intentionally avoided to keep design-token references centralised in
+ * the scoped style block.
  */
-.default-fuel-button {
-  padding: 0.25rem 0.75rem;
-  border: 1px solid var(--cta-light);
+.default-indicator {
+  padding: 0.125rem 0.5rem;
   border-radius: 0.375rem;
-  background-color: var(--cta-lighter);
-  color: var(--cta-neutral-dark);
-  cursor: pointer;
-  font-size: 0.875rem;
+  background-color: var(--color-stone-200);
+  color: var(--color-stone-800);
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 /*
- * .default-fuel-button--saved: BEM modifier using the same CSS custom property
- * tokens as .default-fuel-button. Same rationale applies — Tailwind arbitrary
- * values for design tokens are avoided here for consistency.
+ * .default-fuel-button: Custom CSS required because the button appearance relies
+ * on CSS custom properties (var(--color-stone-200), var(--color-stone-800))
+ * defined in the global design token stylesheet per business-specifications.md.
+ * Tailwind's arbitrary-value syntax (e.g. bg-[var(--color-stone-200)]) is
+ * intentionally avoided to keep design-token references centralised in the
+ * scoped style block rather than scattered across template attributes.
  */
-.default-fuel-button--saved {
-  background-color: var(--cta-base);
-  color: var(--cta-neutral-light);
-  border-color: var(--cta-darker);
+.default-fuel-button {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-stone-400);
+  border-radius: 0.375rem;
+  background-color: var(--color-stone-200);
+  color: var(--color-stone-800);
+  cursor: pointer;
+  font-size: 0.875rem;
 }
 </style>

--- a/src/composables/useDefaultFuelType.spec.ts
+++ b/src/composables/useDefaultFuelType.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for useDefaultFuelType composable — Issue #28.
+ *
+ * useDefaultFuelType is a singleton composable (ADR-002): the module-level ref
+ * is shared across all consumers. vi.resetModules() + dynamic import() is used
+ * to get a fresh module instance (and therefore fresh reactive state) for each
+ * test.
+ *
+ * IndexedDB is mocked with an in-memory Map via vi.mock, following the pattern
+ * established in useStationStorage.spec.ts.
+ *
+ * Scenarios covered:
+ *   TC-06  — saveDefaultFuelType persists and reflects the label in reactive state
+ *   TC-09  — loadDefaultFuelType reads a stored value and sets defaultFuelType
+ *   TC-10  — loadDefaultFuelType sets defaultFuelType to null when nothing is stored
+ *   TC-11  — loadDefaultFuelType sets defaultFuelType to null when the stored value is absent
+ *            (not present in the derived list — validated at component level, not here)
+ *   TC-16  — corrupted (non-string) IndexedDB value is rejected; defaultFuelType stays null
+ *   TC-18  — saveDefaultFuelType writes a plain string to IndexedDB, not an object
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// In-memory IndexedDB mock
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, unknown>()
+
+vi.mock('@/utils/indexedDb', () => ({
+  get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+  set: vi.fn((key: string, value: unknown) => {
+    store.set(key, value)
+    return Promise.resolve()
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function freshComposable() {
+  vi.resetModules()
+  const mod = await import('./useDefaultFuelType')
+  return mod.useDefaultFuelType()
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  store.clear()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// TC-06 — "Save as default" stores the selected fuel type
+// ---------------------------------------------------------------------------
+
+describe('TC-06: saveDefaultFuelType persists the label and updates reactive state', () => {
+  it('sets defaultFuelType.value to the saved label and writes it to IndexedDB', async () => {
+    const { defaultFuelType, saveDefaultFuelType } = await freshComposable()
+
+    expect(defaultFuelType.value).toBeNull()
+
+    await saveDefaultFuelType('SP95')
+
+    expect(defaultFuelType.value).toBe('SP95')
+    expect(store.get('defaultFuelType')).toBe('SP95')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-09 — Stored default is pre-selected when the price view loads
+// ---------------------------------------------------------------------------
+
+describe('TC-09: loadDefaultFuelType reads the stored value into defaultFuelType', () => {
+  it('sets defaultFuelType.value to the stored string after loading', async () => {
+    store.set('defaultFuelType', 'Gasoil')
+
+    const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
+
+    expect(defaultFuelType.value).toBeNull()
+
+    await loadDefaultFuelType()
+
+    expect(defaultFuelType.value).toBe('Gasoil')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-10 — No stored default: defaultFuelType stays null
+// ---------------------------------------------------------------------------
+
+describe('TC-10: loadDefaultFuelType leaves defaultFuelType as null when nothing is stored', () => {
+  it('keeps defaultFuelType.value as null when IndexedDB has no entry', async () => {
+    const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
+
+    await loadDefaultFuelType()
+
+    expect(defaultFuelType.value).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-11 / TC-16 — Corrupted or empty IndexedDB value is rejected
+// ---------------------------------------------------------------------------
+
+describe('TC-11 / TC-16: loadDefaultFuelType rejects non-string and empty-string values', () => {
+  it('sets defaultFuelType to null when the stored value is a number', async () => {
+    store.set('defaultFuelType', 42)
+
+    const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
+    await loadDefaultFuelType()
+
+    expect(defaultFuelType.value).toBeNull()
+  })
+
+  it('sets defaultFuelType to null when the stored value is an empty string', async () => {
+    store.set('defaultFuelType', '')
+
+    const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
+    await loadDefaultFuelType()
+
+    expect(defaultFuelType.value).toBeNull()
+  })
+
+  it('sets defaultFuelType to null when the stored value is an object', async () => {
+    store.set('defaultFuelType', { type: 'SP95' })
+
+    const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
+    await loadDefaultFuelType()
+
+    expect(defaultFuelType.value).toBeNull()
+  })
+
+  it('sets defaultFuelType to null when the stored value is null', async () => {
+    store.set('defaultFuelType', null)
+
+    const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
+    await loadDefaultFuelType()
+
+    expect(defaultFuelType.value).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-18 — Saving a default stores only a plain string, not a structured object
+// ---------------------------------------------------------------------------
+
+describe('TC-18: saveDefaultFuelType writes a plain string to IndexedDB', () => {
+  it('stores a string primitive, not a JSON object or wrapper', async () => {
+    const { saveDefaultFuelType } = await freshComposable()
+
+    await saveDefaultFuelType('E10')
+
+    const stored = store.get('defaultFuelType')
+    expect(typeof stored).toBe('string')
+    expect(stored).toBe('E10')
+  })
+})

--- a/src/composables/useDefaultFuelType.spec.ts
+++ b/src/composables/useDefaultFuelType.spec.ts
@@ -10,13 +10,14 @@
  * established in useStationStorage.spec.ts.
  *
  * Scenarios covered:
- *   TC-06  — saveDefaultFuelType persists and reflects the label in reactive state
- *   TC-09  — loadDefaultFuelType reads a stored value and sets defaultFuelType
- *   TC-10  — loadDefaultFuelType sets defaultFuelType to null when nothing is stored
- *   TC-11  — loadDefaultFuelType sets defaultFuelType to null when the stored value is absent
- *            (not present in the derived list — validated at component level, not here)
- *   TC-16  — corrupted (non-string) IndexedDB value is rejected; defaultFuelType stays null
- *   TC-18  — saveDefaultFuelType writes a plain string to IndexedDB, not an object
+ *   TC-09  — saveDefaultFuelType persists and reflects the label in reactive state
+ *   TC-13  — loadDefaultFuelType reads a stored value and sets defaultFuelType
+ *   TC-14  — loadDefaultFuelType sets defaultFuelType to null when nothing is stored
+ *   TC-20  — updateDefaultFuelType replaces the stored default
+ *   TC-25  — clearDefaultFuelType deletes the key from IndexedDB
+ *   TC-33  — corrupted (non-string) IndexedDB value is rejected; defaultFuelType stays null
+ *   TC-35  — saveDefaultFuelType writes a plain string to IndexedDB, not an object
+ *   TC-36  — clearDefaultFuelType uses key deletion, not overwrite with empty value
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -31,6 +32,10 @@ vi.mock('@/utils/indexedDb', () => ({
   get: vi.fn((key: string) => Promise.resolve(store.get(key))),
   set: vi.fn((key: string, value: unknown) => {
     store.set(key, value)
+    return Promise.resolve()
+  }),
+  del: vi.fn((key: string) => {
+    store.delete(key)
     return Promise.resolve()
   }),
 }))
@@ -55,10 +60,10 @@ beforeEach(() => {
 })
 
 // ---------------------------------------------------------------------------
-// TC-06 — "Save as default" stores the selected fuel type
+// TC-09 — "Save as default" stores the selected fuel type
 // ---------------------------------------------------------------------------
 
-describe('TC-06: saveDefaultFuelType persists the label and updates reactive state', () => {
+describe('TC-09: saveDefaultFuelType persists the label and updates reactive state', () => {
   it('sets defaultFuelType.value to the saved label and writes it to IndexedDB', async () => {
     const { defaultFuelType, saveDefaultFuelType } = await freshComposable()
 
@@ -72,10 +77,10 @@ describe('TC-06: saveDefaultFuelType persists the label and updates reactive sta
 })
 
 // ---------------------------------------------------------------------------
-// TC-09 — Stored default is pre-selected when the price view loads
+// TC-13 — Stored default is pre-selected when the price view loads
 // ---------------------------------------------------------------------------
 
-describe('TC-09: loadDefaultFuelType reads the stored value into defaultFuelType', () => {
+describe('TC-13: loadDefaultFuelType reads the stored value into defaultFuelType', () => {
   it('sets defaultFuelType.value to the stored string after loading', async () => {
     store.set('defaultFuelType', 'Gasoil')
 
@@ -90,10 +95,10 @@ describe('TC-09: loadDefaultFuelType reads the stored value into defaultFuelType
 })
 
 // ---------------------------------------------------------------------------
-// TC-10 — No stored default: defaultFuelType stays null
+// TC-14 — No stored default: defaultFuelType stays null
 // ---------------------------------------------------------------------------
 
-describe('TC-10: loadDefaultFuelType leaves defaultFuelType as null when nothing is stored', () => {
+describe('TC-14: loadDefaultFuelType leaves defaultFuelType as null when nothing is stored', () => {
   it('keeps defaultFuelType.value as null when IndexedDB has no entry', async () => {
     const { defaultFuelType, loadDefaultFuelType } = await freshComposable()
 
@@ -104,10 +109,58 @@ describe('TC-10: loadDefaultFuelType leaves defaultFuelType as null when nothing
 })
 
 // ---------------------------------------------------------------------------
-// TC-11 / TC-16 — Corrupted or empty IndexedDB value is rejected
+// TC-20 — "Update default" replaces the stored default
 // ---------------------------------------------------------------------------
 
-describe('TC-11 / TC-16: loadDefaultFuelType rejects non-string and empty-string values', () => {
+describe('TC-20: updateDefaultFuelType replaces the stored default and updates reactive state', () => {
+  it('overwrites the existing entry in IndexedDB and sets defaultFuelType.value', async () => {
+    store.set('defaultFuelType', 'SP95')
+
+    const { defaultFuelType, updateDefaultFuelType } = await freshComposable()
+
+    // Simulate load: set the reactive state to reflect the stored value
+    defaultFuelType.value = 'SP95'
+
+    await updateDefaultFuelType('Gasoil')
+
+    expect(defaultFuelType.value).toBe('Gasoil')
+    expect(store.get('defaultFuelType')).toBe('Gasoil')
+  })
+
+  it('writes a plain string, not a structured object', async () => {
+    const { updateDefaultFuelType } = await freshComposable()
+
+    await updateDefaultFuelType('E10')
+
+    const stored = store.get('defaultFuelType')
+    expect(typeof stored).toBe('string')
+    expect(stored).toBe('E10')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-25 — Clicking "Clear default" removes the key from IndexedDB
+// ---------------------------------------------------------------------------
+
+describe('TC-25: clearDefaultFuelType removes the stored key entirely', () => {
+  it('deletes the IndexedDB entry and sets defaultFuelType.value to null', async () => {
+    store.set('defaultFuelType', 'SP95')
+
+    const { defaultFuelType, clearDefaultFuelType } = await freshComposable()
+    defaultFuelType.value = 'SP95'
+
+    await clearDefaultFuelType()
+
+    expect(defaultFuelType.value).toBeNull()
+    expect(store.has('defaultFuelType')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-33 — Corrupted or empty IndexedDB value is rejected
+// ---------------------------------------------------------------------------
+
+describe('TC-33: loadDefaultFuelType rejects non-string and empty-string values', () => {
   it('sets defaultFuelType to null when the stored value is a number', async () => {
     store.set('defaultFuelType', 42)
 
@@ -146,10 +199,10 @@ describe('TC-11 / TC-16: loadDefaultFuelType rejects non-string and empty-string
 })
 
 // ---------------------------------------------------------------------------
-// TC-18 — Saving a default stores only a plain string, not a structured object
+// TC-35 — Saving a default stores only a plain string, not a structured object
 // ---------------------------------------------------------------------------
 
-describe('TC-18: saveDefaultFuelType writes a plain string to IndexedDB', () => {
+describe('TC-35: saveDefaultFuelType writes a plain string to IndexedDB', () => {
   it('stores a string primitive, not a JSON object or wrapper', async () => {
     const { saveDefaultFuelType } = await freshComposable()
 
@@ -158,5 +211,21 @@ describe('TC-18: saveDefaultFuelType writes a plain string to IndexedDB', () => 
     const stored = store.get('defaultFuelType')
     expect(typeof stored).toBe('string')
     expect(stored).toBe('E10')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-36 — Clearing a default uses key deletion, not overwrite with empty value
+// ---------------------------------------------------------------------------
+
+describe('TC-36: clearDefaultFuelType deletes the key rather than overwriting with an empty value', () => {
+  it('removes the key from IndexedDB entirely — not setting it to empty string, null, or undefined', async () => {
+    store.set('defaultFuelType', 'SP95')
+
+    const { clearDefaultFuelType } = await freshComposable()
+
+    await clearDefaultFuelType()
+
+    expect(store.has('defaultFuelType')).toBe(false)
   })
 })

--- a/src/composables/useDefaultFuelType.ts
+++ b/src/composables/useDefaultFuelType.ts
@@ -1,0 +1,50 @@
+/**
+ * Singleton composable for persisting the user's preferred default fuel type.
+ *
+ * The reactive default is declared at module level so all consumers share the
+ * same reference (ADR-002 singleton pattern).
+ *
+ * Persistence is handled via the thin IndexedDB wrapper (ADR-008).
+ * Only plain strings are stored; every value read back is validated before use
+ * (security-guidelines.md rules 1 and 3).
+ *
+ * Object Calisthenics exception: the composable function body exceeds five
+ * lines because Vue composable conventions require grouping all returned
+ * reactive state and operations in one function — documented framework
+ * exception.
+ */
+
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { get, set } from '@/utils/indexedDb'
+
+const DEFAULT_FUEL_TYPE_KEY = 'defaultFuelType'
+
+// Module-level ref — all consumers share the same reactive state (ADR-002).
+const defaultFuelType: Ref<string | null> = ref(null)
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+export function useDefaultFuelType() {
+  const loadDefaultFuelType = async (): Promise<void> => {
+    const stored = await get<unknown>(DEFAULT_FUEL_TYPE_KEY)
+    if (!isNonEmptyString(stored)) {
+      defaultFuelType.value = null
+      return
+    }
+    defaultFuelType.value = stored
+  }
+
+  const saveDefaultFuelType = async (label: string): Promise<void> => {
+    await set(DEFAULT_FUEL_TYPE_KEY, label)
+    defaultFuelType.value = label
+  }
+
+  return {
+    defaultFuelType,
+    loadDefaultFuelType,
+    saveDefaultFuelType,
+  }
+}

--- a/src/composables/useDefaultFuelType.ts
+++ b/src/composables/useDefaultFuelType.ts
@@ -16,7 +16,7 @@
 
 import { ref } from 'vue'
 import type { Ref } from 'vue'
-import { get, set } from '@/utils/indexedDb'
+import { get, set, del } from '@/utils/indexedDb'
 
 const DEFAULT_FUEL_TYPE_KEY = 'defaultFuelType'
 
@@ -42,9 +42,21 @@ export function useDefaultFuelType() {
     defaultFuelType.value = label
   }
 
+  const updateDefaultFuelType = async (label: string): Promise<void> => {
+    await set(DEFAULT_FUEL_TYPE_KEY, label)
+    defaultFuelType.value = label
+  }
+
+  const clearDefaultFuelType = async (): Promise<void> => {
+    await del(DEFAULT_FUEL_TYPE_KEY)
+    defaultFuelType.value = null
+  }
+
   return {
     defaultFuelType,
     loadDefaultFuelType,
     saveDefaultFuelType,
+    updateDefaultFuelType,
+    clearDefaultFuelType,
   }
 }

--- a/src/pages/index.spec.ts
+++ b/src/pages/index.spec.ts
@@ -55,6 +55,18 @@ vi.mock('@/composables/useStationStorage', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Mock useDefaultFuelType (required by StationPricesContent — Issue #28)
+// ---------------------------------------------------------------------------
+
+vi.mock('@/composables/useDefaultFuelType', () => ({
+  useDefaultFuelType: () => ({
+    defaultFuelType: ref(null),
+    loadDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+    saveDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+// ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 

--- a/src/utils/fuelTypeUtils.spec.ts
+++ b/src/utils/fuelTypeUtils.spec.ts
@@ -1,12 +1,13 @@
 /**
  * Tests for fuelTypeUtils pure utility functions.
  *
- * TC-01 through TC-10 from test-cases.md.
+ * TC-01 through TC-10 from test-cases.md (issue-25 scenarios).
+ * TC-01 through TC-05 from test-cases.md (issue-28 orderFuelTypes scenarios).
  */
 
 import { describe, expect, it } from 'vitest'
 import type { StationData } from '@/types/station-data'
-import { buildPriceRows, deriveFuelTypes, resolvePrice } from './fuelTypeUtils'
+import { buildPriceRows, deriveFuelTypes, orderFuelTypes, resolvePrice } from './fuelTypeUtils'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -202,5 +203,88 @@ describe('TC-10: resolvePrice returns null when the station does not carry the t
     const result = resolvePrice(station, 'SP95')
 
     expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-01 — Default type is placed first in the list
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-01: orderFuelTypes places the default first', () => {
+  it('moves "Gasoil" to index 0 when it is not already first', () => {
+    const input = ['SP95', 'Gasoil', 'E10']
+
+    const result = orderFuelTypes(input, 'Gasoil')
+
+    expect(result).toEqual(['Gasoil', 'SP95', 'E10'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-02 — No default: list order is unchanged
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-02: orderFuelTypes preserves order when no default is provided', () => {
+  it('returns the same order when default is undefined', () => {
+    const input = ['SP95', 'Gasoil', 'E10']
+
+    expect(orderFuelTypes(input, undefined)).toEqual(['SP95', 'Gasoil', 'E10'])
+  })
+
+  it('returns the same order when default is null', () => {
+    const input = ['SP95', 'Gasoil', 'E10']
+
+    expect(orderFuelTypes(input, null)).toEqual(['SP95', 'Gasoil', 'E10'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-03 — Default is already first: list order is unchanged
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-03: orderFuelTypes does not move the default when it is already first', () => {
+  it('returns the same order when "SP95" is already at index 0', () => {
+    const input = ['SP95', 'Gasoil', 'E10']
+
+    const result = orderFuelTypes(input, 'SP95')
+
+    expect(result).toEqual(['SP95', 'Gasoil', 'E10'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-04 — Default not present in the list: list order is unchanged
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-04: orderFuelTypes preserves order when the default is not in the list', () => {
+  it('returns the original order when the default fuel type is absent', () => {
+    const input = ['SP95', 'Gasoil']
+
+    const result = orderFuelTypes(input, 'E85')
+
+    expect(result).toEqual(['SP95', 'Gasoil'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue-28 TC-05 — Ordering function does not mutate the input array
+// ---------------------------------------------------------------------------
+
+describe('Issue-28 TC-05: orderFuelTypes does not mutate the input array', () => {
+  it('leaves the original array unchanged after reordering', () => {
+    const input = ['SP95', 'Gasoil', 'E10']
+    const originalCopy = [...input]
+
+    orderFuelTypes(input, 'E10')
+
+    expect(input).toEqual(originalCopy)
+  })
+
+  it('returns a new array reference, not the original', () => {
+    const input = ['SP95', 'Gasoil', 'E10']
+
+    const result = orderFuelTypes(input, 'E10')
+
+    expect(result).not.toBe(input)
   })
 })

--- a/src/utils/fuelTypeUtils.ts
+++ b/src/utils/fuelTypeUtils.ts
@@ -69,3 +69,21 @@ export function buildPriceRows(stations: StationData[], fuelType: string): Price
     .map((station: StationData) => toPriceRow(station, fuelType))
     .sort(comparePriceRows)
 }
+
+/**
+ * Return a new fuel type list reordered so the default type appears first.
+ * If the default is absent from the list, or no default is provided,
+ * the original order is preserved.
+ *
+ * The input array is never mutated (security-guidelines.md rule 4).
+ */
+export function orderFuelTypes(
+  fuelTypes: readonly string[],
+  defaultFuelType: string | null | undefined,
+): string[] {
+  if (!defaultFuelType) return [...fuelTypes]
+  const defaultIndex = fuelTypes.indexOf(defaultFuelType)
+  if (defaultIndex <= 0) return [...fuelTypes]
+  const remaining = fuelTypes.filter((type) => type !== defaultFuelType)
+  return [defaultFuelType, ...remaining]
+}


### PR DESCRIPTION
## Summary
- Adds `orderFuelTypes()` pure function — places default fuel type first, never mutates input
- New singleton composable `useDefaultFuelType` with load/save/update/clear operations backed by IndexedDB
- `StationPricesContent.vue` gains three contextual buttons per visibility matrix:
  - "Save as default" — visible only when no default is stored
  - "Update default" — visible when default exists and selection differs
  - "Clear default" — visible whenever a default is stored
- Separate "Default" indicator (`<span>`) shown when current selection matches stored default
- All buttons styled with `--accent` / `--accent-foreground` (stone-200/stone-800)

## Test plan
- [ ] No default: only "Save as default" visible → click it → button disappears, "Default" indicator appears
- [ ] Select a different fuel type → "Update default" + "Clear default" appear
- [ ] Click "Update default" → default moves to new type
- [ ] Click "Clear default" → all buttons reset, list reverts to natural order
- [ ] Reload page → stored default pre-selected and listed first
- [ ] All 225 unit tests pass (\`npm run test\`)

Closes #28