### PR TITLE
ci(agent): add pipeline shell scripts for worktree/PR lifecycle

### DIFF
--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -60,52 +60,49 @@ Use `rtk` for all supported git and gh commands — it compresses output and red
 
 Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `git branch`, `git worktree prune`) run as normal git commands.
 
+## Pipeline Scripts
+
+Three scripts under `scripts/pipeline/` encapsulate the git operations most prone to ordering mistakes or path-discovery errors. **Always prefer these scripts over constructing raw git/gh commands.**
+
+| Script | Purpose |
+|---|---|
+| `scripts/pipeline/worktree-create.sh <type> <slug>` | Fetch, create branch + worktree, install npm deps. Prints `Worktree: <path>`. |
+| `scripts/pipeline/pr-create.sh <worktree> <title> <body-file>` | Push branch, open PR against `develop`. Prints `PR: <url>`. |
+| `scripts/pipeline/pr-complete.sh <worktree> <pr-url>` | Merge PR (rebase), remove worktree, prune, delete local branch, update develop. |
+
+Call them with `bash scripts/pipeline/<script>.sh` from the `develop/` worktree (the scripts resolve the bare repo root automatically).
+
 ## Tasks
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
-The session runs from the `develop/` worktree. The bare repo root is `..` relative to the CWD.
-
-First verify the bare repo has `origin` configured:
+Handled automatically by `worktree-create.sh` in Task 2. If Task 2 is not being run (rare), verify `origin` is configured and fetch manually:
 
 ```bash
 git -C .. remote -v
-```
-
-If `origin` is missing, add it before fetching:
-
-```bash
+# if origin is missing:
 git -C .. remote add origin https://github.com/<owner>/<repo>.git
-```
-
-Then fetch to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
-
-First ensure the fetch refspec is configured (bare repos often lack it, causing `fetch` to update only `FETCH_HEAD` and leaving `refs/remotes/origin/*` stale):
-
-```bash
 git -C .. config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git -C .. fetch origin
 ```
 
 ### Task 2: Create new branch and worktree
 
-The orchestrator passes `Type: <type>` and `Slug: <slug>` directly — use these values. Do NOT read any file or create any directory to determine them.
+The orchestrator passes `Type: <type>` and `Slug: <slug>` directly — use these values.
 
-Run from the `develop/` worktree (bare repo root is `..`):
-
-```bash
-git -C .. worktree add <type>_<slug> -b <type>/<slug> origin/develop
-```
-
-The path `<type>_<slug>` is relative to the bare repo root (the `-C ..` directory), so the worktree lands at `<bare-repo>/<type>_<slug>` — i.e. a sibling of `develop/`. Do NOT prefix with `../` (that would place it one level above the bare repo).
-
-Then install dependencies inside the new worktree so subsequent agents can run lint, type-check, and tests:
+Run from the `develop/` worktree:
 
 ```bash
-cd <type>_<slug> && npm install
+bash scripts/pipeline/worktree-create.sh <type> <slug>
 ```
 
-Resolve the absolute path of the new worktree and report it back to the orchestrator as `Worktree: <absolute-path>` so every subsequent agent can use it.
+The script fetches origin, creates `<bare-repo>/<type>_<slug>` on branch `<type>/<slug>` from `origin/develop`, installs npm dependencies, and prints:
+
+```
+Worktree: <absolute-path>
+```
+
+Report that path back to the orchestrator as `Worktree: <absolute-path>`.
 
 ### Task 3: Commit specs output
 
@@ -156,49 +153,48 @@ If the last line is `status: passed`:
 
 ### Task 6: Create pull request
 
-Run from the worktree root:
+- Derive the PR title from `[task-folder]/business-specifications.md` (short imperative summary, ≤70 chars).
+- Write the PR body to a temporary file (e.g. `/tmp/pr-body.md`). The body must include: a summary of what changed and why, a test plan checklist, and `Closes #<issue-id>`.
+- Target branch is always `develop` — never `main`.
 
 ```bash
-gh pr create --base develop --title "<title>" --body "<body>"
+# Write the body to a temp file first, then call the script:
+cat > /tmp/pr-body.md << 'EOF'
+<body content here>
+EOF
+
+bash scripts/pipeline/pr-create.sh <worktree> "<title>" /tmp/pr-body.md
 ```
 
