### PR TITLE
ci(commands): script the sub-issue output-folder creation

### DIFF
--- a/.claude/commands/jli-sets-up.md
+++ b/.claude/commands/jli-sets-up.md
@@ -107,9 +107,17 @@ errors that the branch already exists — delete the stale local branch, then re
 **Sub-issue variant:**
 - The shared parent specs folder already exists in the worktree — do NOT recreate, copy, or
   duplicate the shared specs.
-- Create the per-sub-issue subfolder `[worktree]/<parent-folder>/sub-issue-<sub-id>/` (it
-  starts empty; the implementation-phase commands fill it with `technical-specifications.md`,
-  `review-results.md`, and `test-results.md`).
+- Create the per-sub-issue subfolder with the script — it fails loudly if the parent folder
+  is missing (merged spec not actually present) or the subfolder already exists (would
+  otherwise silently reuse stale output from a prior cycle), instead of relying on an ad hoc
+  `mkdir`:
+
+  ```bash
+  bash scripts/pipeline/sub-issue-folder-create.sh [worktree] <parent-id> <parent-slug> <sub-id>
+  ```
+
+  It starts empty; the implementation-phase commands fill it with
+  `technical-specifications.md`, `review-results.md`, and `test-results.md`.
 - The `@`-mention every downstream command takes is this subfolder:
   `docs/prompts/tasks/issue-<parent-id>-<parent-slug>/sub-issue-<sub-id>`.
 

--- a/scripts/pipeline/sub-issue-folder-create.sh
+++ b/scripts/pipeline/sub-issue-folder-create.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/pipeline/sub-issue-folder-create.sh
+#
+# Usage: bash scripts/pipeline/sub-issue-folder-create.sh <worktree-path> <parent-id> <parent-slug> <sub-id>
+#
+# Creates the per-sub-issue output subfolder inside a merged parent spec's
+# task folder, for the sub-issue variant of /jli-sets-up:
+#   <worktree-path>/docs/prompts/tasks/issue-<parent-id>-<parent-slug>/sub-issue-<sub-id>/
+#
+# The subfolder starts empty; downstream jli- commands (jli-codes,
+# jli-reviews-code, jli-runs-tests) fill it with technical-specifications.md,
+# review-results.md, and test-results.md.
+#
+# Fails if the parent task folder is missing (the merged spec must already be
+# present in the worktree) or if the sub-issue subfolder already exists
+# (re-running would silently reuse stale output from a prior cycle).
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: sub-issue-folder-create.sh <worktree-path> <parent-id> <parent-slug> <sub-id>}"
+PARENT_ID="${2:?Usage: sub-issue-folder-create.sh <worktree-path> <parent-id> <parent-slug> <sub-id>}"
+PARENT_SLUG="${3:?Usage: sub-issue-folder-create.sh <worktree-path> <parent-id> <parent-slug> <sub-id>}"
+SUB_ID="${4:?Usage: sub-issue-folder-create.sh <worktree-path> <parent-id> <parent-slug> <sub-id>}"
+
+PARENT_FOLDER="docs/prompts/tasks/issue-${PARENT_ID}-${PARENT_SLUG}"
+SUB_FOLDER="${PARENT_FOLDER}/sub-issue-${SUB_ID}"
+
+if [ ! -d "${WORKTREE}/${PARENT_FOLDER}" ]; then
+  echo "error: parent task folder not found: ${PARENT_FOLDER}" >&2
+  echo "The merged spec must already exist in the worktree before creating a sub-issue subfolder." >&2
+  exit 1
+fi
+
+if [ -e "${WORKTREE}/${SUB_FOLDER}" ]; then
+  echo "error: sub-issue folder already exists: ${SUB_FOLDER}" >&2
+  exit 1
+fi
+
+echo "==> Creating sub-issue folder '${SUB_FOLDER}'..."
+mkdir -p "${WORKTREE}/${SUB_FOLDER}"
+
+echo "Sub-issue folder: ${SUB_FOLDER}"


### PR DESCRIPTION
## Summary
- `/jli-sets-up`'s sub-issue variant created the per-sub-issue output subfolder via a free-form instruction, with no check that the parent spec exists and no guard against clobbering a prior cycle's output (observed: `sub-issue-81/` existed but was silently empty).
- Add `scripts/pipeline/sub-issue-folder-create.sh`, mirroring the existing `worktree-create.sh` pattern, and wire it into `jli-sets-up.md` Step 3 (sub-issue variant).

## Test plan
- [x] Script tested manually against a temp dir: creates the subfolder, fails with a clear error on a missing parent folder, fails with a clear error if the subfolder already exists.
- [x] `jli-sets-up.md` still holds the chain invariants (self-contained, no orchestrator vocabulary, argument guard, run location, status-line contract, Next hint) — only Step 3's sub-issue variant text changed.
- [x] `AGENT-COMMAND-MIGRATION.md` needed no update — it never names individual scripts (same as `worktree-create.sh`), only describes the resulting behavior.
