### PR TITLE
ci(commands): add jli-reviews-specs, dual-mode setup, and sub-issue task folders

### DIFF
--- a/.claude/commands/jli-codes.md
+++ b/.claude/commands/jli-codes.md
@@ -9,6 +9,14 @@ opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and 
 Run from the worktree root (your current directory). All file paths are relative to it —
 never read or write outside this worktree.
 
+## Sub-issue task folders
+
+If the task folder is a `sub-issue-<n>` subfolder, read the shared specs
+(`business-specifications.md`, `security-guidelines.md`, `test-cases.md`) from its **parent**
+folder and write this command's outputs into the **subfolder**; parse `[id]` from
+`issue-<id>-<slug>` or `sub-issue-<id>`. Otherwise it is a flat folder holding everything
+(see `AGENT-COMMAND-MIGRATION.md` for the rationale).
+
 ## What this command does
 
 Read `[task-folder]/business-specifications.md`, `[task-folder]/security-guidelines.md`, and

--- a/.claude/commands/jli-commits.md
+++ b/.claude/commands/jli-commits.md
@@ -10,6 +10,14 @@ Run all git commands from the worktree root (your current directory) — never f
 repo root, and never commit directly to `develop` or `main` (you are on the feature branch
 the worktree created). Parse the issue `[id]` from the task-folder name (`issue-<id>-<slug>`).
 
+## Sub-issue task folders
+
+If the task folder is a `sub-issue-<n>` subfolder, its own artifacts
+(`technical-specifications.md`, `review-results.md`, `test-results.md`) live in that
+subfolder while the shared specs sit in the **parent**; parse `[id]` from `issue-<id>-<slug>`
+or `sub-issue-<id>`. Otherwise it is a flat folder holding everything (see
+`AGENT-COMMAND-MIGRATION.md` for the rationale).
+
 ## What this command does
 
 This is the commit step run between phases. Inspect what changed, then create one

--- a/.claude/commands/jli-reviews-code.md
+++ b/.claude/commands/jli-reviews-code.md
@@ -9,6 +9,14 @@ opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and 
 Run from the worktree root (your current directory) — that is where `node_modules` lives and
 where the shell commands below must run.
 
+## Sub-issue task folders
+
+If the task folder is a `sub-issue-<n>` subfolder, read the shared specs
+(`business-specifications.md`, `security-guidelines.md`, `test-cases.md`) from its **parent**
+folder and write this command's outputs into the **subfolder**; parse `[id]` from
+`issue-<id>-<slug>` or `sub-issue-<id>`. Otherwise it is a flat folder holding everything
+(see `AGENT-COMMAND-MIGRATION.md` for the rationale).
+
 ## What this command does
 
 Read `[task-folder]/technical-specifications.md` (the list of changed files),