-- Derive the PR title from `[task-folder]/business-specifications.md` (short imperative summary, ≤70 chars).
-- The PR body must include: a summary of what changed and why, a test plan checklist, and a reference to the issue (`Closes #<issue-id>`).
-- Target branch is always `develop` — never `main`.
-- Report the PR URL back to the orchestrator.
+The script pushes the branch and opens the PR. It prints `PR: <url>` — report that URL back to the orchestrator.
 
 ### Task 7: Merge pull request
 
-Must run from the bare repo root (not from inside any worktree) to avoid `gh` attempting a local `git switch develop` after merging, which fails because `develop` is already checked out in its own worktree.
-
 ```bash
-cd .. && gh pr merge <pr-url> --rebase --delete-branch
+bash scripts/pipeline/pr-complete.sh <worktree> <pr-url>
 ```
 
-- Always rebase-merge to keep `develop` history linear (the repository does not allow squash or merge commits).
-- `--delete-branch` removes the remote branch automatically.
+The script merges with rebase, removes the worktree, prunes stale entries, deletes the local branch, and fast-forwards `develop`. No separate Task 8 steps needed when using this script.
 
 ### Task 8: Remove worktree (post-merge cleanup)
 
-Run from the bare repo root (`..` relative to the `develop/` worktree):
+Handled by `pr-complete.sh` in Task 7. If cleanup must be run independently (e.g. after a manual merge), call the script directly — it is safe to re-run:
 
 ```bash
-git -C .. fetch origin
-git -C .. worktree remove --force <type>_<slug>
-git -C .. worktree prune
-git -C .. branch -D <type>/<slug>
+bash scripts/pipeline/pr-complete.sh <worktree> <pr-url>
 ```
 
-Notes:
-- Run `git worktree remove --force` **before** `git worktree prune`. Prune deregisters stale entries first; if the worktree directory still exists but is deregistered, a subsequent `remove` will fail with a permission error.
-- `--force` handles Windows file-lock edge cases where git would otherwise refuse to delete the directory.
-- If the worktree directory still exists on disk after `git worktree remove --force` (e.g. because git already deregistered it in a prior run), delete it manually: `rm -rf <absolute-worktree-path>`.
-- Use `-D` (force) instead of `-d` on `git branch` because GitHub rebase-merges do not create a merge commit, so git never considers the local branch "fully merged".
-
-Then pull latest into `develop/` to ensure it reflects the merged commit:
+If the PR is already merged and the script fails on the merge step, comment out or skip the `gh pr merge` call and run the remaining git cleanup manually:
 
 ```bash
-git pull origin develop
+BARE_REPO="$(cd <worktree>/.. && pwd)"
+WT_NAME="$(basename <worktree>)"
+BRANCH="$(git -C <worktree> branch --show-current)"
+git -C "$BARE_REPO" worktree remove --force "$WT_NAME"
+git -C "$BARE_REPO" worktree prune
+git -C "$BARE_REPO" branch -D "$BRANCH"
+git -C "$BARE_REPO" fetch origin
+git -C "$BARE_REPO/develop" pull origin develop
 ```
 
 ## Shell Command Retry Limit

--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -1,9 +1,10 @@
 ---
 name: agent-4-git
 description: Handles git operations — fetch, branch, commit, push, PR create/merge/cleanup
-model: claude-haiku-4-5-20251001
+model: haiku
 tools: Bash, Read
 ---
+
 # I am a Versionning Agent
 
 The orchestrator will call me multiple times during the pipeline. Execute only the tasks the orchestrator instructs.
@@ -45,18 +46,18 @@ docs: update API usage in README
 
 Use `rtk` for all supported git and gh commands — it compresses output and reduces token usage:
 
