### PR TITLE
ci(agent): enforce exact vitest JSON reporter commands in test-runner

### DIFF
--- a/.claude/agents/agent-0-orchestrator.md
+++ b/.claude/agents/agent-0-orchestrator.md
@@ -152,7 +152,7 @@ Invoke agent-3-test-runner using the Task tool. Pass the following to the subage
 - `Task folder: [task-folder]`
 - `Worktree: [worktree]`
 
-The subagent runs `npm run test` and writes `[task-folder]/test-results.md`.
+The subagent runs Vitest via the `/run-tests` skill and writes `[task-folder]/test-results.md`.
 
 Wait for `[task-folder]/test-results.md` to end with either `status: passed` or `status: failed`.
 

--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -1,6 +1,6 @@
 ---
 name: agent-3-test-runner
-description: Runs npm test and writes test-results.md with pass/fail status
+description: Runs Vitest via /run-tests and writes test-results.md with pass/fail status
 model: claude-haiku-4-5-20251001
 tools: Read, Write, Bash
 ---
@@ -12,46 +12,9 @@ The orchestrator passes:
 
 ## Running Tests
 
-Always run Vitest from the worktree root using **exactly** the two commands below — never any other invocation. The bare repo root has no `node_modules` — always `cd` to the worktree path first.
+Use the `/run-tests` skill — it contains the exact `npx vitest run --reporter=json 2>/dev/null | jq ...` commands. Never use `npm test`, `npm run test`, `rtk vitest run`, or any other form.
 
-### Step 1 — Get failed test details
-
-```bash
-cd [worktree] && npx vitest run --reporter=json 2>/dev/null | jq '{
-  failedTests: [
-    .testResults[]
-    | .name as $file
-    | .assertionResults[]
-    | select(.status == "failed")
-    | {
-        file: $file,
-        test: .fullName,
-        errors: .failureMessages
-      }
-  ]
-}'
-```
-
-### Step 2 — Get summary
-
-```bash
-cd [worktree] && npx vitest run --reporter=json 2>/dev/null | jq -r '
-  (.numTotalTestSuites) as $files |
-  (.numPassedTestSuites) as $filesPassed |
-  (.numFailedTestSuites) as $filesFailed |
-  (.numTotalTests) as $tests |
-  (.numPassedTests) as $passed |
-  (.numFailedTests) as $failed |
-  ((.testResults | map(.endTime - .startTime) | add) / 1000 | round) as $dur |
-  if $failed == 0 then
-    "\($files) test files, \($tests) tests total - all passed.\n\n- Test files: \($files) passed\n- Tests: \($tests) passed (0 failed)\n- Duration: ~\($dur) seconds"
-  else
-    "\($files) test files, \($tests) tests total - \($failed) failed.\n\n- Test files: \($filesPassed) passed, \($filesFailed) failed\n- Tests: \($passed) passed (\($failed) failed)\n- Duration: ~\($dur) seconds"
-  end
-'
-```
-
-Both commands run the full test suite — the first extracts structured failure data, the second produces the human-readable summary. You may combine them into two separate `cd [worktree] && ...` calls.
+Replace `[worktree]` in the skill commands with the worktree path passed by the orchestrator.
 
 ## Shell Command Retry Limit
 

--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -10,13 +10,48 @@ The orchestrator passes:
 - `Task folder: [task-folder]` — directory where all pipeline artifacts are written
 - `Worktree: [worktree]` — absolute path to the active worktree
 
-Run Vitest from the worktree root using the exact command below. The bare repo root has no `node_modules` — always `cd` to the worktree path first.
+## Running Tests
+
+Always run Vitest from the worktree root using **exactly** the two commands below — never any other invocation. The bare repo root has no `node_modules` — always `cd` to the worktree path first.
+
+### Step 1 — Get failed test details
 
 ```bash
-cd [worktree] && rtk vitest run
+cd [worktree] && npx vitest run --reporter=json 2>/dev/null | jq '{
+  failedTests: [
+    .testResults[]
+    | .name as $file
+    | .assertionResults[]
+    | select(.status == "failed")
+    | {
+        file: $file,
+        test: .fullName,
+        errors: .failureMessages
+      }
+  ]
+}'
 ```
 