--- a/.claude/commands/jli-reviews-specs.md
+++ b/.claude/commands/jli-reviews-specs.md
@@ -1,0 +1,132 @@
+Review and amend a feature's spec-phase artifacts from PR feedback: $ARGUMENTS
+
+`$ARGUMENTS` is the number of the PR that shipped the spec phase (e.g. `87`). It may also
+carry extra notes. Do not hard-stop when it is empty — instead resolve the PR interactively:
+
+- If `$ARGUMENTS` has no PR number, ask:
+  > Which PR carries the spec feedback? Reply with its number
+  > (usage: `/jli-reviews-specs <pr-number>`). If there is **no PR**, paste your
+  > feedback / amendments here in chat and I will apply them directly.
+- If the user says there is no PR, take their chat feedback as the review input and skip
+  Step 1's PR read and Step 3's PR read; everything else proceeds the same.
+
+## What this command does
+
+The spec phase produced several artifacts: the business specification
+(`business-specifications.md`), the security specification (`security-guidelines.md`), the
+test specification (`test-cases.md`), and — when the feature warranted one — one or more ADRs
+under `docs/decisions/`. This command gathers the human review feedback left on the spec PR
+(or given in chat when there is no PR) and reviews **all four artifact kinds together**:
+business specs, security specs, test specs, and ADR(s). Its job is not only to fold in the
+feedback but to **ensure they stay coherent with one another** — every rule changed in the
+business spec must be reflected in the test cases and security guidelines, and must not
+contradict the ADR(s) (and vice-versa). It records the result as a review artifact and routes
+back to `/jli-writes-spec` so the spec is amended by its single owner command.
+
+Run this from the **feature worktree** — the sibling of the develop worktree you opened for
+this feature — exactly like the other phase commands. All task-folder paths are relative to
+it. If that worktree was cleaned up after the spec PR merged, Step 2 recreates it first.
+
+### Step 1 — Resolve the PR, branch, and task folder
+
+If you are already inside the feature worktree, the branch and task folder are the current
+ones; you only need the PR for its feedback. Read the PR metadata (skip on the no-PR path):
+
+```bash
+rtk gh pr view <pr-number> --json headRefName,title,body,url,state
+```
+
+- `branch` = the PR's `headRefName` (e.g. `feat/github-repo-preferences`). It is `<type>/<slug>`.
+- `slug` = the branch text after the first `/`.
+- `id` = the issue number the PR closes — read it from the body (`Closes #<id>`) or from
+  `closingIssuesReferences`. If it cannot be determined, ask the user for the issue number.
+- `task-folder` (relative) = `docs/prompts/tasks/issue-<id>-<slug>`.
+
+### Step 2 — Ensure the feature worktree exists
+
+Normally you are already inside it — skip to Step 3. Only if the feature worktree was removed
+after the spec PR merged do you need to recreate it. The PR gave you the branch in Step 1, so
+you can recreate the sibling worktree folder directly on that existing branch.
+
+The repo uses one bare repo with sibling worktrees under a shared parent folder:
+
+```
+<parent>/<repo-name>.git              <- bare repo
+<parent>/<repo-name>-develop          <- develop worktree
+<parent>/<repo-name>_<type>-<slug>    <- the feature worktree to recreate
+```
+
+Recreate it on the PR branch (derive the bare repo from `git worktree list` — its `(bare)`
+entry — never assume it is the parent directory), then open it and run this command from
+inside it:
+
+```bash
+git worktree list                             # the (bare) entry is the bare repo path
+BARE="<path printed as (bare) above>"
+WT="<parent>/<repo-name>_<type>-<slug>"       # sibling of the bare repo; '/' in slug -> '-'
+
+git -C "$BARE" fetch origin
+git -C "$BARE" worktree add "$WT" "<branch>" \
+  || git -C "$BARE" worktree add "$WT" --track -b "<branch>" "origin/<branch>"
+(cd "$WT" && npm install --silent)
+echo "Worktree: $WT"
+```
+
+### Step 3 — Collect the feedback
+
+For the PR path, gather all three feedback channels (skip on the no-PR path — use the chat
+feedback instead):
+
+```bash
+rtk gh pr view <pr-number> --comments                                   # conversation comments
+rtk gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews               # review summaries (approve / request changes)
+rtk gh api repos/{owner}/{repo}/pulls/<pr-number>/comments             # inline diff comments
+```
+
+Summarize the feedback into concrete, actionable amendment requests. Drop resolved/outdated
+threads and pure "LGTM" noise.
+
+### Step 4 — Review for coherence and write the review artifact
+
+Read the four artifact kinds in the task folder / `docs/decisions/` and cross-check them
+against each other and against the feedback. Then write
+`[task-folder]/spec-review.md` containing:
+
+- The PR number and URL (or "source: chat feedback" for the no-PR path).
+- A bulleted list of amendment requests, each tagged with the artifact it targets
+  (`business-specifications.md`, `security-guidelines.md`, `test-cases.md`, or the specific
+  `ADR-xxx`).
+- A short **coherence** section listing any contradictions found *between* artifacts (e.g. a
+  spec rule with no matching test case, or an ADR decision the security spec contradicts).
+- Any open questions the feedback raises for the user.
+
+End the file with a status line as its last line:
+
+- `status: review specs` — amendments are needed (the common case).
+- `status: approved` — the feedback requests no changes and the artifacts are coherent.
+
+Do NOT use horizontal rules (`---`) anywhere in the file.
+
+## Commit rules reference
+
+- Changes under `docs/` (the review artifact) → `docs: …`
+- This command does not commit anything itself. Run `/jli-commits @<task-folder>` after.
+
+## Shell command retry limit
+
+Do not run more than 3 failing shell commands in total. After 3 failures, stop and report
+the full error output to the user.
+
+## Next
+
+Show the user the amendment + coherence summary, then:
+
+- If `spec-review.md` ends with `status: review specs`:
+  > Feedback captured in `spec-review.md`. Amend the spec from this worktree by running
+  > `/jli-writes-spec @docs/prompts/tasks/issue-<id>-<slug>` to fold in the amendments, then
+  > `/jli-commits @docs/prompts/tasks/issue-<id>-<slug>`. (If you had to recreate the worktree
+  > in Step 2, run these from inside it via `code [worktree]`.)
+- If it ends with `status: approved`:
+  > No spec changes requested and the artifacts are coherent. Commit the review note with
+  > `/jli-commits @docs/prompts/tasks/issue-<id>-<slug>`, then continue the chain from wherever
+  > the feature left off (e.g. `/jli-verifies-security @docs/prompts/tasks/issue-<id>-<slug>`).

--- a/.claude/commands/jli-runs-tests.md
+++ b/.claude/commands/jli-runs-tests.md
@@ -8,6 +8,14 @@ opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and 
 
 Run from the worktree root (your current directory) — that is where `node_modules` lives.
 
+## Sub-issue task folders
+
+If the task folder is a `sub-issue-<n>` subfolder, read any shared specs
+(`business-specifications.md`, `security-guidelines.md`, `test-cases.md`) from its **parent**
+folder and write this command's outputs into the **subfolder**; parse `[id]` from
+`issue-<id>-<slug>` or `sub-issue-<id>`. Otherwise it is a flat folder holding everything
+(see `AGENT-COMMAND-MIGRATION.md` for the rationale).
+
 ## What this command does
 
 Run Vitest in non-watch mode from the worktree using the exact commands below. Do NOT use

