### PR TITLE
ci(agent): move branch deletion from pr-complete to worktree-cleanup

### DIFF
--- a/scripts/pipeline/pr-complete.sh
+++ b/scripts/pipeline/pr-complete.sh
@@ -3,8 +3,12 @@
 #
 # Usage: bash scripts/pipeline/pr-complete.sh <pr-url>
 #
-# Merges an open PR into develop (rebase strategy) and deletes the remote
-# branch. Skips gracefully if the PR is already merged or closed.
+# Merges an open PR into develop (rebase strategy).
+# Skips gracefully if the PR is already merged or closed.
+#
+# Branch deletion (local + remote) is owned by worktree-cleanup.sh so
+# that the worktree is removed first — deleting a branch that is still
+# checked out in a worktree fails on all platforms.
 #
 # Run from any pipeline worktree. Follow with:
 #   worktree-cleanup.sh <worktree-path>
@@ -31,6 +35,6 @@ fi
 echo "==> Merging PR (rebase)..."
 # Run from bare repo root so `gh` does not attempt a local `git switch develop`
 # (which would fail because develop is already checked out in its own worktree).
-(cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
+(cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase)
 
 echo "==> PR merged."

--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -4,7 +4,12 @@
 # Usage: bash scripts/pipeline/worktree-cleanup.sh <worktree-path>
 #
 # Removes a pipeline worktree directory, prunes stale git entries, and
-# deletes the local branch. Safe to re-run if a prior attempt was partial.
+# deletes the local and remote branch. Safe to re-run if a prior attempt
+# was partial.
+#
+# Branch deletion happens here (not in pr-complete.sh) so the worktree is
+# always removed before the branch — deleting a branch still checked out
+# in a worktree fails on all platforms.
 #
 # Run after pr-complete.sh (or after a manual GitHub merge/close).
 # Follow with refresh-develop.sh to fast-forward the develop worktree.
@@ -34,6 +39,9 @@ if [ -n "$BRANCH" ]; then
   # Use -D (force) because GitHub rebase-merge does not create a merge commit,
   # so git never considers the local branch "fully merged".
   git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
+
+  echo "==> Deleting remote branch '${BRANCH}'..."
+  git -C "$BARE_REPO" push origin --delete "$BRANCH" 2>/dev/null || true
 fi
 
 echo "==> Worktree '${WT_NAME}' cleaned up."


### PR DESCRIPTION
## Problem

`gh pr merge --delete-branch` attempts to delete the local branch while the worktree is still checked out, failing with:

```
error: cannot delete branch '<branch>' used by worktree at '<path>'
```

## Fix

- Remove `--delete-branch` from `pr-complete.sh` — it now only merges
- Add remote branch deletion (`git push origin --delete`) to `worktree-cleanup.sh`, after the worktree directory is removed

The worktree is always gone before the branch is touched, so deletion succeeds on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