-`rtk vitest run` runs Vitest in non-watch mode and shows failures only — saving significant tokens on large test suites.
+### Step 2 — Get summary
+
+```bash
+cd [worktree] && npx vitest run --reporter=json 2>/dev/null | jq -r '
+  (.numTotalTestSuites) as $files |
+  (.numPassedTestSuites) as $filesPassed |
+  (.numFailedTestSuites) as $filesFailed |
+  (.numTotalTests) as $tests |
+  (.numPassedTests) as $passed |
+  (.numFailedTests) as $failed |
+  ((.testResults | map(.endTime - .startTime) | add) / 1000 | round) as $dur |
+  if $failed == 0 then
+    "\($files) test files, \($tests) tests total - all passed.\n\n- Test files: \($files) passed\n- Tests: \($tests) passed (0 failed)\n- Duration: ~\($dur) seconds"
+  else
+    "\($files) test files, \($tests) tests total - \($failed) failed.\n\n- Test files: \($filesPassed) passed, \($filesFailed) failed\n- Tests: \($passed) passed (\($failed) failed)\n- Duration: ~\($dur) seconds"
+  end
+'
+```
+
+Both commands run the full test suite — the first extracts structured failure data, the second produces the human-readable summary. You may combine them into two separate `cd [worktree] && ...` calls.
 
 ## Shell Command Retry Limit
 
@@ -31,7 +66,7 @@ Create `[task-folder]/test-results.md` using this exact template:
 
 ## Test Run
 
-Command: `npm test` (Vitest vX.Y.Z) from the `[worktree name]` worktree.
+Command: `npx vitest run --reporter=json` (Vitest vX.Y.Z) from the `[worktree name]` worktree.
 
 ## Files Run
 
@@ -50,7 +85,7 @@ All tests passed. No failures.
 <else>
 ### Failures
 
-<list each failing test with its stack trace or error output>
+<list each failing test with its file, test name, and error messages from the failedTests output>
 <end-if>
 
 status: passed

--- a/.claude/commands/fix-pipeline.md
+++ b/.claude/commands/fix-pipeline.md
@@ -7,6 +7,7 @@ Follow this workflow to fix it.
 - Never directly edit files in `develop/` from the main conversation
 - Never fix pipeline issues inline during a pipeline run for another issue — this must be a separate worktree
 - ALWAYS use `subagent_type="general-purpose"`
+- Never run git or gh commands directly — always delegate to agent-4-git via the Agent tool
 
 ## Step 1 — Create a GitHub issue
 
@@ -20,14 +21,15 @@ Record the issue number as `[id]` and derive a slug (≤ 30 chars, kebab-case).
 
 ## Step 2 — Create a dedicated worktree
 
-The session runs from `develop/`. The bare repo root is `..`.
+Invoke agent-4-git via the Agent tool (`subagent_type="general-purpose"`). Pass the full content of `.claude/agents/agent-4-git.md` as the prompt, then append:
 