--- a/.claude/commands/jli-sets-up.md
+++ b/.claude/commands/jli-sets-up.md
@@ -1,21 +1,55 @@
-Bootstrap a worktree and task folder for a GitHub issue: $ARGUMENTS
+Bootstrap a worktree for a feature — from a new issue, a sub-issue, or a merged spec: $ARGUMENTS
 
-`$ARGUMENTS` must contain the GitHub issue number (and optionally a title or extra
-context). If it is empty, stop and reply:
+`$ARGUMENTS` identifies the work in one of these ways, matching the entry modes below:
 
-> Usage: `/jli-sets-up <issue-number> [title or notes]` — I need an issue number to
-> create the branch and task folder.
+- **Mode A — from scratch**: a GitHub issue number for a standalone feature or bug fix with
+  no spec yet (and optionally a title / notes).
+- **Mode B — continue from a merged spec**: the specs folder,
+  `docs/prompts/tasks/issue-<id>-<slug>`.
+- **Sub-issue variant of Mode B**: a sub-issue's number, when its spec was written and merged
+  as part of a larger **parent** issue. This is detected automatically in Step 1.
+
+If `$ARGUMENTS` is empty or the mode is unclear, ask before doing anything:
+
+> Which scenario?
+> 1. **From scratch** (new feature or bug fix, no spec yet) — reply with the **issue number**.
+> 2. **Continue from a merged spec** — reply with the **specs folder**
+>    (`docs/prompts/tasks/issue-<id>-<slug>`).
+
+Decide the mode from the answer: a bare issue number > Mode A (then run the sub-issue check in
+Step 1); a `docs/prompts/tasks/...` folder > Mode B.
 
 ## What this command does
 
