### PR TITLE
feat(auth): add GitHub OAuth login/logout composable (#82)

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -90,6 +90,7 @@ declare global {
   const useCssModule: typeof import('vue').useCssModule
   const useCssVars: typeof import('vue').useCssVars
   const useDefaultFuelType: typeof import('./src/composables/useDefaultFuelType').useDefaultFuelType
+  const useGitHubAuth: typeof import('./src/composables/useGitHubAuth').useGitHubAuth
   const useId: typeof import('vue').useId
   const useKnownFuelTypes: typeof import('./src/composables/useKnownFuelTypes').useKnownFuelTypes
   const useModel: typeof import('vue').useModel
@@ -126,6 +127,9 @@ declare global {
   // @ts-ignore
   export type { PriceRow } from './src/types/price-row'
   import('./src/types/price-row')
+  // @ts-ignore
+  export type { RepoConfigDraft } from './src/types/repo-config'
+  import('./src/types/repo-config')
   // @ts-ignore
   export type { StationData } from './src/types/station-data'
   import('./src/types/station-data')

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/business-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/business-specifications.md
@@ -16,14 +16,17 @@ This issue is split into sub-issues. Each section below corresponds to one sub-i
 
 ## Sub-Issue A — GitHub OAuth Login / Logout
 
-**Depends on:** nothing
+**Depends on:** nothing for the login/logout logic itself. Rendering that logic in the Settings
+UI (field layout, enabled/disabled states) is Sub-Issue E's responsibility; this sub-issue owns
+only the login-readiness check, auth-state detection, and the login/logout actions themselves,
+which Sub-Issue E's page consumes once built.
 
 ### Rules
 
-1. The user can initiate a GitHub OAuth login flow from the Settings page once `owner/repo`, file path, and `revalidate-cache-days` are all filled in — the "Login with GitHub" button stays disabled until then (see Sub-Issue B). On success, an HTTP-only cookie containing the access token is set by the Netlify function that handles the OAuth callback.
+1. The system exposes a login-readiness check: the user can initiate the GitHub OAuth login flow once repository configuration (`owner/repo`, file path, and `revalidate-cache-days`) is complete and valid. Sub-Issue E's Settings page consumes this check to decide when its "Login with GitHub" button is enabled (see Sub-Issue E, rule 4). On success, an HTTP-only cookie containing the access token is set by the Netlify function that handles the OAuth callback.
 2. The login flow uses the GitHub OAuth App authorization URL. The app requests only the minimum scopes needed to read and write a single file in one user-owned repository (`repo` scope or `public_repo` if the target repo is always public — see sub-issue B).
 3. After the callback, the user is redirected back to the Settings page with a visible success or error state.
-4. The user can log out; logout clears the HTTP-only cookie only — it does not disconnect the account from GitHub or touch stored data. The repo config (`owner/repo`, file path, `revalidate-cache-days`) and station data both remain in IndexedDB and in the Settings UI; the config fields become editable again (see Sub-Issue E).
+4. The user can log out; logout clears the HTTP-only cookie only — it does not disconnect the account from GitHub or touch stored data. The repo config (`owner/repo`, file path, `revalidate-cache-days`) and station data both remain in IndexedDB. Whether the config fields become editable again in the UI is Sub-Issue E's concern (see Sub-Issue E, rule 3).
 5. If the cookie is absent or expired when the app loads, the user is treated as unauthenticated; no error is shown unless they attempt a sync, add, update or delete action.
 6. The HTTP-only cookie has a lifetime of **8 hours** (matching a typical browser session). After expiry, the user must re-authenticate. The cookie is not refreshed automatically; expiry is detected on the next GitHub API call returning 401.
 
@@ -34,13 +37,16 @@ This issue is split into sub-issues. Each section below corresponds to one sub-i
 
 ### How to test locally
 
+*(Verifying the field-enabled/disabled states referenced above requires Sub-Issue E's Settings
+page. Until then, verify the login-readiness check and auth state directly.)*
+
 1. Start the app with `netlify dev` so Netlify Functions are available.
-2. Navigate to the Settings page; confirm a "Login with GitHub" button is visible but disabled, and the `owner/repo`, file path, and `revalidate-cache-days` fields are enabled and empty.
-3. Fill in `owner/repo`, file path, and `revalidate-cache-days`; confirm "Login with GitHub" becomes enabled, then click it; confirm the browser redirects to GitHub's OAuth authorization page.
-4. Authorize the app on GitHub; confirm the browser is redirected back to the Settings page with a success indicator and the `owner/repo`/file path fields are now disabled (read-only) while `revalidate-cache-days` stays editable.
-5. Reload the page; confirm the user remains logged in (cookie persists across reloads) and the fields keep their disabled/enabled states.
-6. Click "Logout"; confirm the `owner/repo`/file path fields become enabled again (still holding their previous values) and no token cookie is present (inspect cookies in DevTools → Application → Cookies).
-7. To simulate an expired/absent cookie: delete the cookie in DevTools, reload the page, and confirm the user is treated as unauthenticated with no error banner and the config fields are enabled.
+2. With no cookie present, confirm the login-readiness check reports "not ready" while repo config is incomplete, and "ready" once `owner/repo`, file path, and `revalidate-cache-days` are all valid.
+3. Trigger the login action; confirm the browser redirects to GitHub's OAuth authorization page.
+4. Authorize the app on GitHub; confirm the browser is redirected back to the Settings page with a success indicator and the cookie is present.
+5. Reload the page; confirm the user remains logged in (cookie persists across reloads).
+6. Trigger the logout action; confirm no token cookie is present afterward (inspect cookies in DevTools → Application → Cookies).
+7. To simulate an expired/absent cookie: delete the cookie in DevTools, reload the page, and confirm the user is treated as unauthenticated with no error banner.
 
 #### Going live
 
@@ -149,6 +155,7 @@ This issue is split into sub-issues. Each section below corresponds to one sub-i
 1. The Settings page gains a "GitHub Sync" section with: login/logout control, `owner/repo` field, file path field, and a `revalidate-cache-days` number input.
 2. `revalidate-cache-days` accepts a positive integer; values ≤ 0 are rejected with an inline validation message.
 3. `owner/repo` and file path are disabled once the user is authenticated — a message instructs the user to log out to change them (Sub-Issue B, rule 3). `revalidate-cache-days` is always editable, whether authenticated or not.
+4. The "Login with GitHub" button's enabled/disabled state is driven by Sub-Issue A's login-readiness check (Sub-Issue A, rule 1), evaluated against the current values of `owner/repo`, file path, and `revalidate-cache-days`.
 
 ### How to test locally
 

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-82/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-82/technical-specifications.md
@@ -1,84 +1,63 @@
 # Technical Specifications — Sub-Issue A (#82): GitHub OAuth Login / Logout
 
+## Re-run context
+
+This command previously ended with `status: review specs` because `test-cases.md` assumed a
+Settings page (Sub-Issues B/E) that did not exist yet. That mismatch has since been resolved by
+rescoping `business-specifications.md` and `test-cases.md` (commits `b393c8d`, `f8dc3c6`) to scope
+Sub-Issue A to the login-readiness check, auth-state detection, and login/logout actions only. The
+composable committed in `5c8d4d7` already satisfies every rescoped Sub-Issue A rule and test case
+(A-1 through A-10) without changes. This run made one small addition (below) and re-verified the
+rest.
+
 ## Summary of files created/changed
 
-- `src/composables/useGitHubAuth.ts` — new. Singleton composable (ADR-002) owning login/logout,
-  auth-callback-param handling, and authenticated/error state: `isAuthenticated`, `authError`,
-  `initializeAuthState`, `canInitiateLogin`, `login`, `logout`, `handleUnauthorized`.
-
-No Settings page, repo-config fields, or IndexedDB schema for `owner`/`repo`/`revalidate-cache-days`
-were created — see "Specifications Need Review" below.
+- `src/types/repo-config.ts` — new. Extracted `RepoConfigDraft` (previously declared inline in
+  `useGitHubAuth.ts`) into `src/types/`, per this project's "type-first" convention (types are
+  defined in `src/types/` before the logic that uses them).
+- `src/composables/useGitHubAuth.ts` — changed. Removed the inline `RepoConfigDraft` interface;
+  imports it from `@/types/repo-config` instead. No behavioral change.
 
 ## Non-trivial decisions
 
-- **Composable-only scope, no Settings page.** Sub-Issue A's own test cases (A-1, A-2, A-3, A-5,
-  A-6, A-7) reference a Settings page with `owner/repo`, file path, and `revalidate-cache-days`
-  fields, but that page and its persistence/validation are owned by Sub-Issues B (#83) and E (#84),
-  neither implemented yet. Per explicit user direction, this command implements only the
-  login/logout composable and leaves the page to those sub-issues, accepting that several test
-  cases are not satisfiable yet (see below).
-- **`canInitiateLogin(config)` takes the repo-config draft as a parameter instead of owning it.**
-  Business rule 1 ties the login button's enabled state to three field values this composable
-  does not own. Accepting them as a parameter lets the future Settings page (Sub-Issue E) reuse
-  this gating logic without `useGitHubAuth` reaching into IndexedDB keys that belong to Sub-Issue B.
-- **Auth state persisted via the existing IndexedDB wrapper (`get`/`set`/`del`), not `localStorage`.**
-  ADR-008 mandates IndexedDB for client-side persistence in this app; introducing a second storage
-  mechanism for one boolean would contradict that decision without a stated reason to deviate.
-- **The persisted flag is a non-sensitive UI hint, not an auth check.** The `gh_token` cookie is
-  HttpOnly (ADR-011) — the SPA cannot read it to confirm the user is still logged in. `initializeAuthState`
-  trusts the `auth=success` redirect param (set only by the trusted server-side callback function)
-  and, on later reloads, a persisted boolean written at that same moment. This means a user who
-  manually crafts `?auth=success` in the URL would see a false "authenticated" UI state; this is
-  bounded because no real GitHub API call succeeds without the actual cookie, and `handleUnauthorized`
-  (invoked by future Sub-Issue C/D composables on a 401) corrects it on the first real request.
-  Verifying auth server-side on every load would need a dedicated status endpoint, out of scope here.
-- **`handleUnauthorized` is exported but has no caller yet.** Security-guidelines.md rule 5 assigns
-  the UI re-auth prompt to "the composable that calls the proxy" — that composable belongs to
-  Sub-Issues C/D. `useGitHubAuth` exposes the hook now so those composables have a stable contract
-  to call into once built, rather than inventing a second copy of the same state-clearing logic later.
-- **`requestServerLogout` swallows fetch failures.** `logout()` always clears the local UI state
-  even if the network call to the Netlify logout function fails, so a flaky connection cannot leave
-  the UI stuck showing an authenticated session the user explicitly tried to leave (self-review fix).
+- **`RepoConfigDraft` moved to `src/types/`, not kept inline.** It's consumed by
+  `canInitiateLogin` here, but its fields (`owner/repo`, file path, `revalidate-cache-days`) are
+  owned by Sub-Issue B and rendered by Sub-Issue E — both will need the same shape. A single
+  exported type in `src/types/` avoids each sub-issue declaring its own copy.
+- **No other code changes.** The composable already implements every rescoped Sub-Issue A rule
+  (business-specifications.md rules 1, 3–6; edge cases) and passes a manual trace against all ten
+  rescoped test cases:
+  - A-1/A-2 — `canInitiateLogin` returns `false`/`true` based on `hasRequiredRepoConfig` and
+    `hasValidCacheDays`.
+  - A-3 — `login()` sets `window.location.href` to the OAuth start endpoint.
+  - A-4/A-9 — `initializeAuthState` reads the `auth` query param, applies success/error state via
+    `applyAuthCallbackResult`, and strips the param via `stripAuthCallbackParam`.
+  - A-5/A-8 — `restoreStoredAuthState` reads the persisted flag and always clears `authError`,
+    so a plain reload with no callback param shows the stored state with no stale error.
+  - A-6/A-7 — `logout()` only touches the `githubAuthenticated` IndexedDB key (never station data
+    or repo config keys) and always clears local state even when `requestServerLogout` rejects.
+  - A-10 — `handleUnauthorized()` is exported for the future proxy-calling composable (Sub-Issues
+    C/D) to invoke on a 401.
+- **Deviation from ADR-011's stated auth-detection method, carried over from the prior run.**
+  ADR-011 says the SPA detects auth state "by calling the GitHub API proxy... checking whether it
+  returns a valid response or a 401." That proxy-calling composable doesn't exist yet (Sub-Issues
+  C/D), so `initializeAuthState` instead trusts a persisted non-sensitive IndexedDB boolean,
+  written only in response to the trusted server-side `auth=success` redirect. This was already
+  documented and accepted in the prior run; carrying it forward rather than re-litigating it here.
+  It remains bounded: no real GitHub API call succeeds without the actual `HttpOnly` cookie, and
+  `handleUnauthorized` corrects the flag on the first real 401 once Sub-Issues C/D wire it in.
 
 ## Self-code review
 
-Three issues found and fixed after the first draft:
+No new logic was introduced (only a type extraction), so no new bugs were introduced. Re-checked
+the three fixes from the prior run's self-review are still in place and unaffected by the type
+move:
 
-1. **`logout()` could throw on network failure, leaving the UI stuck authenticated.** The `fetch`
-   call to `github-auth-logout` was unguarded; any network error would reject before the local
-   `isAuthenticated`/`authError` state was cleared. Extracted `requestServerLogout()`, which
-   catches and discards the error — the client-side state now always clears on explicit logout.
-2. **`stripAuthCallbackParam` relied on implicit `URL` → string coercion for `history.replaceState`.**
-   Changed to an explicit `url.toString()` call instead of passing the `URL` object directly.
-3. **Stale `authError` could survive across composable re-initialization within the same SPA session.**
-   `restoreStoredAuthState` only set `isAuthenticated` and left a prior `authError` (e.g. from an
-   earlier failed action) visible on a later, unrelated visit to the auth-consuming page. Routed it
-   through the shared `updateAuthState(authenticated, null)` helper so every explicit re-init clears
-   any leftover error, matching business rule 5 ("no error is shown unless [a sync action] is attempted").
+1. `requestServerLogout()` still catches/discards `fetch` failures so `logout()` cannot leave the
+   UI stuck authenticated on a network error (A-7).
+2. `stripAuthCallbackParam` still calls `url.toString()` explicitly rather than relying on
+   implicit `URL` coercion.
+3. `restoreStoredAuthState` still routes through `updateAuthState(stored === true, null)`, clearing
+   any stale `authError` on every re-initialization.
 
-## Specifications Need Review
-
-Please review current code and results.
-
-The following `test-cases.md` scenarios for Sub-Issue A assume a Settings page with `owner/repo`,
-file path, and `revalidate-cache-days` fields already exists, but that page is owned by Sub-Issues B
-(#83) and E (#84), neither implemented at the time of this command:
-
-- **A-1** — fields enabled / login button disabled on first visit: no page exists to hold these fields.
-- **A-2** — login button disabled until all three fields are filled: same, plus depends on B/E's field state.
-- **A-5** — `owner/repo`/file path disabled on reload while authenticated: field disable/enable state is Sub-Issue E's responsibility.
-- **A-6** — logout re-enables `owner/repo`/file path fields: same.
-- **A-7** — config fields enabled when unauthenticated: same.
-
-`useGitHubAuth.ts` implements everything Sub-Issue A can own independently (`login`, `logout`,
-callback-param handling, `canInitiateLogin` as a pure function of an externally-supplied config,
-`handleUnauthorized`), and A-3, A-8 are satisfiable once a page wires this composable in. A-4, A-9
-are backend behavior already covered by Sub-Issue F (#81). A-10 is satisfiable once Sub-Issues C/D
-call `handleUnauthorized` on a 401.
-
-Recommend either: (a) re-sequencing so Sub-Issue E's page (or a minimal shared fields component) is
-built before or alongside Sub-Issue A so its own test cases are checkable in isolation, or (b) moving
-A-1, A-2, A-5, A-6, A-7 into Sub-Issue E's test-cases.md, since they test field behavior E owns, and
-leaving Sub-Issue A's test cases scoped to what `useGitHubAuth` alone controls.
-
-status: review specs
+status: ready

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-82/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-82/technical-specifications.md
@@ -1,0 +1,84 @@
+# Technical Specifications — Sub-Issue A (#82): GitHub OAuth Login / Logout
+
+## Summary of files created/changed
+
+- `src/composables/useGitHubAuth.ts` — new. Singleton composable (ADR-002) owning login/logout,
+  auth-callback-param handling, and authenticated/error state: `isAuthenticated`, `authError`,
+  `initializeAuthState`, `canInitiateLogin`, `login`, `logout`, `handleUnauthorized`.
+
+No Settings page, repo-config fields, or IndexedDB schema for `owner`/`repo`/`revalidate-cache-days`
+were created — see "Specifications Need Review" below.
+
+## Non-trivial decisions
+
+- **Composable-only scope, no Settings page.** Sub-Issue A's own test cases (A-1, A-2, A-3, A-5,
+  A-6, A-7) reference a Settings page with `owner/repo`, file path, and `revalidate-cache-days`
+  fields, but that page and its persistence/validation are owned by Sub-Issues B (#83) and E (#84),
+  neither implemented yet. Per explicit user direction, this command implements only the
+  login/logout composable and leaves the page to those sub-issues, accepting that several test
+  cases are not satisfiable yet (see below).
+- **`canInitiateLogin(config)` takes the repo-config draft as a parameter instead of owning it.**
+  Business rule 1 ties the login button's enabled state to three field values this composable
+  does not own. Accepting them as a parameter lets the future Settings page (Sub-Issue E) reuse
+  this gating logic without `useGitHubAuth` reaching into IndexedDB keys that belong to Sub-Issue B.
+- **Auth state persisted via the existing IndexedDB wrapper (`get`/`set`/`del`), not `localStorage`.**
+  ADR-008 mandates IndexedDB for client-side persistence in this app; introducing a second storage
+  mechanism for one boolean would contradict that decision without a stated reason to deviate.
+- **The persisted flag is a non-sensitive UI hint, not an auth check.** The `gh_token` cookie is
+  HttpOnly (ADR-011) — the SPA cannot read it to confirm the user is still logged in. `initializeAuthState`
+  trusts the `auth=success` redirect param (set only by the trusted server-side callback function)
+  and, on later reloads, a persisted boolean written at that same moment. This means a user who
+  manually crafts `?auth=success` in the URL would see a false "authenticated" UI state; this is
+  bounded because no real GitHub API call succeeds without the actual cookie, and `handleUnauthorized`
+  (invoked by future Sub-Issue C/D composables on a 401) corrects it on the first real request.
+  Verifying auth server-side on every load would need a dedicated status endpoint, out of scope here.
+- **`handleUnauthorized` is exported but has no caller yet.** Security-guidelines.md rule 5 assigns
+  the UI re-auth prompt to "the composable that calls the proxy" — that composable belongs to
+  Sub-Issues C/D. `useGitHubAuth` exposes the hook now so those composables have a stable contract
+  to call into once built, rather than inventing a second copy of the same state-clearing logic later.
+- **`requestServerLogout` swallows fetch failures.** `logout()` always clears the local UI state
+  even if the network call to the Netlify logout function fails, so a flaky connection cannot leave
+  the UI stuck showing an authenticated session the user explicitly tried to leave (self-review fix).
+
+## Self-code review
+
+Three issues found and fixed after the first draft:
+
+1. **`logout()` could throw on network failure, leaving the UI stuck authenticated.** The `fetch`
+   call to `github-auth-logout` was unguarded; any network error would reject before the local
+   `isAuthenticated`/`authError` state was cleared. Extracted `requestServerLogout()`, which
+   catches and discards the error — the client-side state now always clears on explicit logout.
+2. **`stripAuthCallbackParam` relied on implicit `URL` → string coercion for `history.replaceState`.**
+   Changed to an explicit `url.toString()` call instead of passing the `URL` object directly.
+3. **Stale `authError` could survive across composable re-initialization within the same SPA session.**
+   `restoreStoredAuthState` only set `isAuthenticated` and left a prior `authError` (e.g. from an
+   earlier failed action) visible on a later, unrelated visit to the auth-consuming page. Routed it
+   through the shared `updateAuthState(authenticated, null)` helper so every explicit re-init clears
+   any leftover error, matching business rule 5 ("no error is shown unless [a sync action] is attempted").
+
+## Specifications Need Review
+
+Please review current code and results.
+
+The following `test-cases.md` scenarios for Sub-Issue A assume a Settings page with `owner/repo`,
+file path, and `revalidate-cache-days` fields already exists, but that page is owned by Sub-Issues B
+(#83) and E (#84), neither implemented at the time of this command:
+
+- **A-1** — fields enabled / login button disabled on first visit: no page exists to hold these fields.
+- **A-2** — login button disabled until all three fields are filled: same, plus depends on B/E's field state.
+- **A-5** — `owner/repo`/file path disabled on reload while authenticated: field disable/enable state is Sub-Issue E's responsibility.
+- **A-6** — logout re-enables `owner/repo`/file path fields: same.
+- **A-7** — config fields enabled when unauthenticated: same.
+
+`useGitHubAuth.ts` implements everything Sub-Issue A can own independently (`login`, `logout`,
+callback-param handling, `canInitiateLogin` as a pure function of an externally-supplied config,
+`handleUnauthorized`), and A-3, A-8 are satisfiable once a page wires this composable in. A-4, A-9
+are backend behavior already covered by Sub-Issue F (#81). A-10 is satisfiable once Sub-Issues C/D
+call `handleUnauthorized` on a 401.
+
+Recommend either: (a) re-sequencing so Sub-Issue E's page (or a minimal shared fields component) is
+built before or alongside Sub-Issue A so its own test cases are checkable in isolation, or (b) moving
+A-1, A-2, A-5, A-6, A-7 into Sub-Issue E's test-cases.md, since they test field behavior E owns, and
+leaving Sub-Issue A's test cases scoped to what `useGitHubAuth` alone controls.
+
+status: review specs

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-82/test-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-82/test-results.md
@@ -1,0 +1,25 @@
+# Test Results — Issue #64: GitHub Repository Preferences (Sub-Issue A / #82)
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.0) from the
+`french-gas-stations-scraper_feat-github-repo-preferences` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md), including the full
+existing suite (291 test files) alongside the new `src/composables/useGitHubAuth.spec.ts`.
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+291 test files, 346 tests total — all passed.
+
+- Test files: 291 passed
+- Tests: 346 passed (0 failed)
+- Duration: ~5 seconds
+
+status: passed

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/test-cases.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/test-cases.md
@@ -2,57 +2,60 @@
 
 ## Sub-Issue A — GitHub OAuth Login / Logout
 
-### A-1: Fields enabled and login button disabled on first visit
-- **Precondition:** No `gh_token` cookie is set. `owner/repo`, file path, and `revalidate-cache-days` are empty.
-- **Action:** Navigate to the Settings page.
-- **Expected:** The `owner/repo`, file path, and `revalidate-cache-days` fields are enabled and empty. A "Login with GitHub" button is visible but disabled.
+*(Rescoped: this sub-issue owns only the login-readiness check, auth-state detection, and the
+login/logout actions — not the Settings page or its fields, which are Sub-Issue E's
+responsibility. Field-visibility scenarios formerly listed here now live under Sub-Issue E.)*
 
-### A-2: Login button stays disabled until all config fields are filled in
-- **Precondition:** No `gh_token` cookie is set. `owner/repo` and file path are filled in; `revalidate-cache-days` is empty.
-- **Action:** Observe the "Login with GitHub" button.
-- **Expected:** The button remains disabled.
+### A-1: Login-readiness check reports not ready when repo config is incomplete
+- **Precondition:** A repo-config draft (`owner/repo`, file path, `revalidate-cache-days`) has at least one value empty or invalid.
+- **Action:** Evaluate the login-readiness check against the draft.
+- **Expected:** The check reports "not ready".
 
-### A-3: Login flow redirects to GitHub authorization page
-- **Precondition:** No `gh_token` cookie is set. `owner/repo`, file path, and `revalidate-cache-days` are all filled in, enabling the "Login with GitHub" button.
-- **Action:** Click "Login with GitHub" on the Settings page.
-- **Expected:** The browser redirects to GitHub's OAuth authorization URL (`github.com/login/oauth/authorize`), including the `client_id`, `scope`, and `state` query parameters.
+### A-2: Login-readiness check reports ready when repo config is complete and valid
+- **Precondition:** `owner/repo` and file path are non-empty; `revalidate-cache-days` is a positive integer.
+- **Action:** Evaluate the login-readiness check against the draft.
+- **Expected:** The check reports "ready".
 
-### A-4: Successful OAuth callback sets cookie and redirects to Settings
-*(Manual/integration test — exercises the `github-auth-callback` Netlify function via a real OAuth redirect; not verifiable in a Vitest unit test.)*
-- **Precondition:** The user completes GitHub authorization (code returned by GitHub).
-- **Action:** The `github-auth-callback` Netlify function receives the `code` and valid `state` parameter.
-- **Expected:** The function exchanges the code for a token, sets the `gh_token` cookie (`HttpOnly`, `SameSite=Strict`, `Max-Age=28800`), and redirects to `/settings?auth=success`. The Settings page shows an authenticated state.
+### A-3: Triggering login navigates to the GitHub OAuth start endpoint
+- **Precondition:** None.
+- **Action:** Trigger the login action.
+- **Expected:** The browser navigates to the GitHub OAuth start endpoint. (That endpoint's own redirect to GitHub's authorization page with `client_id`/`scope`/`state` is Sub-Issue F's behavior, covered by F-1.)
 
-### A-5: Authenticated state persists across page reloads
-- **Precondition:** `gh_token` cookie is present and valid.
-- **Action:** Reload the Settings page.
-- **Expected:** The user remains authenticated. `owner/repo` and file path fields are disabled (read-only), showing their saved values. `revalidate-cache-days` remains enabled.
+### A-4: A successful-callback indicator marks the user authenticated
+- **Precondition:** The app loads with a success indicator present in the URL (set by Sub-Issue F's callback function after a completed OAuth exchange, covered by F-2).
+- **Action:** The app processes the page load.
+- **Expected:** The user is shown as authenticated; no error is present; the success indicator is removed from the URL afterward.
 
-### A-6: Logout clears the cookie and re-enables config fields
-- **Precondition:** User is authenticated (`gh_token` cookie present); `owner/repo` and file path are disabled and show saved values.
-- **Action:** Click "Logout".
-- **Expected:** The `gh_token` cookie is cleared. `owner/repo` and file path fields become enabled again, still showing their previous values. Station data in IndexedDB is unchanged.
+### A-5: Authenticated state persists across a plain reload
+- **Precondition:** The user previously completed a successful login in this browser. The URL carries no callback indicator this time.
+- **Action:** Reload the page.
+- **Expected:** The user remains shown as authenticated.
 
-### A-7: Absent or expired cookie — unauthenticated state with no error banner
-*(Manual test — requires deleting/expiring a browser cookie.)*
-- **Precondition:** The `gh_token` cookie is absent or expired.
-- **Action:** Navigate to the Settings page without performing any sync action.
-- **Expected:** The user is shown as unauthenticated. No error banner is displayed. Config fields are enabled.
+### A-6: Logout clears the authenticated state without touching station data
+- **Precondition:** The user is shown as authenticated.
+- **Action:** Trigger the logout action.
+- **Expected:** The user is shown as unauthenticated afterward, with no error. Station data and repo config values in IndexedDB are unchanged.
 
-### A-8: OAuth callback with error parameter shows error in UI
-- **Precondition:** GitHub returns `error=access_denied` in the callback URL.
-- **Action:** The `github-auth-callback` function receives the error parameter.
-- **Expected:** The function redirects to `/settings?auth=error`. The Settings page displays a human-readable error message. No cookie is set.
+### A-7: Logout clears local authenticated state even if the server-side call fails
+- **Precondition:** The user is shown as authenticated; the network request to the logout endpoint fails (e.g. offline).
+- **Action:** Trigger the logout action.
+- **Expected:** The user is still shown as unauthenticated locally afterward.
 
-### A-9: state parameter mismatch in OAuth callback is rejected
-- **Precondition:** The `state` parameter in the callback does not match the one generated at login start.
-- **Action:** The `github-auth-callback` function receives a mismatched `state`.
-- **Expected:** The function does not exchange the code for a token. The response is an error redirect (or equivalent failure). No cookie is set.
+### A-8: No prior session and no callback indicator — unauthenticated with no error banner
+- **Precondition:** The user has never logged in. The URL carries no success/error indicator.
+- **Action:** Load the app.
+- **Expected:** The user is shown as unauthenticated. No error is displayed.
 
-### A-10: Token expiry detected on GitHub API call
-- **Precondition:** User has a `gh_token` cookie that has been revoked on GitHub's side (simulated by revoking in GitHub OAuth settings).
-- **Action:** User triggers any action that calls the GitHub API proxy.
-- **Expected:** The proxy receives a 401 from GitHub, clears the `gh_token` cookie, and the UI prompts the user to log in again.
+### A-9: An error-callback indicator shows a human-readable error
+- **Precondition:** The app loads with an error indicator present in the URL (set by Sub-Issue F's callback function after a failed OAuth exchange, covered by F-3).
+- **Action:** The app processes the page load.
+- **Expected:** The user is shown as unauthenticated. A human-readable error message is displayed. The error indicator is removed from the URL afterward.
+
+### A-10: A 401 from a GitHub API call clears the authenticated state and prompts re-login
+*(Verifiable end-to-end once Sub-Issues C/D wire their proxy-calling composable(s) into this hook.)*
+- **Precondition:** The user is shown as authenticated; a GitHub API call made through the proxy returns 401 (e.g. the token was revoked).
+- **Action:** The calling composable reports the 401 to the auth composable.
+- **Expected:** The user is shown as unauthenticated afterward, with a message prompting re-login.
 
 ---
 
@@ -214,6 +217,11 @@
 - **Precondition:** User is authenticated; `owner/repo` and file path are disabled.
 - **Action:** Click "Logout".
 - **Expected:** `owner/repo` and file path fields become enabled again, retaining their values. `revalidate-cache-days` remains enabled throughout (it was never disabled).
+
+### E-7: Login button reflects the login-readiness check
+- **Precondition:** User is unauthenticated on the Settings page. `owner/repo` and file path are filled in; `revalidate-cache-days` is empty.
+- **Action:** Observe the "Login with GitHub" button, then fill in a valid positive integer for `revalidate-cache-days`.
+- **Expected:** The button is disabled while any field is empty or invalid, and becomes enabled once `owner/repo`, file path, and `revalidate-cache-days` are all filled in and valid (Sub-Issue A's login-readiness check).
 
 ---
 

--- a/src/composables/useGitHubAuth.spec.ts
+++ b/src/composables/useGitHubAuth.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for useGitHubAuth composable — Sub-Issue A, issue #64.
+ *
+ * useGitHubAuth is a singleton composable (ADR-002): the module-level refs
+ * are shared across all consumers. vi.resetModules() + dynamic import() is
+ * used to get a fresh module instance (and therefore fresh reactive state)
+ * for each test, following the pattern established in
+ * useDefaultFuelType.spec.ts.
+ *
+ * IndexedDB is mocked with an in-memory Map via vi.mock, same pattern as
+ * useDefaultFuelType.spec.ts / useStationStorage.spec.ts.
+ *
+ * `window.location` and `window.history.replaceState` are replaced with
+ * plain, fully-controlled stubs (vi.stubGlobal / vi.spyOn) rather than
+ * relying on the test environment's real navigation behavior, so these
+ * tests only assert what useGitHubAuth itself does with those values.
+ *
+ * `authError`'s exact message text is not part of the composable's public
+ * API (the constants are module-private), but is asserted verbatim here to
+ * match the source — keep in sync with CALLBACK_ERROR_MESSAGE /
+ * SESSION_EXPIRED_MESSAGE in useGitHubAuth.ts if those change.
+ *
+ * Scenarios covered (test-cases.md, Sub-Issue A):
+ *   A-1  — login-readiness check reports not ready when repo config is incomplete
+ *   A-2  — login-readiness check reports ready when repo config is complete and valid
+ *   A-3  — triggering login navigates to the GitHub OAuth start endpoint
+ *   A-4  — a successful-callback indicator marks the user authenticated
+ *   A-5  — authenticated state persists across a plain reload
+ *   A-6  — logout clears the authenticated state without touching station data
+ *   A-7  — logout clears local authenticated state even if the server-side call fails
+ *   A-8  — no prior session and no callback indicator — unauthenticated with no error banner
+ *   A-9  — an error-callback indicator shows a human-readable error
+ *   A-10 — a 401 from a GitHub API call clears the authenticated state and prompts re-login
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RepoConfigDraft } from '@/types/repo-config'
+
+// ---------------------------------------------------------------------------
+// In-memory IndexedDB mock
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, unknown>()
+
+vi.mock('@/utils/indexedDb', () => ({
+  get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+  set: vi.fn((key: string, value: unknown) => {
+    store.set(key, value)
+    return Promise.resolve()
+  }),
+  del: vi.fn((key: string) => {
+    store.delete(key)
+    return Promise.resolve()
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Constants mirrored from useGitHubAuth.ts (module-private, not exported)
+// ---------------------------------------------------------------------------
+
+const AUTH_STATE_KEY = 'githubAuthenticated'
+const LOGIN_START_PATH = '/.netlify/functions/github-auth-start'
+const LOGOUT_PATH = '/.netlify/functions/github-auth-logout'
+const CALLBACK_ERROR_MESSAGE = 'La connexion à GitHub a échoué. Merci de réessayer.'
+const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: RepoConfigDraft = {
+  ownerRepo: 'alice/my-stations',
+  filePath: 'stations.json',
+  revalidateCacheDays: 7,
+}
+
+async function freshComposable() {
+  vi.resetModules()
+  const mod = await import('./useGitHubAuth')
+  return mod.useGitHubAuth()
+}
+
+function stubLocation(search: string): { href: string; search: string } {
+  const locationStub = { href: `http://localhost:3000/settings${search}`, search }
+  vi.stubGlobal('location', locationStub)
+  return locationStub
+}
+
+function spyOnReplaceState() {
+  return vi.spyOn(window.history, 'replaceState').mockImplementation(() => {})
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  store.clear()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+// ---------------------------------------------------------------------------
+// A-1: Login-readiness check reports not ready when repo config is incomplete
+// ---------------------------------------------------------------------------
+
+describe('A-1: canInitiateLogin reports not ready when repo config is incomplete', () => {
+  it.each<[string, RepoConfigDraft]>([
+    ['ownerRepo is empty', { ...VALID_CONFIG, ownerRepo: '' }],
+    ['filePath is empty', { ...VALID_CONFIG, filePath: '' }],
+    ['revalidateCacheDays is null', { ...VALID_CONFIG, revalidateCacheDays: null }],
+    ['revalidateCacheDays is zero', { ...VALID_CONFIG, revalidateCacheDays: 0 }],
+    ['revalidateCacheDays is negative', { ...VALID_CONFIG, revalidateCacheDays: -3 }],
+  ])('returns false when %s', async (_description, draft) => {
+    const { canInitiateLogin } = await freshComposable()
+
+    expect(canInitiateLogin(draft)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-2: Login-readiness check reports ready when repo config is complete and valid
+// ---------------------------------------------------------------------------
+
+describe('A-2: canInitiateLogin reports ready when repo config is complete and valid', () => {
+  it('returns true when ownerRepo and filePath are non-empty and revalidateCacheDays is a positive integer', async () => {
+    const { canInitiateLogin } = await freshComposable()
+
+    expect(canInitiateLogin(VALID_CONFIG)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-3: Triggering login navigates to the GitHub OAuth start endpoint
+// ---------------------------------------------------------------------------
+
+describe('A-3: login navigates the browser to the GitHub OAuth start endpoint', () => {
+  it('sets window.location.href to the OAuth start endpoint', async () => {
+    const locationStub = stubLocation('')
+    const { login } = await freshComposable()
+
+    login()
+
+    expect(locationStub.href).toBe(LOGIN_START_PATH)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-4: A successful-callback indicator marks the user authenticated
+// ---------------------------------------------------------------------------
+
+describe('A-4: a successful-callback indicator marks the user authenticated', () => {
+  it('sets isAuthenticated, clears authError, persists the flag, and strips the URL param', async () => {
+    stubLocation('?auth=success')
+    const replaceStateSpy = spyOnReplaceState()
+    const { isAuthenticated, authError, initializeAuthState } = await freshComposable()
+
+    await initializeAuthState()
+
+    expect(isAuthenticated.value).toBe(true)
+    expect(authError.value).toBeNull()
+    expect(store.get(AUTH_STATE_KEY)).toBe(true)
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', 'http://localhost:3000/settings')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-5: Authenticated state persists across a plain reload
+// ---------------------------------------------------------------------------
+
+describe('A-5: authenticated state persists across a plain reload', () => {
+  it('restores isAuthenticated from the persisted flag when the URL carries no callback indicator', async () => {
+    store.set(AUTH_STATE_KEY, true)
+    stubLocation('')
+    const { isAuthenticated, authError, initializeAuthState } = await freshComposable()
+
+    await initializeAuthState()
+
+    expect(isAuthenticated.value).toBe(true)
+    expect(authError.value).toBeNull()
+  })
+
+  it('clears a stale authError left over from an earlier callback on a later plain reload', async () => {
+    store.set(AUTH_STATE_KEY, true)
+    const replaceStateSpy = spyOnReplaceState()
+    stubLocation('?auth=error')
+    const { authError, initializeAuthState } = await freshComposable()
+    await initializeAuthState()
+    expect(authError.value).toBe(CALLBACK_ERROR_MESSAGE)
+
+    replaceStateSpy.mockClear()
+    stubLocation('')
+    await initializeAuthState()
+
+    expect(authError.value).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-6: Logout clears the authenticated state without touching station data
+// ---------------------------------------------------------------------------
+
+describe('A-6: logout clears the authenticated state without touching station data', () => {
+  it('sets isAuthenticated to false, clears authError, and leaves unrelated IndexedDB keys untouched', async () => {
+    store.set(AUTH_STATE_KEY, true)
+    store.set('stations', [{ name: 'Station A', url: 'https://example.test/1' }])
+    store.set('repoConfig', VALID_CONFIG)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+    const { isAuthenticated, authError, logout } = await freshComposable()
+
+    await logout()
+
+    expect(isAuthenticated.value).toBe(false)
+    expect(authError.value).toBeNull()
+    expect(store.has(AUTH_STATE_KEY)).toBe(false)
+    expect(store.get('stations')).toEqual([{ name: 'Station A', url: 'https://example.test/1' }])
+    expect(store.get('repoConfig')).toEqual(VALID_CONFIG)
+  })
+
+  it('calls the logout endpoint with POST', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    const { logout } = await freshComposable()
+
+    await logout()
+
+    expect(fetchMock).toHaveBeenCalledWith(LOGOUT_PATH, { method: 'POST' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-7: Logout clears local authenticated state even if the server-side call fails
+// ---------------------------------------------------------------------------
+
+describe('A-7: logout clears local authenticated state even if the server-side call fails', () => {
+  it('sets isAuthenticated to false when the network request to the logout endpoint rejects', async () => {
+    store.set(AUTH_STATE_KEY, true)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    const { isAuthenticated, logout } = await freshComposable()
+
+    await expect(logout()).resolves.toBeUndefined()
+
+    expect(isAuthenticated.value).toBe(false)
+    expect(store.has(AUTH_STATE_KEY)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-8: No prior session and no callback indicator — unauthenticated with no error banner
+// ---------------------------------------------------------------------------
+
+describe('A-8: no prior session and no callback indicator — unauthenticated with no error banner', () => {
+  it('reports unauthenticated with no error when nothing is stored and the URL carries no indicator', async () => {
+    stubLocation('')
+    const { isAuthenticated, authError, initializeAuthState } = await freshComposable()
+
+    await initializeAuthState()
+
+    expect(isAuthenticated.value).toBe(false)
+    expect(authError.value).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-9: An error-callback indicator shows a human-readable error
+// ---------------------------------------------------------------------------
+
+describe('A-9: an error-callback indicator shows a human-readable error', () => {
+  it('sets authError, leaves isAuthenticated false, and strips the URL param', async () => {
+    stubLocation('?auth=error')
+    const replaceStateSpy = spyOnReplaceState()
+    const { isAuthenticated, authError, initializeAuthState } = await freshComposable()
+
+    await initializeAuthState()
+
+    expect(isAuthenticated.value).toBe(false)
+    expect(authError.value).toBe(CALLBACK_ERROR_MESSAGE)
+    expect(store.get(AUTH_STATE_KEY)).toBeUndefined()
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', 'http://localhost:3000/settings')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A-10: A 401 from a GitHub API call clears the authenticated state and prompts re-login
+// ---------------------------------------------------------------------------
+
+describe('A-10: a 401 from a GitHub API call clears the authenticated state and prompts re-login', () => {
+  it('sets isAuthenticated to false and shows a re-login message when handleUnauthorized is invoked', async () => {
+    store.set(AUTH_STATE_KEY, true)
+    const { isAuthenticated, authError, handleUnauthorized } = await freshComposable()
+
+    await handleUnauthorized()
+
+    expect(isAuthenticated.value).toBe(false)
+    expect(authError.value).toBe(SESSION_EXPIRED_MESSAGE)
+    expect(store.has(AUTH_STATE_KEY)).toBe(false)
+  })
+})

--- a/src/composables/useGitHubAuth.ts
+++ b/src/composables/useGitHubAuth.ts
@@ -27,6 +27,7 @@
 import { ref } from 'vue'
 import type { Ref } from 'vue'
 import { get, set, del } from '@/utils/indexedDb'
+import type { RepoConfigDraft } from '@/types/repo-config'
 
 const AUTH_STATE_KEY = 'githubAuthenticated'
 const LOGIN_START_PATH = '/.netlify/functions/github-auth-start'
@@ -36,12 +37,6 @@ const CALLBACK_ERROR_MESSAGE = 'La connexion à GitHub a échoué. Merci de rée
 const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
 
 type AuthCallbackResult = 'success' | 'error'
-
-export interface RepoConfigDraft {
-  ownerRepo: string
-  filePath: string
-  revalidateCacheDays: number | null
-}
 
 // Module-level state — all consumers share the same reference (ADR-002).
 const isAuthenticated: Ref<boolean> = ref(false)

--- a/src/composables/useGitHubAuth.ts
+++ b/src/composables/useGitHubAuth.ts
@@ -1,0 +1,153 @@
+/**
+ * Singleton composable for GitHub OAuth login/logout state (Sub-Issue A, issue #64).
+ *
+ * Owns only the login/logout flow and the resulting authenticated/error state.
+ * It does not own repo configuration fields (`owner/repo`, file path,
+ * `revalidate-cache-days`) or their IndexedDB persistence — those belong to
+ * Sub-Issues B and E. `canInitiateLogin` accepts that config as a parameter so
+ * the future Settings page can gate its "Login with GitHub" button without
+ * this composable knowing where the values come from.
+ *
+ * The access token itself never reaches the browser (ADR-011) — it lives only
+ * in the `gh_token` HttpOnly cookie set by the Netlify functions. The boolean
+ * flag persisted here under `githubAuthenticated` is a non-sensitive UI hint
+ * only (ADR-008: IndexedDB, not localStorage) so the authenticated view
+ * survives a page reload without re-reading a cookie JavaScript cannot see.
+ *
+ * `handleUnauthorized` is called by the composable(s) that own future GitHub
+ * API proxy calls (Sub-Issues C/D) when a request returns 401 — this
+ * composable does not call the proxy itself.
+ *
+ * Object Calisthenics exception: the composable function body exceeds five
+ * lines because Vue composable conventions require grouping all returned
+ * reactive state and operations in one function — documented framework
+ * exception.
+ */
+
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { get, set, del } from '@/utils/indexedDb'
+
+const AUTH_STATE_KEY = 'githubAuthenticated'
+const LOGIN_START_PATH = '/.netlify/functions/github-auth-start'
+const LOGOUT_PATH = '/.netlify/functions/github-auth-logout'
+const AUTH_QUERY_PARAM = 'auth'
+const CALLBACK_ERROR_MESSAGE = 'La connexion à GitHub a échoué. Merci de réessayer.'
+const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
+
+type AuthCallbackResult = 'success' | 'error'
+
+export interface RepoConfigDraft {
+  ownerRepo: string
+  filePath: string
+  revalidateCacheDays: number | null
+}
+
+// Module-level state — all consumers share the same reference (ADR-002).
+const isAuthenticated: Ref<boolean> = ref(false)
+const authError: Ref<string | null> = ref(null)
+
+function readAuthCallbackParam(): AuthCallbackResult | null {
+  const params = new URLSearchParams(window.location.search)
+  const value = params.get(AUTH_QUERY_PARAM)
+  return value === 'success' || value === 'error' ? value : null
+}
+
+function stripAuthCallbackParam(): void {
+  const url = new URL(window.location.href)
+  url.searchParams.delete(AUTH_QUERY_PARAM)
+  window.history.replaceState({}, '', url.toString())
+}
+
+function updateAuthState(authenticated: boolean, errorMessage: string | null): void {
+  isAuthenticated.value = authenticated
+  authError.value = errorMessage
+}
+
+async function persistAuthenticatedFlag(authenticated: boolean): Promise<void> {
+  if (!authenticated) {
+    await del(AUTH_STATE_KEY)
+    return
+  }
+  await set(AUTH_STATE_KEY, true)
+}
+
+async function applyAuthCallbackResult(result: AuthCallbackResult): Promise<void> {
+  if (result === 'success') {
+    updateAuthState(true, null)
+    await persistAuthenticatedFlag(true)
+    return
+  }
+  updateAuthState(false, CALLBACK_ERROR_MESSAGE)
+  await persistAuthenticatedFlag(false)
+}
+
+async function applyCallbackAndCleanUrl(result: AuthCallbackResult): Promise<void> {
+  await applyAuthCallbackResult(result)
+  stripAuthCallbackParam()
+}
+
+async function restoreStoredAuthState(): Promise<void> {
+  const stored = await get<boolean>(AUTH_STATE_KEY)
+  updateAuthState(stored === true, null)
+}
+
+function hasRequiredRepoConfig(config: RepoConfigDraft): boolean {
+  return config.ownerRepo.trim().length > 0 && config.filePath.trim().length > 0
+}
+
+function hasValidCacheDays(config: RepoConfigDraft): boolean {
+  return config.revalidateCacheDays !== null && config.revalidateCacheDays > 0
+}
+
+// Clearing the client-side flag is the point of logout, regardless of whether
+// the network call to clear the server-side cookie succeeds — otherwise a
+// flaky connection would leave the UI stuck showing an authenticated state
+// the user explicitly asked to leave.
+async function requestServerLogout(): Promise<void> {
+  try {
+    await fetch(LOGOUT_PATH, { method: 'POST' })
+  } catch {
+    // Local auth state is cleared by the caller regardless.
+  }
+}
+
+export function useGitHubAuth() {
+  const initializeAuthState = async (): Promise<void> => {
+    const callbackResult = readAuthCallbackParam()
+    if (callbackResult) {
+      await applyCallbackAndCleanUrl(callbackResult)
+      return
+    }
+    await restoreStoredAuthState()
+  }
+
+  const canInitiateLogin = (config: RepoConfigDraft): boolean => {
+    return hasRequiredRepoConfig(config) && hasValidCacheDays(config)
+  }
+
+  const login = (): void => {
+    window.location.href = LOGIN_START_PATH
+  }
+
+  const logout = async (): Promise<void> => {
+    await requestServerLogout()
+    updateAuthState(false, null)
+    await persistAuthenticatedFlag(false)
+  }
+
+  const handleUnauthorized = async (): Promise<void> => {
+    updateAuthState(false, SESSION_EXPIRED_MESSAGE)
+    await persistAuthenticatedFlag(false)
+  }
+
+  return {
+    isAuthenticated,
+    authError,
+    initializeAuthState,
+    canInitiateLogin,
+    login,
+    logout,
+    handleUnauthorized,
+  }
+}

--- a/src/types/repo-config.ts
+++ b/src/types/repo-config.ts
@@ -1,0 +1,11 @@
+/**
+ * Draft values of the GitHub repo-sync configuration (Sub-Issue B, issue #64),
+ * as entered in the Settings UI (Sub-Issue E) before or after persistence.
+ * Shared by Sub-Issue A's login-readiness check (`canInitiateLogin`) and any
+ * future composable/component that reads or writes these fields.
+ */
+export interface RepoConfigDraft {
+  ownerRepo: string
+  filePath: string
+  revalidateCacheDays: number | null
+}

--- a/typed-router.d.ts
+++ b/typed-router.d.ts
@@ -17,7 +17,8 @@ import type {
 
 declare module 'vue-router' {
   interface TypesConfig {
-    ParamParsers: never
+    ParamParsers:
+      | never
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `useGitHubAuth`, a singleton composable owning GitHub OAuth login-readiness,
  auth-state detection, and login/logout actions (Sub-Issue A of issue #64).
- Introduces `RepoConfigDraft` in `src/types/repo-config.ts`, the shared shape for
  the repo-config fields (`owner/repo`, file path, `revalidate-cache-days`) that
  gate the login-readiness check — reusable by Sub-Issues B and E.
- Rescopes Sub-Issue A's specs/test-cases to the login/logout logic only, since the
  Settings page rendering that logic belongs to Sub-Issue E.

## Test plan
- [x] `useGitHubAuth.spec.ts` covers all 10 rescoped test cases (A-1 through A-10)
- [x] Full suite passes: 291 test files, 346 tests (see `test-results.md`)

Closes #82