-| Raw command | RTK equivalent |
-|---|---|
-| `git status` | `rtk git status` |
-| `git diff` | `rtk git diff` |
-| `git log` | `rtk git log` |
-| `git add <files>` | `rtk git add <files>` |
-| `git commit -m "msg"` | `rtk git commit -m "msg"` |
+| Raw command                | RTK equivalent                 |
+| -------------------------- | ------------------------------ |
+| `git status`               | `rtk git status`               |
+| `git diff`                 | `rtk git diff`                 |
+| `git log`                  | `rtk git log`                  |
+| `git add <files>`          | `rtk git add <files>`          |
+| `git commit -m "msg"`      | `rtk git commit -m "msg"`      |
 | `git push origin <branch>` | `rtk git push origin <branch>` |
-| `git pull` | `rtk git pull` |
-| `gh pr list` | `rtk gh pr list` |
-| `gh pr view <n>` | `rtk gh pr view <n>` |
-| `gh run list` | `rtk gh run list` |
+| `git pull`                 | `rtk git pull`                 |
+| `gh pr list`               | `rtk gh pr list`               |
+| `gh pr view <n>`           | `rtk gh pr view <n>`           |
+| `gh run list`              | `rtk gh run list`              |
 
 Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `git branch`, `git worktree prune`) run as normal git commands.
 
@@ -64,12 +65,14 @@ Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `
 
 Three scripts under `scripts/pipeline/` encapsulate the git operations most prone to ordering mistakes or path-discovery errors. **Always prefer these scripts over constructing raw git/gh commands.**
 
-| Script | Purpose |
-|---|---|
-| `scripts/pipeline/fetch-origin.sh [bare-repo]` | Ensure `origin` is configured + full refspec, then fetch. Called by `worktree-create.sh`; run standalone for Task 1 alone. |
-| `scripts/pipeline/worktree-create.sh <type> <slug>` | Fetch (via `fetch-origin.sh`), create branch + worktree, install npm deps. Prints `Worktree: <path>`. |
-| `scripts/pipeline/pr-create.sh <worktree> <title> <body-file>` | Push branch, open PR against `develop`. Prints `PR: <url>`. |
-| `scripts/pipeline/pr-complete.sh <worktree> <pr-url>` | Merge PR (rebase), remove worktree, prune, delete local branch, update develop. |
+| Script                                                         | Purpose                                                                                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/pipeline/fetch-origin.sh [bare-repo]`                 | Ensure `origin` is configured + full refspec, then fetch. Called by `worktree-create.sh`; run standalone for Task 1 alone. |
+| `scripts/pipeline/worktree-create.sh <type> <slug>`            | Fetch (via `fetch-origin.sh`), create branch + worktree, install npm deps. Prints `Worktree: <path>`.                      |
+| `scripts/pipeline/pr-create.sh <worktree> <title> <body-file>` | Push branch, open PR against `develop`. Prints `PR: <url>`.                                                                |
+| `scripts/pipeline/pr-complete.sh <pr-url>`                     | Merge open PR (rebase + delete remote branch). Skips gracefully if already merged/closed.                                  |
+| `scripts/pipeline/worktree-cleanup.sh <worktree>`              | Remove worktree directory, prune stale entries, delete local branch.                                                       |
+| `scripts/pipeline/refresh-develop.sh`                          | Fetch origin and fast-forward the `develop` worktree. Closes the pipeline cycle.                                           |
 
 Call them with `bash scripts/pipeline/<script>.sh` from the `develop/` worktree (the scripts resolve the bare repo root automatically).
 
@@ -170,31 +173,19 @@ The script pushes the branch and opens the PR. It prints `PR: <url>` — report 
 ### Task 7: Merge pull request
 
 ```bash
-bash scripts/pipeline/pr-complete.sh <worktree> <pr-url>
+bash scripts/pipeline/pr-complete.sh <pr-url>
 ```
 
-The script merges with rebase, removes the worktree, prunes stale entries, deletes the local branch, and fast-forwards `develop`. No separate Task 8 steps needed when using this script.
+Merges the PR with rebase and deletes the remote branch. Skips gracefully if the PR was already merged or closed by the user on GitHub.
 
-### Task 8: Remove worktree (post-merge cleanup)
-
-Handled by `pr-complete.sh` in Task 7. If cleanup must be run independently (e.g. after a manual merge), call the script directly — it is safe to re-run:
+### Task 8: Remove worktree and refresh develop
 
 ```bash
-bash scripts/pipeline/pr-complete.sh <worktree> <pr-url>
+bash scripts/pipeline/worktree-cleanup.sh <worktree>
+bash scripts/pipeline/refresh-develop.sh
 ```
 