-This is the first step of the manual feature chain. It creates the isolated worktree and
-the task folder that every later `jli-` command reads from. Run it from the `develop/`
-worktree (the session's working directory).
+This is the first step of the manual feature chain. It creates the isolated worktree the
+later `jli-` commands run in. Run it from the `develop/` worktree (the session's working
+directory).
 
-### Step 1 — Identify the issue
+- **Mode A (from scratch)** builds a brand-new task folder from the issue; the chain then
+  starts at `/jli-writes-spec`. The common case for a small feature or bug fix run end-to-end.
+- **Mode B (continue)** targets a feature whose spec was already written, reviewed, and
+  **merged into develop**. The new worktree, branched from `origin/develop`, already contains
+  the merged spec artifacts, so this command creates no task folder — it resumes the chain at
+  the first phase not yet done.
+- **Sub-issue variant** implements one sub-issue of a larger merged spec. The shared spec
+  lives in the parent issue's folder; this command creates a per-sub-issue **subfolder** for
+  that sub-issue's own outputs and resumes at `/jli-codes`.
 
+### Step 1 — Identify the work
+
+**Mode A:**
 - Parse the issue number from `$ARGUMENTS`.
 - Fetch the issue with `rtk gh issue view <number>` to get its title and body.
+- **Sub-issue check** (run before building anything): if the issue title contains
+  `Sub-Issue` (case-insensitive) or its body contains `Part of #<n>`, this is a sub-issue of
+  parent `#<n>`. Do NOT continue as Mode A — parse the parent id and ask the user to confirm
+  the switch:
+  > Issue #<sub-id> is a sub-issue of #<parent-id>. Its spec should already be merged under
+  > `docs/prompts/tasks/issue-<parent-id>-<parent-slug>`. Switch to the sub-issue variant
+  > (implement it against that merged spec)? Confirm, or give the specs-folder path if it
+  > differs.
+
+  On confirmation, proceed with the **sub-issue variant** below. Otherwise (not a sub-issue):
 - Build:
   - `slug` = a short (≤ 30 chars) kebab-case summary of the issue title (e.g.
     `back-button-fix`). Do NOT use the full title — long slugs cause path-length failures
@@ -23,29 +57,61 @@ worktree (the session's working directory).
   - `type` = the conventional-commit type implied by the issue label or nature (`feat`,
     `fix`, `docs`, `refactor`, …).
 
+**Mode B (whole-feature continue):**
+- Parse the specs folder from `$ARGUMENTS`. Its name is `issue-<id>-<slug>`, so read `id` and
+  `slug` straight from it — the implementation reuses the spec's own issue and slug.
+- Infer `type` the same way as Mode A: `rtk gh issue view <id>`.
+
+**Sub-issue variant:**
+- `sub-id` = the sub-issue number; `sub-slug` = a short (≤ 30 chars) kebab-case summary of the
+  sub-issue's **own** title (drop the `Sub-Issue X (#..):` prefix, e.g. `netlify-oauth-proxy`).
+- `type` = inferred from the sub-issue's label/nature.
+- `parent-folder` (relative) = `docs/prompts/tasks/issue-<parent-id>-<parent-slug>` — the
+  merged specs folder confirmed above.
+
 ### Step 2 — Fetch origin and create the worktree
 
-Prefer the pipeline scripts over raw git. Run from `develop/`:
+Run from `develop/`:
 
 ```bash
 bash scripts/pipeline/fetch-origin.sh
 bash scripts/pipeline/worktree-create.sh <type> <slug>
 ```
 
-`worktree-create.sh` creates the worktree folder `<repo-name>_<type>-<slug>` (a sibling of
-the bare repo) on branch `<type>/<slug>` from `origin/develop`, installs npm deps, and prints
-`Worktree: <absolute-path>`. Capture that absolute path as `[worktree]`.
+Use `<slug>` for Mode A, the parent `<slug>` for Mode B whole-feature, or `<sub-slug>` for
+the sub-issue variant. `worktree-create.sh` creates the worktree folder
+`<repo-name>_<type>-<slug>` (a sibling of the bare repo) on branch `<type>/<slug>` from
+`origin/develop`, installs npm deps, and prints `Worktree: <absolute-path>`. Capture that
+path as `[worktree]`.
 
-### Step 3 — Create the task folder and README
+In **Mode B** and the **sub-issue variant**, because the spec was merged into develop, the new
+worktree already contains the parent specs folder with its artifacts. (If a needed branch name
+still exists from an earlier cycle and was not deleted after its merge, `worktree-create.sh`
+errors that the branch already exists — delete the stale local branch, then re-run.)
 
-- `task-folder` = `[worktree]/docs/prompts/tasks/issue-<id>-<slug>/`
-- The relative form (used by every later command) is `docs/prompts/tasks/issue-<id>-<slug>`.
+### Step 3 — Task folder
+
+**Mode A:**
+- `task-folder` = `[worktree]/docs/prompts/tasks/issue-<id>-<slug>/`; relative form
+  `docs/prompts/tasks/issue-<id>-<slug>`.
 - Write `[task-folder]/README.md` containing:
   - A first line: `Worktree: [worktree]` (so the path is recorded for reference).
-  - The issue title and the full issue body fetched in Step 1, plus any extra notes the
-    user passed in `$ARGUMENTS`. This is the feature request the spec phase will read.
+  - The issue title and the full issue body fetched in Step 1, plus any extra notes the user
+    passed in `$ARGUMENTS`. This is the feature request the spec phase will read.
+- Do NOT create the task folder before the worktree path is confirmed.
 
-Do NOT create the task folder before the worktree path is confirmed.
+**Mode B (whole-feature continue):**
+- The task folder already exists (it came with the merge) — do NOT recreate or overwrite it.
+- Update only the first `Worktree:` line of its `README.md` to `[worktree]`.
+
+**Sub-issue variant:**
+- The shared parent specs folder already exists in the worktree — do NOT recreate, copy, or
+  duplicate the shared specs.
+- Create the per-sub-issue subfolder `[worktree]/<parent-folder>/sub-issue-<sub-id>/` (it
+  starts empty; the implementation-phase commands fill it with `technical-specifications.md`,
+  `review-results.md`, and `test-results.md`).
+- The `@`-mention every downstream command takes is this subfolder:
+  `docs/prompts/tasks/issue-<parent-id>-<parent-slug>/sub-issue-<sub-id>`.
 
 ## Commit rules reference (used by every git step in this chain)
 
@@ -65,7 +131,9 @@ the full error output to the user.
 
 ## Next
 
-Report the absolute worktree path and the relative task-folder path, then show:
+Report the absolute worktree path and the relative task-folder path.
+
+**Mode A:**
 
 > Worktree and task folder ready.
 > Worktree: `[worktree]`
@@ -82,3 +150,46 @@ Report the absolute worktree path and the relative task-folder path, then show:
 > command takes the task folder as a `@`-mention relative to the worktree root — you never
 > need the absolute path again. The final cleanup command is the exception: it runs back in
 > this `develop` window.
+
+**Mode B (whole-feature continue):** determine the resume point from which artifacts already
+exist in the task folder, walking the chain order:
+
+- no `security-guidelines.md` present > resume at `/jli-verifies-security`
+- else no `test-cases.md` present > resume at `/jli-writes-tests-spec`
+- else > resume at `/jli-codes`
+
+Then show:
+
+> Worktree ready with the merged spec.
+> Worktree: `[worktree]`
+> Task folder (relative): `docs/prompts/tasks/issue-<id>-<slug>`
+>
+> Next: open the worktree in its own editor window:
+>
+> ```
+> code [worktree]
+> ```
+>
+> Then, from that window, resume the chain at `/<resume-command> @docs/prompts/tasks/issue-<id>-<slug>`.
+> Every later command takes the task folder as a `@`-mention relative to the worktree root.
+> The final cleanup command runs back in this `develop` window.
+
+**Sub-issue variant:** the shared spec is complete in the parent folder, so resume at
+`/jli-codes` with the **subfolder** as the task folder:
+
+> Worktree ready for sub-issue #<sub-id> against the merged #<parent-id> spec.
+> Worktree: `[worktree]`
+> Sub-issue task folder (relative): `docs/prompts/tasks/issue-<parent-id>-<parent-slug>/sub-issue-<sub-id>`
+>
+> Next: open the worktree in its own editor window:
+>
+> ```
+> code [worktree]
+> ```
+>
+> Then, from that window, run
+> `/jli-codes @docs/prompts/tasks/issue-<parent-id>-<parent-slug>/sub-issue-<sub-id>`. Every later
+> command takes that subfolder as its `@`-mention; each reads the shared specs from the parent
+> folder automatically. (If the parent folder is missing `security-guidelines.md` or
+> `test-cases.md`, run the matching shared-spec command against the parent folder first.) The
+> final cleanup command runs back in this `develop` window.

--- a/.claude/commands/jli-ships.md
+++ b/.claude/commands/jli-ships.md
@@ -11,6 +11,14 @@ task-folder name. The pipeline scripts resolve the bare repo automatically. This
 outward-facing and irreversible — honour the two approval gates below. It does NOT remove the
 worktree (you are standing in it); cleanup is a separate command run from `develop`.
 
+## Sub-issue task folders
+
+If the task folder is a `sub-issue-<n>` subfolder, read `business-specifications.md` (for the
+PR title) from its **parent** folder and read `test-results.md` from the subfolder; parse
+`[id]` from `issue-<id>-<slug>` or `sub-issue-<id>` (so the PR closes the sub-issue).
+Otherwise it is a flat folder holding everything (see `AGENT-COMMAND-MIGRATION.md` for the
+rationale).
+
 ## Step 1 — Push and open the PR
 
 Confirm `test-results.md` in the task folder ends with `status: passed`. If not, stop and

--- a/.claude/commands/jli-tweaks-command-chain.md
+++ b/.claude/commands/jli-tweaks-command-chain.md
@@ -49,7 +49,8 @@ command must still hold ALL of these invariants:
 2. **Argument guard** — opens by requiring its argument and printing a usage line when empty.
    The argument is the task folder as a `@`-mention relative to the worktree
    (`@docs/prompts/tasks/issue-<id>-<slug>`) for the phase/commit/ship commands;
-   `jli-sets-up` takes an issue number; `jli-cleans` takes a worktree name/path.
+   `jli-sets-up` takes an issue number (from-scratch mode) or a merged-spec folder
+   (continue mode); `jli-cleans` takes a worktree name/path.
 3. **Run location** — phase/commit/ship commands run from inside the feature worktree and
    treat the task-folder argument as relative to it (no path derivation). `jli-sets-up`
    and `jli-cleans` run from the `develop` worktree.

--- a/.claude/commands/jli-writes-spec.md
+++ b/.claude/commands/jli-writes-spec.md
@@ -9,11 +9,26 @@ opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and 
 Run from the worktree root (your current directory). All paths below are relative to it; read
 and write only inside this worktree.
 
+## Sub-issue task folders and the "review specs" loop-back
+
+The task folder given may be a `sub-issue-<n>` subfolder. If so, the request `README.md` and
+the shared `business-specifications.md` you write live in the **parent** folder, not the
+subfolder.
+
+When re-run as a `status: review specs` loop-back from `/jli-codes`, read the feedback first:
+it is the `### Specifications Need Review` section of `technical-specifications.md` — a sibling
+file in a flat task folder, or **inside the sub-issue subfolder** you were given. Amend the
+shared `business-specifications.md` accordingly; because it is shared, keep the change minimal
+and tell the user it affects every sub-issue of the parent. (Rationale in
+`AGENT-COMMAND-MIGRATION.md`.)
+
 ## What this command does
 
-Read the feature request in `[task-folder]/README.md` (this is the input — this phase does
-not read any other artifact). Using the project context in `CLAUDE.md` and `README.md`,
-write a detailed business spec to `[task-folder]/business-specifications.md`.
+Read the feature request in the task folder's `README.md` (for a sub-issue subfolder, in its
+parent). On a first run this is the only input; on a `review specs` loop-back also read the
+feedback described above. Using the project context in `CLAUDE.md` and the project `README.md`,
+write the business spec to `business-specifications.md` — in the task folder, or its parent for
+a sub-issue subfolder.
 
 The spec describes WHAT the system does — goals, rules, constraints, observable outcomes —
 never HOW. Use the Example Mapping method.
@@ -53,8 +68,9 @@ architectural choice with its context, rationale, and consequences. In doubt, as
 
 ## Output contract
 
-Create `[task-folder]/business-specifications.md`. End it with `status: ready` as the last
-line. Do NOT use horizontal rules (`---`) anywhere in the file.
+Create or update `business-specifications.md` in the task folder (its parent for a sub-issue
+subfolder). End it with `status: ready` as the last line. Do NOT use horizontal rules (`---`)
+anywhere in the file.
 
 ## Shell command retry limit
 

--- a/.claude/commands/jli-writes-tests.md
+++ b/.claude/commands/jli-writes-tests.md
@@ -9,6 +9,14 @@ opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and 
 Run from the worktree root (your current directory). All paths below are relative to it; read
 and write only inside this worktree.
 
+## Sub-issue task folders
+
+If the task folder is a `sub-issue-<n>` subfolder, read the shared specs
+(`business-specifications.md`, `security-guidelines.md`, `test-cases.md`) from its **parent**
+folder and write this command's outputs into the **subfolder**; parse `[id]` from
+`issue-<id>-<slug>` or `sub-issue-<id>`. Otherwise it is a flat folder holding everything
+(see `AGENT-COMMAND-MIGRATION.md` for the rationale).
+
 ## What this command does
 
 This is the **after-coding** test pass. It turns the plain-language scenarios from

--- a/AGENT-COMMAND-MIGRATION.md
+++ b/AGENT-COMMAND-MIGRATION.md
@@ -30,7 +30,7 @@ command runs from inside the **feature worktree** — you open it in its own edi
 
 All state lives in the task folder under the feature worktree:
 `docs/prompts/tasks/issue-<id>-<slug>/`. Each command reads the artifacts written by earlier
-commands and writes its own. Because the phase/commit/ship commands run *inside* the feature
+commands and writes its own. Because the phase/commit/ship commands run _inside_ the feature
 worktree, the task folder is a simple relative path — you pass it as a `@`-mention
 (`@docs/prompts/tasks/issue-<id>-<slug>`), never an absolute path. The argument is required on
 every command, so each one rebuilds what it needs from disk after a `/clear`.
@@ -38,21 +38,69 @@ every command, so each one rebuilds what it needs from disk after a `/clear`.
 The **specification phase is the input exception**: `/jli-writes-spec` reads the `README.md`
 request created by `/jli-sets-up` rather than a prior pipeline artifact.
 
+`/jli-sets-up` has **two entry modes**, chosen by the size of the work:
+
+- **From scratch** (issue number) — the common path for a small feature or bug fix run
+  end-to-end in one cycle: it creates the task folder and the chain starts at `/jli-writes-spec`.
+- **Continue from a merged spec** (specs folder) — for a larger feature whose spec was
+  written, reviewed, and merged to develop in an earlier cycle. The new worktree, branched
+  from `origin/develop`, already carries the merged spec artifacts, so no task folder is
+  created; setup resumes the chain at the first phase not yet done (normally `/jli-codes`, or
+  `/jli-verifies-security` / `/jli-writes-tests-spec` if those artifacts were not part of the
+  merged spec). The implementation reuses the spec's own issue and slug.
+
+### Sub-issues of a larger feature
+
+When a large feature is split into sub-issues (each `Sub-Issue X (#parent)` in its title, or
+`Part of #parent` in its body), the spec is written once for the **parent** and merged, then
+each sub-issue is implemented in its own cycle. `/jli-sets-up` detects a sub-issue number in
+Step 1, confirms the switch, and sets up the **sub-issue variant** of Mode B:
+
+- The branch/worktree slug is a short summary of the **sub-issue's own** title (e.g.
+  `netlify-oauth-proxy` for #81), not the parent's — one branch/PR per sub-issue.
+- The **shared spec artifacts** (`business-specifications.md`, `security-guidelines.md`,
+  `test-cases.md`, plus `README.md` / `spec-review.md`) stay in the parent folder
+  `docs/prompts/tasks/issue-<parent-id>-<parent-slug>/`.
+- Each sub-issue's **own outputs** (`technical-specifications.md`, `review-results.md`,
+  `test-results.md`) go in a per-sub-issue subfolder
+  `.../issue-<parent-id>-<parent-slug>/sub-issue-<n>/`, which is the `@`-mention passed to
+  every downstream command for that sub-issue.
+- The implementation-phase commands (`/jli-codes`, `/jli-reviews-code`, `/jli-writes-tests`,
+  `/jli-runs-tests`, `/jli-commits`, `/jli-ships`) carry a uniform "Sub-issue task folders"
+  rule: read each shared spec from the given folder if present, otherwise from its parent;
+  write their own output into the given folder; and parse the issue id from `issue-<id>-<slug>`
+  or `sub-issue-<id>`. For a normal (non-sub-issue) folder the parent is never consulted, so
+  the rule is a no-op there. The chain resumes at `/jli-codes` since the shared spec is done.
+- The `/jli-codes` > `status: review specs` loop-back honours the same layout: `/jli-writes-spec`,
+  re-run with the sub-issue subfolder as its argument, reads the feedback (the
+  `### Specifications Need Review` section of the subfolder's `technical-specifications.md`) and
+  amends the **shared** `business-specifications.md` in the parent. Because that spec is shared,
+  the amendment affects every sub-issue of the parent — keep it minimal and flag it.
+
 ## Command ↔ agent mapping
 
-| Command | Runs from | Replaces (agent) |
-|---|---|---|
-| `/jli-sets-up <issue-num + title>` | develop | `agent-4-git` Tasks 1–2 (fetch + worktree) |
-| `/jli-writes-spec @<task-folder>` | feature worktree | `agent-1-specs` |
-| `/jli-verifies-security @<task-folder>` | feature worktree | `agent-5-security` |
-| `/jli-writes-tests-spec @<task-folder>` | feature worktree | `agent-3-test-writer` (pass 1: test cases) |
-| `/jli-codes @<task-folder>` | feature worktree | `agent-2-coder` |
-| `/jli-reviews-code @<task-folder>` | feature worktree | `agent-6-reviewer` |
-| `/jli-writes-tests @<task-folder>` | feature worktree | `agent-3-test-writer` (pass 2: `*.spec.ts`) |
-| `/jli-runs-tests @<task-folder>` | feature worktree | `agent-3-test-runner` |
-| `/jli-commits @<task-folder>` | feature worktree | `agent-4-git` commit tasks (3 / 3.5 / 3.7 / 4 / 5-commit) |
-| `/jli-ships @<task-folder>` | feature worktree | `agent-4-git` Tasks 5-push / 6 / 7 (push, PR, merge) |
-| `/jli-cleans <worktree>` | develop | `agent-4-git` Task 8 (worktree cleanup + refresh develop) |
+| Command                                    | Runs from        | Replaces (agent)                                          |
+| ------------------------------------------ | ---------------- | --------------------------------------------------------- |
+| `/jli-sets-up <issue-num \| specs-folder>` | develop          | `agent-4-git` Tasks 1–2 (fetch + worktree)                |
+| `/jli-writes-spec @<task-folder>`          | feature worktree | `agent-1-specs`                                           |
+| `/jli-verifies-security @<task-folder>`    | feature worktree | `agent-5-security`                                        |
+| `/jli-writes-tests-spec @<task-folder>`    | feature worktree | `agent-3-test-writer` (pass 1: test cases)                |
+| `/jli-codes @<task-folder>`                | feature worktree | `agent-2-coder`                                           |
+| `/jli-reviews-code @<task-folder>`         | feature worktree | `agent-6-reviewer`                                        |
+| `/jli-writes-tests @<task-folder>`         | feature worktree | `agent-3-test-writer` (pass 2: `*.spec.ts`)               |
+| `/jli-runs-tests @<task-folder>`           | feature worktree | `agent-3-test-runner`                                     |
+| `/jli-commits @<task-folder>`              | feature worktree | `agent-4-git` commit tasks (3 / 3.5 / 3.7 / 4 / 5-commit) |
+| `/jli-ships @<task-folder>`                | feature worktree | `agent-4-git` Tasks 5-push / 6 / 7 (push, PR, merge)      |
+| `/jli-cleans <worktree>`                   | develop          | `agent-4-git` Task 8 (worktree cleanup + refresh develop) |
+| `/jli-reviews-specs <pr-num>`              | feature worktree | _(new — no agent equivalent)_                             |
+
+`/jli-reviews-specs` is an on-demand review entry, not a linear step: after the spec phase
+ships in a PR, it collects the human feedback left on that PR (or given in chat when there is
+no PR), reviews all spec-phase artifacts together — business specs, security specs, test
+specs, and ADR(s) — for coherence with each other and with the feedback, and loops back into
+`/jli-writes-spec` to amend. It runs from the feature worktree like the other phase commands;
+if that worktree was cleaned up after the spec PR merged, it first recreates the sibling
+worktree on the PR branch (the PR supplies the branch).
 
 `agent-0-orchestrator` is **dissolved** into the "Next" hint at the end of each command — no
 command replaces it. The deprecated agents (`agent-0` through `agent-6`) are maintained via
@@ -69,17 +117,41 @@ is self-contained.
 
 ## The chain
 
-The full workflow, including the two-editor split and the loop-backs:
+Two diagrams: the **entry modes** (how `/jli-sets-up` gets you onto the chain) and the
+**full chain** (the phase flow and loop-backs once you are on it).
+
+### Entry modes
 
 ```mermaid
 flowchart TD
-    subgraph INST1["VSCode instance 1 — develop worktree"]
+    setup["/jli-sets-up"]
+    setup -->|"Mode A: issue #, no spec yet"| a["/jli-writes-spec<br/>flat issue-&lt;id&gt;-&lt;slug&gt;/"]
+    setup -->|"Mode B: merged-spec folder"| b["resume at first phase not done<br/>usually /jli-codes · flat folder"]
+    setup -->|"sub-issue of a merged parent"| c["/jli-codes<br/>parent specs + sub-issue-&lt;n&gt;/ subfolder"]
+
+    classDef mode fill:#eef,stroke:#557,stroke-width:1px;
+    class setup mode;
+```
+
+Mode A and Mode B (whole-feature) use a **flat** task folder — `issue-<id>-<slug>/` holds
+every artifact. The sub-issue variant is **nested**: shared specs stay in the parent
+`issue-<parent-id>-<parent-slug>/`, and each sub-issue's outputs go in its own
+`sub-issue-<n>/` subfolder.
+
+### Full chain
+
+The phase flow, the two-editor split, and the loop-backs:
+
+```mermaid
+flowchart TD
+    subgraph INST1["Git Bash — develop worktree"]
         setup["/jli-sets-up"]
         cleanup["/jli-cleans &lt;worktree&gt;"]
     end
 
-    subgraph INST2["VSCode instance 2 — feature worktree"]
+    subgraph INST2["VSCode — feature worktree"]
         direction TB
+        reviewspecs["/jli-reviews-specs &lt;pr-num&gt;"]
         spec["/jli-writes-spec"] --> sec["/jli-verifies-security"]
         sec --> tw1["/jli-writes-tests-spec"]
         tw1 --> code["/jli-codes"]
@@ -96,6 +168,7 @@ flowchart TD
     trun -. "failed: code bug" .-> code
     trun -. "failed: bad test" .-> tw2
     code -. "review specs" .-> spec
+    reviewspecs -. "PR feedback: review all specs + ADR, amend" .-> spec
 
     commit{{"/jli-commits — run after every phase<br/>(between each step above and the next)"}}
     commit -. "each phase" .-> INST2
@@ -111,12 +184,11 @@ flowchart TD
     class clear reset;
 ```
 
-Setup (`/jli-sets-up`) and cleanup (`/jli-cleans`) run in the **develop-worktree
-editor**; every phase command runs in a **separate editor window** opened on the feature
+Setup (`/jli-sets-up`) and cleanup (`/jli-cleans`) run in Git Bash (no need for VSCode); a **VSCode window** is opened on the feature
 worktree. `/clear` is available at any stage — each command rebuilds what it needs from the
 task folder, so clearing context between steps is safe. The same chain in text:
 
-```
+```plaintext
 [develop worktree]
 /jli-sets-up
   > code <worktree>            (open the feature worktree; everything below runs there)
@@ -136,10 +208,15 @@ task folder, so clearing context between steps is safe. The same chain in text:
 ```
 
 Loop-backs (each command's hint states the branch it took):
+
 - `/jli-reviews-code` > `status: changes requested` > back to `/jli-codes`.
 - `/jli-runs-tests` > `status: failed` > back to `/jli-codes` if the code is wrong, or to
   `/jli-writes-tests` if the test is wrong (the human diagnoses which from the failure).
 - `/jli-codes` > `status: review specs` > back to `/jli-writes-spec`.
+- `/jli-reviews-specs` > `status: review specs` > back to `/jli-writes-spec` (this loop-back is
+  driven by PR review feedback rather than by the coder; it runs from the feature worktree,
+  reviews all spec-phase artifacts for coherence, and recreates the worktree from the PR branch
+  first if it was cleaned up).
 
 The two test phases are separate commands: `/jli-writes-tests-spec` runs **before** coding
 and writes the plain-language `test-cases.md`; `/jli-writes-tests` runs **after** review and
@@ -158,6 +235,7 @@ confused for one another.
 
 The gate is the human deciding to run the next command. Two points are made explicit in the
 hints:
+
 - `/jli-writes-spec` and `/jli-codes` warn when their artifact contains `### ADR Required` —
   approve the ADR (add it under `docs/decisions/`, update the index) before continuing.
 - `/jli-ships` pauses for confirmation before opening the PR and again before merging,


### PR DESCRIPTION
## Summary

Maintenance of the manual `jli-` command chain. Adds a new review command, gives `/jli-sets-up`
multiple entry modes, and teaches the chain to handle features split into sub-issues.

## Changes

- **New `/jli-reviews-specs`** — reviews and amends merged spec-phase artifacts from PR feedback
  (or chat when there is no PR); can recreate the feature worktree on the PR branch.
- **`/jli-sets-up` entry modes** — from-scratch (issue number), continue-from-merged-spec
  (specs folder, resumes at the first phase not done), and a **sub-issue variant** detected
  from `Sub-Issue`/`Part of #<n>`.
- **Sub-issue task folders** — shared specs stay in the parent `issue-<id>-<slug>/`; each
  sub-issue's outputs go in a `sub-issue-<n>/` subfolder. A uniform rule was added to
  `/jli-codes`, `/jli-reviews-code`, `/jli-writes-tests`, `/jli-runs-tests`, `/jli-commits`,
  `/jli-ships` (read shared from parent, write outputs to the given folder; parse id from
  `issue-<id>-<slug>` or `sub-issue-<id>`).
- **`review specs` loop-back** — `/jli-writes-spec` now locates the feedback
  (`### Specifications Need Review` in `technical-specifications.md`, flat sibling or inside the
  sub-issue subfolder) and amends the shared parent spec.
- **Docs** — `AGENT-COMMAND-MIGRATION.md` split into entry-modes and full-chain diagrams, with
  a new sub-issues section.

## Notes

- Chain invariants preserved (self-contained, argument guard, run location, status-line
  contract, Next hints); no orchestrator vocabulary introduced.
- `.claude/` orchestration files + one root doc only — no product source, tests, or `docs/prompts/` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
