### PR TITLE
fix(pipeline): derive bare repo path via git instead of fixed traversal

### DIFF
--- a/scripts/pipeline/fetch-origin.sh
+++ b/scripts/pipeline/fetch-origin.sh
@@ -6,22 +6,21 @@
 # Ensures the bare repo has `origin` configured with the correct fetch
 # refspec, then fetches all remote refs.
 #
-# <bare-repo-path> defaults to the parent of the worktree that contains
-# this script (i.e. `..` relative to `develop/`), which is correct for
-# all standard pipeline worktrees.
+# <bare-repo-path> defaults to the shared git directory of the worktree
+# this script is run from (via `git rev-parse --git-common-dir`), which
+# is correct regardless of naming/nesting convention.
 #
 # Called automatically by worktree-create.sh. Run standalone when only
 # a fetch is needed (e.g. Task 1 without Task 2).
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEFAULT_BARE="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEFAULT_BARE="$(git rev-parse --path-format=absolute --git-common-dir)"
 BARE_REPO="${1:-$DEFAULT_BARE}"
 
 # Ensure origin remote exists
 if ! git -C "$BARE_REPO" remote get-url origin &>/dev/null; then
-  REMOTE_URL="$(cd "$BARE_REPO/develop" && git remote get-url origin 2>/dev/null || true)"
+  REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
   if [ -z "$REMOTE_URL" ]; then
     echo "ERROR: origin remote not found in bare repo and could not be inferred." >&2
     echo "Run: git -C \"$BARE_REPO\" remote add origin <url>" >&2

--- a/scripts/pipeline/refresh-develop.sh
+++ b/scripts/pipeline/refresh-develop.sh
@@ -9,9 +9,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-DEVELOP="${BARE_REPO}/develop"
+BARE_REPO="$(git rev-parse --path-format=absolute --git-common-dir)"
+DEVELOP="$(pwd)"
 
 echo "==> Fetching origin..."
 git -C "$BARE_REPO" fetch origin

--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -16,16 +16,25 @@
 
 set -euo pipefail
 
-WORKTREE="${1:?Usage: worktree-cleanup.sh <worktree-path>}"
+WORKTREE_ARG="${1:?Usage: worktree-cleanup.sh <worktree-path>}"
 
-BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
+BARE_REPO="$(git rev-parse --path-format=absolute --git-common-dir)"
+REPO_PARENT="$(dirname "$BARE_REPO")"
+
+# Accept either a bare folder name (resolved as a sibling of the bare repo)
+# or an absolute path.
+case "$WORKTREE_ARG" in
+  /*|[A-Za-z]:/*|[A-Za-z]:\\*) WORKTREE="$WORKTREE_ARG" ;;
+  *) WORKTREE="${REPO_PARENT}/${WORKTREE_ARG}" ;;
+esac
+
 WT_NAME="$(basename "$WORKTREE")"
 
 # Read branch name before the worktree is removed
 BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
 
 echo "==> Removing worktree '${WT_NAME}'..."
-git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
+git -C "$BARE_REPO" worktree remove --force "$WORKTREE" || true
 # If git already deregistered the entry, the directory may still exist on disk
 if [ -d "$WORKTREE" ]; then
   rm -rf "$WORKTREE"

--- a/scripts/pipeline/worktree-create.sh
+++ b/scripts/pipeline/worktree-create.sh
@@ -6,9 +6,9 @@
 # Creates a git worktree for a new feature/fix branch, installs npm deps,
 # and prints the absolute worktree path as "Worktree: <path>".
 #
-# Works when called from any worktree (develop/, feat_*/,  ci_*/) because
-# the bare repo is always the parent directory of whichever worktree holds
-# this script.
+# Works when called from any worktree (develop/, feat_*/, ci_*/) because
+# the bare repo's shared git directory is discovered via
+# `git rev-parse --git-common-dir` rather than assumed from folder nesting.
 #
 # Prerequisites: run fetch-origin.sh before this script.
 
@@ -17,17 +17,16 @@ set -euo pipefail
 TYPE="${1:?Usage: worktree-create.sh <type> <slug>}"
 SLUG="${2:?Usage: worktree-create.sh <type> <slug>}"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# scripts/pipeline is 2 levels below the worktree root, which is 1 level
-# below the bare repo: <bare-repo>/<worktree>/scripts/pipeline
-BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BARE_REPO="$(git rev-parse --path-format=absolute --git-common-dir)"
+REPO_PARENT="$(dirname "$BARE_REPO")"
+REPO_NAME="$(basename "$BARE_REPO" .git)"
 
-WT_NAME="${TYPE}_${SLUG}"
+WT_NAME="${REPO_NAME}_${TYPE}-${SLUG}"
 BRANCH="${TYPE}/${SLUG}"
-WT_PATH="${BARE_REPO}/${WT_NAME}"
+WT_PATH="${REPO_PARENT}/${WT_NAME}"
 
 echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
-git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop
+git -C "$BARE_REPO" worktree add "$WT_PATH" -b "$BRANCH" origin/develop
 
 echo "==> Installing npm dependencies in ${WT_PATH}..."
 (cd "$WT_PATH" && npm install --silent)


### PR DESCRIPTION
## Summary
- `scripts/pipeline/refresh-develop.sh`, `fetch-origin.sh`, and `worktree-create.sh` computed the bare repo path with a fixed number of `..` traversals, assuming worktrees are nested subfolders of the bare repo. This repo's actual layout has the bare repo and worktrees as siblings, so the traversal landed on a non-repo parent directory and every git command in these scripts failed with `fatal: not a git repository`.
- `worktree-cleanup.sh` had the same latent bug but happened to work by accident (relative-path collapse quirk); it's now fixed to resolve the real bare repo and the full worktree path instead of relying on that quirk, and no longer silently swallows `worktree remove` failures.
- `worktree-create.sh` also now names new worktrees `<repo-name>_<type>-<slug>`, matching the documented/actual convention (previously `<type>_<slug>`, missing the repo-name prefix).
- All fixes use `git rev-parse --path-format=absolute --git-common-dir`, which resolves the shared git directory correctly regardless of naming/nesting convention.

## Test plan
- [x] Verified `git rev-parse --path-format=absolute --git-common-dir` returns the correct bare repo path from the develop worktree
- [x] Ran `refresh-develop.sh` and confirmed the fetch step now succeeds (previously failed with "not a git repository")
- [ ] Exercise `worktree-create.sh` / `worktree-cleanup.sh` end-to-end on the next real feature cycle

Closes #91