-If the PR is already merged and the script fails on the merge step, comment out or skip the `gh pr merge` call and run the remaining git cleanup manually:
-
-```bash
-BARE_REPO="$(cd <worktree>/.. && pwd)"
-WT_NAME="$(basename <worktree>)"
-BRANCH="$(git -C <worktree> branch --show-current)"
-git -C "$BARE_REPO" worktree remove --force "$WT_NAME"
-git -C "$BARE_REPO" worktree prune
-git -C "$BARE_REPO" branch -D "$BRANCH"
-git -C "$BARE_REPO" fetch origin
-git -C "$BARE_REPO/develop" pull origin develop
-```
+`worktree-cleanup.sh` removes the worktree directory, prunes stale git entries, and deletes the local branch. `refresh-develop.sh` fetches origin and fast-forwards `develop`. Both scripts are safe to re-run if a prior attempt was partial.
 
 ## Shell Command Retry Limit
 

--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -66,7 +66,8 @@ Three scripts under `scripts/pipeline/` encapsulate the git operations most pron
 
 | Script | Purpose |
 |---|---|
-| `scripts/pipeline/worktree-create.sh <type> <slug>` | Fetch, create branch + worktree, install npm deps. Prints `Worktree: <path>`. |
+| `scripts/pipeline/fetch-origin.sh [bare-repo]` | Ensure `origin` is configured + full refspec, then fetch. Called by `worktree-create.sh`; run standalone for Task 1 alone. |
+| `scripts/pipeline/worktree-create.sh <type> <slug>` | Fetch (via `fetch-origin.sh`), create branch + worktree, install npm deps. Prints `Worktree: <path>`. |
 | `scripts/pipeline/pr-create.sh <worktree> <title> <body-file>` | Push branch, open PR against `develop`. Prints `PR: <url>`. |
 | `scripts/pipeline/pr-complete.sh <worktree> <pr-url>` | Merge PR (rebase), remove worktree, prune, delete local branch, update develop. |
 
@@ -76,15 +77,13 @@ Call them with `bash scripts/pipeline/<script>.sh` from the `develop/` worktree 
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
-Handled automatically by `worktree-create.sh` in Task 2. If Task 2 is not being run (rare), verify `origin` is configured and fetch manually:
+Handled automatically by `worktree-create.sh` in Task 2. If Task 2 is not being run (rare), run:
 
 ```bash
-git -C .. remote -v
-# if origin is missing:
-git -C .. remote add origin https://github.com/<owner>/<repo>.git
-git -C .. config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-git -C .. fetch origin
+bash scripts/pipeline/fetch-origin.sh
 ```
+
+The script checks that `origin` exists (adds it if missing, inferring the URL from the `develop/` remote config), ensures the full fetch refspec is set, and fetches all remote refs.
 
 ### Task 2: Create new branch and worktree
 

--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -67,8 +67,8 @@ Three scripts under `scripts/pipeline/` encapsulate the git operations most pron
 
 | Script                                                         | Purpose                                                                                                                    |
 | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `scripts/pipeline/fetch-origin.sh [bare-repo]`                 | Ensure `origin` is configured + full refspec, then fetch. Called by `worktree-create.sh`; run standalone for Task 1 alone. |
-| `scripts/pipeline/worktree-create.sh <type> <slug>`            | Fetch (via `fetch-origin.sh`), create branch + worktree, install npm deps. Prints `Worktree: <path>`.                      |
+| `scripts/pipeline/fetch-origin.sh [bare-repo]`                 | Ensure `origin` is configured + full refspec, then fetch. Always run first (Task 1).                                       |
+| `scripts/pipeline/worktree-create.sh <type> <slug>`            | Create branch + worktree, install npm deps. Prints `Worktree: <path>`. Requires fetch-origin.sh to have run first.        |
 | `scripts/pipeline/pr-create.sh <worktree> <title> <body-file>` | Push branch, open PR against `develop`. Prints `PR: <url>`.                                                                |
 | `scripts/pipeline/pr-complete.sh <pr-url>`                     | Merge open PR (rebase + delete remote branch). Skips gracefully if already merged/closed.                                  |
 | `scripts/pipeline/worktree-cleanup.sh <worktree>`              | Remove worktree directory, prune stale entries, delete local branch.                                                       |