-```bash
-git -C .. fetch origin
-git -C .. worktree add ci_<slug> -b ci/<slug> origin/develop
+```
+Perform Task 1 and Task 2 only.
+Type: ci
+Slug: <slug>
 ```
 
-Record the resulting worktree absolute path as `[worktree]`.
+Record the `Worktree: <path>` value printed by the agent as `[worktree]`.
 
 ## Step 3 — Apply the fix
 
@@ -36,6 +38,7 @@ Read and edit the affected files directly in the main conversation. You may read
 - `[worktree]/.claude/agents/agent-*.md` — agent instruction files
 - `[worktree]/CLAUDE.md` — main project instructions
 - `[worktree]/CLAUDE-*.md` — supplementary workflow documents
+- `[worktree]/.claude/commands/*.md` — skill files
 
 Do not edit source code, test files, or pipeline artifacts under `docs/prompts/tasks/`.
 
@@ -47,35 +50,47 @@ For every change:
 
 ## Step 4 — Commit
 
-Stage only the affected files and commit using conventional commits:
+Invoke agent-4-git via the Agent tool (`subagent_type="general-purpose"`). Pass the full content of `.claude/agents/agent-4-git.md` as the prompt, then append:
 
-- Files under `.claude/agents/` → `ci(agent): <message>`
-- Files at the repo root (`CLAUDE*.md`) → `docs: <message>`
+```
+Worktree: [worktree]
 
-Use `rtk git add <files>` and `rtk git commit -m "..."`.
+Stage only these files and commit them:
+<list every file you edited in Step 3>
+
+Use commit type ci(agent) for files under .claude/agents/ or .claude/commands/.
+Use commit type docs for CLAUDE*.md files.
+Do not push yet.
+Closes #[id]
+```
 
 ## Step 5 — Push and open a PR
 
-```bash
-rtk git push origin ci/<slug>
-gh pr create --base develop --title "<title>" --body "<body with Closes #[id]>"
+Invoke agent-4-git via the Agent tool (`subagent_type="general-purpose"`). Pass the full content of `.claude/agents/agent-4-git.md` as the prompt, then append:
+
 ```
+Worktree: [worktree]
+
+Perform Task 5 and Task 6.
+
+For Task 5: all files were already committed in the previous step — just push the branch.
+For Task 6: derive the PR title from the issue title (#[id]). The PR body must include:
+- a summary of what was wrong and what was fixed
+- Closes #[id]
+Target branch: develop
+```
+
+Record the `PR: <url>` value printed by the agent.
 
 Show the user the PR URL and ask for approval to merge.
 
 ## Step 6 — Merge and clean up
 
-Once approved, remove the worktree first (so the branch is free), then merge from the bare repo root:
+Once approved, invoke agent-4-git via the Agent tool (`subagent_type="general-purpose"`). Pass the full content of `.claude/agents/agent-4-git.md` as the prompt, then append:
 
-```bash
-git -C .. worktree remove --force ci_<slug>
-git -C .. worktree prune
-cd .. && gh pr merge <pr-url> --rebase --delete-branch
-git -C .. fetch origin
 ```
+Worktree: [worktree]
 
-Then pull latest into `develop/`:
-
-```bash
-git pull --rebase origin develop
+Perform Task 7 then Task 8.
+PR URL: <pr-url>
 ```

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -1,0 +1,40 @@
+Run the full Vitest test suite using the exact commands below. Always `cd [worktree]` first — the bare repo root has no `node_modules`.
+
+## Step 1 — Failure details (structured JSON)
+
+```bash
+cd [worktree] && npx vitest run --reporter=json 2>/dev/null | jq '{
+  failedTests: [
+    .testResults[]
+    | .name as $file
+    | .assertionResults[]
+    | select(.status == "failed")
+    | {
+        file: $file,
+        test: .fullName,
+        errors: .failureMessages
+      }
+  ]
+}'
+```
+
+## Step 2 — Summary (human-readable)
+
+```bash
+cd [worktree] && npx vitest run --reporter=json 2>/dev/null | jq -r '
+  (.numTotalTestSuites) as $files |
+  (.numPassedTestSuites) as $filesPassed |
+  (.numFailedTestSuites) as $filesFailed |
+  (.numTotalTests) as $tests |
+  (.numPassedTests) as $passed |
+  (.numFailedTests) as $failed |
+  ((.testResults | map(.endTime - .startTime) | add) / 1000 | round) as $dur |
+  if $failed == 0 then
+    "\($files) test files, \($tests) tests total - all passed.\n\n- Test files: \($files) passed\n- Tests: \($tests) passed (0 failed)\n- Duration: ~\($dur) seconds"
+  else
+    "\($files) test files, \($tests) tests total - \($failed) failed.\n\n- Test files: \($filesPassed) passed, \($filesFailed) failed\n- Tests: \($passed) passed (\($failed) failed)\n- Duration: ~\($dur) seconds"
+  end
+'
+```
+
+Never use `npm test`, `npm run test`, `rtk vitest run`, or any other form.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,44 +227,7 @@ rtk err npm run build   # errors/warnings only
 
 ### Running tests
 
-**Always** use the exact commands below — never `npm test`, `rtk vitest run`, or any other form.
-
-**Failure details** (structured JSON per failing test):
-
-```bash
-npx vitest run --reporter=json 2>/dev/null | jq '{
-  failedTests: [
-    .testResults[]
-    | .name as $file
-    | .assertionResults[]
-    | select(.status == "failed")
-    | {
-        file: $file,
-        test: .fullName,
-        errors: .failureMessages
-      }
-  ]
-}'
-```
-
-**Summary** (human-readable pass/fail counts and duration):
-
-```bash
-npx vitest run --reporter=json 2>/dev/null | jq -r '
-  (.numTotalTestSuites) as $files |
-  (.numPassedTestSuites) as $filesPassed |
-  (.numFailedTestSuites) as $filesFailed |
-  (.numTotalTests) as $tests |
-  (.numPassedTests) as $passed |
-  (.numFailedTests) as $failed |
-  ((.testResults | map(.endTime - .startTime) | add) / 1000 | round) as $dur |
-  if $failed == 0 then
-    "\($files) test files, \($tests) tests total - all passed.\n\n- Test files: \($files) passed\n- Tests: \($tests) passed (0 failed)\n- Duration: ~\($dur) seconds"
-  else
-    "\($files) test files, \($tests) tests total - \($failed) failed.\n\n- Test files: \($filesPassed) passed, \($filesFailed) failed\n- Tests: \($passed) passed (\($failed) failed)\n- Duration: ~\($dur) seconds"
-  end
-'
-```
+Always use the `/run-tests` skill — never `npm test`, `npm run test`, `rtk vitest run`, or any other form. The skill contains the exact `npx vitest run --reporter=json 2>/dev/null | jq ...` commands for both failure details and summary output.
 
 ### Files & search
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,10 +221,50 @@ rtk gh run list         # workflow run status
 rtk tsc                 # TypeScript errors grouped by file
 rtk lint                # ESLint grouped by rule/file
 rtk err npm run build   # errors/warnings only
-rtk vitest run          # failures only
 ```
 
 `npm run type-check` (vue-tsc) has no rtk equivalent — keep as-is.
+
+### Running tests
+
+**Always** use the exact commands below — never `npm test`, `rtk vitest run`, or any other form.
+
+**Failure details** (structured JSON per failing test):
+
+```bash
+npx vitest run --reporter=json 2>/dev/null | jq '{
+  failedTests: [
+    .testResults[]
+    | .name as $file
+    | .assertionResults[]
+    | select(.status == "failed")
+    | {
+        file: $file,
+        test: .fullName,
+        errors: .failureMessages
+      }
+  ]
+}'
+```
+
+**Summary** (human-readable pass/fail counts and duration):
+
+```bash
+npx vitest run --reporter=json 2>/dev/null | jq -r '
+  (.numTotalTestSuites) as $files |
+  (.numPassedTestSuites) as $filesPassed |
+  (.numFailedTestSuites) as $filesFailed |
+  (.numTotalTests) as $tests |
+  (.numPassedTests) as $passed |
+  (.numFailedTests) as $failed |
+  ((.testResults | map(.endTime - .startTime) | add) / 1000 | round) as $dur |
+  if $failed == 0 then
+    "\($files) test files, \($tests) tests total - all passed.\n\n- Test files: \($files) passed\n- Tests: \($tests) passed (0 failed)\n- Duration: ~\($dur) seconds"
+  else
+    "\($files) test files, \($tests) tests total - \($failed) failed.\n\n- Test files: \($filesPassed) passed, \($filesFailed) failed\n- Tests: \($passed) passed (\($failed) failed)\n- Duration: ~\($dur) seconds"
+  end
+'
+```
 
 ### Files & search
 


### PR DESCRIPTION
## Summary

- Replaces `rtk vitest run` with the exact `npx vitest run --reporter=json 2>/dev/null | jq ...` commands
- Step 1: extracts structured `failedTests` JSON (file, test name, errors)
- Step 2: produces human-readable pass/fail summary with counts and duration
- Updates the test-results.md template to reflect the new command

## Why

The previous `rtk vitest run` produced filtered plain-text output that was harder to parse structurally. The new JSON reporter + jq pipeline gives the agent precise, machine-readable failure data and a clean summary — consistent with what is expected by the orchestrator and reviewer agents.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)