@@ -80,25 +80,25 @@ Call them with `bash scripts/pipeline/<script>.sh` from the `develop/` worktree 
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
-Handled automatically by `worktree-create.sh` in Task 2. If Task 2 is not being run (rare), run:
+**Always run this first — never skip it.**
 
 ```bash
 bash scripts/pipeline/fetch-origin.sh
 ```
 
-The script checks that `origin` exists (adds it if missing, inferring the URL from the `develop/` remote config), ensures the full fetch refspec is set, and fetches all remote refs.
+Ensures `origin` is configured (adds it if missing, inferring the URL from `develop/`), sets the full fetch refspec, and fetches all remote refs.
 
 ### Task 2: Create new branch and worktree
 
 The orchestrator passes `Type: <type>` and `Slug: <slug>` directly — use these values.
 
-Run from the `develop/` worktree:
+**Requires Task 1 to have completed successfully.**
 
 ```bash
 bash scripts/pipeline/worktree-create.sh <type> <slug>
 ```
 
-The script fetches origin, creates `<bare-repo>/<type>_<slug>` on branch `<type>/<slug>` from `origin/develop`, installs npm dependencies, and prints:
+Creates `<bare-repo>/<type>_<slug>` on branch `<type>/<slug>` from `origin/develop` and installs npm dependencies. Prints:
 
 ```
 Worktree: <absolute-path>

--- a/scripts/pipeline/fetch-origin.sh
+++ b/scripts/pipeline/fetch-origin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/pipeline/fetch-origin.sh
+#
+# Usage: bash scripts/pipeline/fetch-origin.sh [bare-repo-path]
+#
+# Ensures the bare repo has `origin` configured with the correct fetch
+# refspec, then fetches all remote refs.
+#
+# <bare-repo-path> defaults to the parent of the worktree that contains
+# this script (i.e. `..` relative to `develop/`), which is correct for
+# all standard pipeline worktrees.
+#
+# Called automatically by worktree-create.sh. Run standalone when only
+# a fetch is needed (e.g. Task 1 without Task 2).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_BARE="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BARE_REPO="${1:-$DEFAULT_BARE}"
+
+# Ensure origin remote exists
+if ! git -C "$BARE_REPO" remote get-url origin &>/dev/null; then
+  REMOTE_URL="$(cd "$BARE_REPO/develop" && git remote get-url origin 2>/dev/null || true)"
+  if [ -z "$REMOTE_URL" ]; then
+    echo "ERROR: origin remote not found in bare repo and could not be inferred." >&2
+    echo "Run: git -C \"$BARE_REPO\" remote add origin <url>" >&2
+    exit 1
+  fi
+  git -C "$BARE_REPO" remote add origin "$REMOTE_URL"
+fi
+
+# Ensure full refspec so remote-tracking refs stay current
+git -C "$BARE_REPO" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git -C "$BARE_REPO" fetch origin
+
+echo "==> origin fetched (bare repo: $BARE_REPO)"

--- a/scripts/pipeline/pr-complete.sh
+++ b/scripts/pipeline/pr-complete.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# scripts/pipeline/pr-complete.sh
+#
+# Usage: bash scripts/pipeline/pr-complete.sh <worktree-path> <pr-url>
+#
+# Merges the PR (rebase strategy), removes the worktree, prunes git state,
+# deletes the local branch, and fast-forwards develop to origin.
+#
+# Must be run BEFORE the worktree is removed so the branch name can be read.
+#
+# Arguments:
+#   <worktree-path>  Absolute path to the feature worktree (e.g. .../feat_slug).
+#   <pr-url>         Full GitHub PR URL to merge.
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: pr-complete.sh <worktree-path> <pr-url>}"
+PR_URL="${2:?Usage: pr-complete.sh <worktree-path> <pr-url>}"
+
+BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
+WT_NAME="$(basename "$WORKTREE")"
+BRANCH="$(git -C "$WORKTREE" branch --show-current)"
+DEVELOP="${BARE_REPO}/develop"
+
+echo "==> Merging PR (rebase)..."
+# Run from bare repo root so `gh` does not attempt a local `git switch develop`
+# (which would fail because develop is already checked out in its own worktree).
+(cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
+
+echo "==> Removing worktree '${WT_NAME}'..."
+git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
+# If git already deregistered the entry (e.g. a prior partial run), the
+# directory may still exist on disk — delete it manually.
+if [ -d "$WORKTREE" ]; then
+  rm -rf "$WORKTREE"
+fi
+
+echo "==> Pruning stale worktree entries..."
+git -C "$BARE_REPO" worktree prune
+
+echo "==> Deleting local branch '${BRANCH}'..."
+# Use -D (force) because GitHub rebase-merge does not create a merge commit,
+# so git never considers the local branch "fully merged".
+git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
+
+echo "==> Fetching origin and updating develop..."
+git -C "$BARE_REPO" fetch origin
+git -C "$DEVELOP" pull origin develop
+
+echo "Done. develop is up to date."

--- a/scripts/pipeline/pr-complete.sh
+++ b/scripts/pipeline/pr-complete.sh
@@ -1,59 +1,36 @@
 #!/usr/bin/env bash
 # scripts/pipeline/pr-complete.sh
 #
-# Usage: bash scripts/pipeline/pr-complete.sh <worktree-path> <pr-url>
+# Usage: bash scripts/pipeline/pr-complete.sh <pr-url>
 #
-# Merges the PR (rebase strategy), removes the worktree, prunes git state,
-# deletes the local branch, and fast-forwards develop to origin.
+# Merges an open PR into develop (rebase strategy) and deletes the remote
+# branch. Skips gracefully if the PR is already merged or closed.
 #
-# Must be run BEFORE the worktree is removed so the branch name can be read.
-#
-# Arguments:
-#   <worktree-path>  Absolute path to the feature worktree (e.g. .../feat_slug).
-#   <pr-url>         Full GitHub PR URL to merge.
+# Run from any pipeline worktree. Follow with:
+#   worktree-cleanup.sh <worktree-path>
+#   refresh-develop.sh
 
 set -euo pipefail
 
-WORKTREE="${1:?Usage: pr-complete.sh <worktree-path> <pr-url>}"
-PR_URL="${2:?Usage: pr-complete.sh <worktree-path> <pr-url>}"
+PR_URL="${1:?Usage: pr-complete.sh <pr-url>}"
 
-BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
-WT_NAME="$(basename "$WORKTREE")"
-BRANCH="$(git -C "$WORKTREE" branch --show-current)"
-DEVELOP="${BARE_REPO}/develop"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 echo "==> Checking PR state..."
 PR_STATE="$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")"
 
 if [ "$PR_STATE" = "MERGED" ]; then
-  echo "    PR already merged — skipping merge step."
+  echo "    PR already merged — nothing to do."
+  exit 0
 elif [ "$PR_STATE" = "CLOSED" ]; then
-  echo "    PR is closed (not merged) — skipping merge step."
-else
-  echo "==> Merging PR (rebase)..."
-  # Run from bare repo root so `gh` does not attempt a local `git switch develop`
-  # (which would fail because develop is already checked out in its own worktree).
-  (cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
+  echo "    PR is closed (not merged) — nothing to do."
+  exit 0
 fi
 
-echo "==> Removing worktree '${WT_NAME}'..."
-git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
-# If git already deregistered the entry (e.g. a prior partial run), the
-# directory may still exist on disk — delete it manually.
-if [ -d "$WORKTREE" ]; then
-  rm -rf "$WORKTREE"
-fi
+echo "==> Merging PR (rebase)..."
+# Run from bare repo root so `gh` does not attempt a local `git switch develop`
+# (which would fail because develop is already checked out in its own worktree).
+(cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
 
-echo "==> Pruning stale worktree entries..."
-git -C "$BARE_REPO" worktree prune
-
-echo "==> Deleting local branch '${BRANCH}'..."
-# Use -D (force) because GitHub rebase-merge does not create a merge commit,
-# so git never considers the local branch "fully merged".
-git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
-
-echo "==> Fetching origin and updating develop..."
-git -C "$BARE_REPO" fetch origin
-git -C "$DEVELOP" pull origin develop
-
-echo "Done. develop is up to date."
+echo "==> PR merged."

--- a/scripts/pipeline/pr-complete.sh
+++ b/scripts/pipeline/pr-complete.sh
@@ -22,10 +22,19 @@ WT_NAME="$(basename "$WORKTREE")"
 BRANCH="$(git -C "$WORKTREE" branch --show-current)"
 DEVELOP="${BARE_REPO}/develop"
 
-echo "==> Merging PR (rebase)..."
-# Run from bare repo root so `gh` does not attempt a local `git switch develop`
-# (which would fail because develop is already checked out in its own worktree).
-(cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
+echo "==> Checking PR state..."
+PR_STATE="$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")"
+
+if [ "$PR_STATE" = "MERGED" ]; then
+  echo "    PR already merged — skipping merge step."
+elif [ "$PR_STATE" = "CLOSED" ]; then
+  echo "    PR is closed (not merged) — skipping merge step."
+else
+  echo "==> Merging PR (rebase)..."
+  # Run from bare repo root so `gh` does not attempt a local `git switch develop`
+  # (which would fail because develop is already checked out in its own worktree).
+  (cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
+fi
 
 echo "==> Removing worktree '${WT_NAME}'..."
 git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true

--- a/scripts/pipeline/pr-create.sh
+++ b/scripts/pipeline/pr-create.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/pipeline/pr-create.sh
+#
+# Usage: bash scripts/pipeline/pr-create.sh <worktree-path> <title> <body-file>
+#
+# Pushes the current branch and opens a PR against `develop`.
+# Prints the PR URL as "PR: <url>".
+#
+# Arguments:
+#   <worktree-path>  Absolute path to the feature worktree.
+#   <title>          PR title (≤70 chars, imperative mood).
+#   <body-file>      Path to a file containing the full PR body (markdown).
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+TITLE="${2:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+BODY_FILE="${3:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+
+BRANCH="$(git -C "$WORKTREE" branch --show-current)"
+
+echo "==> Pushing branch '${BRANCH}' to origin..."
+git -C "$WORKTREE" push origin "$BRANCH"
+
+echo "==> Creating PR..."
+PR_URL="$(cd "$WORKTREE" && gh pr create \
+  --base develop \
+  --title "$TITLE" \
+  --body-file "$BODY_FILE")"
+
+echo "PR: ${PR_URL}"

--- a/scripts/pipeline/refresh-develop.sh
+++ b/scripts/pipeline/refresh-develop.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/pipeline/refresh-develop.sh
+#
+# Usage: bash scripts/pipeline/refresh-develop.sh
+#
+# Fetches all remote refs and fast-forwards the develop worktree to
+# origin/develop. Call this at the end of every pipeline cycle to ensure
+# the next pipeline starts from an up-to-date base.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEVELOP="${BARE_REPO}/develop"
+
+echo "==> Fetching origin..."
+git -C "$BARE_REPO" fetch origin
+
+echo "==> Updating develop..."
+git -C "$DEVELOP" pull origin develop
+
+echo "==> develop is up to date."

--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/pipeline/worktree-cleanup.sh
+#
+# Usage: bash scripts/pipeline/worktree-cleanup.sh <worktree-path>
+#
+# Removes a pipeline worktree directory, prunes stale git entries, and
+# deletes the local branch. Safe to re-run if a prior attempt was partial.
+#
+# Run after pr-complete.sh (or after a manual GitHub merge/close).
+# Follow with refresh-develop.sh to fast-forward the develop worktree.
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: worktree-cleanup.sh <worktree-path>}"
+
+BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
+WT_NAME="$(basename "$WORKTREE")"
+
+# Read branch name before the worktree is removed
+BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
+
+echo "==> Removing worktree '${WT_NAME}'..."
+git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
+# If git already deregistered the entry, the directory may still exist on disk
+if [ -d "$WORKTREE" ]; then
+  rm -rf "$WORKTREE"
+fi
+
+echo "==> Pruning stale worktree entries..."
+git -C "$BARE_REPO" worktree prune
+
+if [ -n "$BRANCH" ]; then
+  echo "==> Deleting local branch '${BRANCH}'..."
+  # Use -D (force) because GitHub rebase-merge does not create a merge commit,
+  # so git never considers the local branch "fully merged".
+  git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
+fi
+
+echo "==> Worktree '${WT_NAME}' cleaned up."

--- a/scripts/pipeline/worktree-create.sh
+++ b/scripts/pipeline/worktree-create.sh
@@ -9,6 +9,8 @@
 # Works when called from any worktree (develop/, feat_*/,  ci_*/) because
 # the bare repo is always the parent directory of whichever worktree holds
 # this script.
+#
+# Prerequisites: run fetch-origin.sh before this script.
 
 set -euo pipefail
 
@@ -23,8 +25,6 @@ BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 WT_NAME="${TYPE}_${SLUG}"
 BRANCH="${TYPE}/${SLUG}"
 WT_PATH="${BARE_REPO}/${WT_NAME}"
-
-bash "$SCRIPT_DIR/fetch-origin.sh" "$BARE_REPO"
 
 echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
 git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop

--- a/scripts/pipeline/worktree-create.sh
+++ b/scripts/pipeline/worktree-create.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/pipeline/worktree-create.sh
+#
+# Usage: bash scripts/pipeline/worktree-create.sh <type> <slug>
+#
+# Creates a git worktree for a new feature/fix branch, installs npm deps,
+# and prints the absolute worktree path as "Worktree: <path>".
+#
+# Works when called from any worktree (develop/, feat_*/,  ci_*/) because
+# the bare repo is always the parent directory of whichever worktree holds
+# this script.
+
+set -euo pipefail
+
+TYPE="${1:?Usage: worktree-create.sh <type> <slug>}"
+SLUG="${2:?Usage: worktree-create.sh <type> <slug>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# scripts/pipeline is 2 levels below the worktree root, which is 1 level
+# below the bare repo: <bare-repo>/<worktree>/scripts/pipeline
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+WT_NAME="${TYPE}_${SLUG}"
+BRANCH="${TYPE}/${SLUG}"
+WT_PATH="${BARE_REPO}/${WT_NAME}"
+
+echo "==> Fetching origin..."
+git -C "$BARE_REPO" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git -C "$BARE_REPO" fetch origin
+
+echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
+git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop
+
+echo "==> Installing npm dependencies in ${WT_PATH}..."
+(cd "$WT_PATH" && npm install --silent)
+
+echo "Worktree: ${WT_PATH}"

--- a/scripts/pipeline/worktree-create.sh
+++ b/scripts/pipeline/worktree-create.sh
@@ -24,9 +24,7 @@ WT_NAME="${TYPE}_${SLUG}"
 BRANCH="${TYPE}/${SLUG}"
 WT_PATH="${BARE_REPO}/${WT_NAME}"
 
-echo "==> Fetching origin..."
-git -C "$BARE_REPO" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-git -C "$BARE_REPO" fetch origin
+bash "$SCRIPT_DIR/fetch-origin.sh" "$BARE_REPO"
 
 echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
 git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop


### PR DESCRIPTION
## Summary

- Add `scripts/pipeline/worktree-create.sh` — fetch origin, create branch + worktree, `npm install`; prints `Worktree: <path>`
- Add `scripts/pipeline/pr-create.sh` — push branch, open PR against `develop`; prints `PR: <url>`
- Add `scripts/pipeline/pr-complete.sh` — merge PR (rebase), remove worktree, prune stale entries, delete local branch, fast-forward `develop`
- Update `agent-4-git.md` Tasks 1-2, 6, 7-8 to call these scripts instead of constructing raw git/gh commands

## Why

During pipeline runs, `agent-4-git` was spending tokens re-discovering paths, inferring command sequences, and occasionally getting the ordering wrong (e.g. pruning before removing, or trying to `git switch develop` from inside a worktree). These scripts encode the correct sequence once and make it callable with a single line.

## Test plan

- [ ] Run a new pipeline issue end-to-end — verify `worktree-create.sh` creates the worktree and installs deps
- [ ] Verify `pr-create.sh` pushes and opens a PR against `develop`
- [ ] Verify `pr-complete.sh` merges, cleans up, and leaves `develop` up to date

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)