### PR TITLE
feat(repo-config): persist and validate GitHub repo sync config

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -96,6 +96,7 @@ declare global {
   const useModel: typeof import('vue').useModel
   const usePreferencesExport: typeof import('./src/composables/usePreferencesExport').usePreferencesExport
   const usePreferencesImport: typeof import('./src/composables/usePreferencesImport').usePreferencesImport
+  const useRepoConfig: typeof import('./src/composables/useRepoConfig').useRepoConfig
   const useRoute: typeof import('vue-router').useRoute
   const useRouter: typeof import('vue-router').useRouter
   const useSlots: typeof import('vue').useSlots

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/review-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/review-results.md
@@ -1,0 +1,59 @@
+# Review Results — Sub-Issue B (#83): Repo Configuration
+
+## `npm run lint`
+
+`rtk lint` itself failed to run in this environment ("Failed to run eslint... program not found" —
+same known issue recorded in `sub-issue-81/review-results.md`), so `npm run lint` (`eslint . --fix`)
+was used directly:
+
+```
+E:\Git\...\src\composables\usePreferencesExport.spec.ts
+  39:5  error  'lastDownloaded' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+E:\Git\...\src\composables\usePreferencesImport.spec.ts
+   36:15  error  'PreferencesDiff' is defined but never used       @typescript-eslint/no-unused-vars
+   71:33  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   72:36  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+   72:50  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   73:42  error  '_label' is defined but never used                @typescript-eslint/no-unused-vars
+  433:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  466:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  468:11  error  'externalUrl' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+✖ 9 problems (9 errors, 0 warnings)
+```
+
+All 9 errors are in `usePreferencesExport.spec.ts`/`usePreferencesImport.spec.ts` — pre-existing,
+unrelated to this sub-issue's changed files. `npx eslint src/composables/useRepoConfig.ts
+netlify/functions/github-api-proxy/github-api-proxy.ts` (targeted run) reports zero errors —
+clean for the changed files.
+
+## `npm run type-check`
+
+Passes cleanly — no output.
+
+## Checklist
+
+- Security guidelines coverage:
+  - Rule 1 (never expose secret/token) — ✓. `useRepoConfig.ts` never touches the token; `github-api-proxy.ts`'s new `repoCheck` path reuses the same header-building code as `read`, which never logs or returns the token.
+  - Rule 2 (cookie flags) — N/A, this sub-issue does not touch cookie issuance.
+  - Rule 3 (state round-trip) — N/A, no OAuth flow code touched.
+  - Rule 4 (forward owner/repo/path exactly, no server-side cross-check) — ✓. The new `repoCheck` branch forwards `owner`/`repo` exactly as supplied by the SPA, percent-encoded only for URL hygiene (`contentsUrl`, github-api-proxy.ts:151-161), consistent with the existing `read`/`write` branches.
+  - Rule 5 (401 clears cookie server-side, composable surfaces a re-auth prompt) — **✗, see Finding 1.** Server-side half is fine (`unauthorizedResponse` clears the cookie for the new `repoCheck` path exactly as it already did for `read`/`write`), but the composable half is not self-contained.
+  - Rule 6 (token never reaches the SPA) — ✓. `checkProxyReachable` only reads `response.status`, never the body, for both the file check and the repo check.
+
+- Object Calisthenics — mostly ✓ (guard clauses only, no `else`, discriminated-union domain types for `ProxyCheckResult`/`ContentsRequest`, no abbreviations, `useRepoConfig()`'s own body-length exception already documented in its header comment matching `useGitHubAuth.ts`/`useStationStorage.ts` precedent). **One gap, see Finding 2.**
+- Business spec match — ✓. Rule 2 (save always persists; validation only when authenticated; human-readable error on failure) is implemented exactly, including the "file exists OR repo reachable" two-step check the rule names. Rule 1/3/4 correctly left to Sub-Issues A/E/F as scoped in `technical-specifications.md`.
+- No dead code/unused imports — ✓.
+- Naming clarity — ✓, no abbreviations found in either changed file.
+- Vue/TS pitfalls — no destructuring of reactive state (all access is via qualified `draft.field` paths, so reactivity is preserved), no `reactive()` on a primitive, composable returns a plain object of refs/functions (not wrapped in `reactive()`), no `any`, no non-null `!` assertions, all parameters typed, all functions except `useRepoConfig()` itself have explicit return types (that one omission matches `useGitHubAuth()`/`useStationStorage()`'s existing pattern, not a regression). `useRepoConfig` takes no reactive args, so `toValue()`/`toRef()` normalization doesn't apply. No side effects requiring `onUnmounted` cleanup. `URLSearchParams` used correctly for query-string building (no raw string concatenation, no `new URL()` parse-failure risk since it's never constructed from an untrusted absolute string).
+
+### Findings
+
+1. **`saveRepoConfig`'s `onUnauthorized` callback is optional, so security-guidelines.md rule 5's UI-prompt requirement isn't guaranteed by this composable alone.**
+   `src/composables/useRepoConfig.ts:91-94,124-136` — `notifyUnauthorized` calls `onUnauthorized?.()` and always resolves to `null`. If a caller invokes `saveRepoConfig` without passing `onUnauthorized` (or passes a no-op), a 401 from the validation call resolves `validationError.value` to `null` — i.e. the UI shows *no error at all* for an expired/revoked session, which is the opposite of "surface a re-authentication prompt in the UI." Rule 5 explicitly names "the composable that calls the proxy" as responsible for the UI prompt, but that responsibility is entirely outsourced to correct call-site wiring with no fallback. Recommend either making `onUnauthorized` a required parameter, or having `resolveValidationError` set a dedicated message (mirroring `useGitHubAuth.ts`'s `SESSION_EXPIRED_MESSAGE`) in addition to invoking the callback, so the guideline holds even if a future caller forgets to wire it.
+
+2. **`resolveValidationError`'s guard-clause chain exceeds the 5-line Object Calisthenics guideline without a documented exception.**
+   `src/composables/useRepoConfig.ts:96-112` — 12 lines of sequential guard clauses (owner/repo format, file-path presence, file-check outcomes, repo-check outcomes). This is the same shape as `github-auth-callback.ts`'s `validateCallbackRequest` from Sub-Issue F, which received an explicit documented exception in that sub-issue's `technical-specifications.md` ("splitting further would fragment one coherent validation into indirection without improving readability"). No equivalent note exists in this sub-issue's `technical-specifications.md`. Low severity — add the same documented-exception note for consistency with the established precedent.
+
+status: changes requested

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/review-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/review-results.md
@@ -1,4 +1,4 @@
-# Review Results — Sub-Issue B (#83): Repo Configuration (re-review after fixes)
+# Review Results — Sub-Issue B (#83): Repo Configuration (final re-review)
 
 ## `npm run lint`
 
@@ -23,7 +23,7 @@ E:\Git\...\src\composables\usePreferencesImport.spec.ts
 ✖ 9 problems (9 errors, 0 warnings)
 ```
 
-All 9 errors are pre-existing in unrelated spec files (same as the prior review round).
+All 9 errors are pre-existing in unrelated spec files (same as both prior review rounds).
 `npx eslint src/composables/useRepoConfig.ts` (targeted run) reports zero errors — clean.
 
 ## `npm run type-check`
@@ -33,26 +33,36 @@ Passes cleanly — no output.
 ## Checklist
 
 - Security guidelines coverage:
-  - Rule 1 (never expose secret/token) — ✓, unchanged from prior round.
+  - Rule 1 (never expose secret/token) — ✓.
   - Rule 2 (cookie flags) — N/A.
   - Rule 3 (state round-trip) — N/A.
-  - Rule 4 (forward owner/repo/path exactly) — ✓, unchanged from prior round (`github-api-proxy.ts` not touched this round).
-  - Rule 5 (401 clears cookie server-side, composable surfaces a re-auth prompt) — ✓, **Finding 1 resolved.** `notifyUnauthorized` (`useRepoConfig.ts:101-108`) now always resolves to `SESSION_EXPIRED_MESSAGE`, independent of whether `onUnauthorized` was passed and independent of that callback throwing (wrapped in `try/catch`). The re-auth prompt is now guaranteed by this composable alone, matching the wording already used by `useGitHubAuth.ts`'s own `SESSION_EXPIRED_MESSAGE`.
-  - Rule 6 (token never reaches the SPA) — ✓, unchanged.
+  - Rule 4 (forward owner/repo/path exactly) — ✓.
+  - Rule 5 (401 clears cookie server-side, composable surfaces a re-auth prompt) — ✓. `notifyUnauthorized` always resolves to `SESSION_EXPIRED_MESSAGE`, independent of callback wiring or failure.
+  - Rule 6 (token never reaches the SPA) — ✓.
 
-- Object Calisthenics:
-  - **Finding 2 resolved.** `resolveValidationError`'s guard-clause chain now has a documented exception, both inline (`useRepoConfig.ts:110-115`) and in `technical-specifications.md` ("Object Calisthenics exceptions"), matching the `validateCallbackRequest` precedent.
-  - **New finding, see below (Finding 1).** The new `latestSaveRequestId` module-level counter is a third piece of shared module state in this file (alongside `repoConfig` and `validationError`), where the ≤2-variable guideline and this codebase's own precedent (`useGitHubAuth.ts` keeps exactly 2: `isAuthenticated`, `authError`) both point to 2. No exception is documented for it.
-  - Otherwise ✓ — guard clauses only, no `else`, no abbreviations, discriminated-union domain types unchanged.
-
-- Business spec match — ✓. Sub-Issue B rule 2 still implemented exactly (save always persists — the new `requestId` guard only gates the `validationError` write, never `persistRepoConfig`/`repoConfig.value`, so "saving always persists to IndexedDB" still holds unconditionally). No scope creep: the race-condition guard fixes a self-identified bug, not a new feature.
+- Object Calisthenics — ✓. All three deviations in this file are now documented in both the
+  code (inline comments at `useRepoConfig.ts:19-22`, `54-58`, `115-120`) and
+  `technical-specifications.md`'s "Object Calisthenics exceptions" section: the composable
+  body length, `resolveValidationError`'s guard-clause chain, and the third module-level
+  variable `latestSaveRequestId`. Guard clauses only, no `else`, no abbreviations,
+  discriminated-union domain types (`ProxyCheckResult`, `OwnerRepo`).
+- Business spec match — ✓. Sub-Issue B rule 2 still implemented exactly: `persistRepoConfig`
+  (`useRepoConfig.ts:156`) runs unconditionally on every save, unaffected by the
+  `latestSaveRequestId` guard, which only gates the two reactive-state writes
+  (`repoConfig.value`, `validationError.value`) — so "saving always persists to IndexedDB"
+  still holds regardless of request ordering.
 - No dead code/unused imports — ✓.
-- Naming clarity — ✓. `requestId`, `latestSaveRequestId` are clear, no abbreviations.
-- Vue/TS pitfalls — ✓, same as prior round: no reactive destructuring, no `reactive()` on a primitive, no `any`, no non-null `!`, all parameters and exported functions typed (aside from `useRepoConfig()` itself, matching existing precedent). The new `try/catch` in `notifyUnauthorized` and the `requestId` check in `saveRepoConfig` don't introduce any of the listed pitfalls.
+- Naming clarity — ✓.
+- Vue/TS pitfalls — ✓. `repoConfig.value = { ...draft }` (`useRepoConfig.ts:157`) now assigns
+  a shallow copy instead of aliasing the caller's object into singleton state, closing the
+  gap where a caller mutating its own form-model object after `saveRepoConfig` returned could
+  previously leak into the composable's shared reactive state without another explicit save.
+  No destructuring of reactive state, no `reactive()` on a primitive, no `any`, no non-null
+  `!`, all parameters and exported functions typed (aside from `useRepoConfig()` itself,
+  matching existing precedent).
 
 ### Findings
 
-1. **Undocumented Object Calisthenics deviation: `latestSaveRequestId` is a third module-level state variable in a file that otherwise holds to 2.**
-   `src/composables/useRepoConfig.ts:53` — `repoConfig` and `validationError` were already documented (implicitly, by precedent) as this composable's 2 pieces of shared state, matching `useGitHubAuth.ts`'s own 2 (`isAuthenticated`, `authError`). `latestSaveRequestId` adds a third, with no exception note in `technical-specifications.md`'s "Object Calisthenics exceptions" section (which already documents the file's other two deviations). Low severity — either add a documented-exception note there (the counter exists solely to guard against a stale concurrent `saveRepoConfig` call overwriting `validationError`, and isn't part of the composable's public reactive surface), for consistency with how the two prior deviations in this same file were handled.
+None.
 
-status: changes requested
+status: approved

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/review-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/review-results.md
@@ -1,8 +1,8 @@
-# Review Results — Sub-Issue B (#83): Repo Configuration
+# Review Results — Sub-Issue B (#83): Repo Configuration (re-review after fixes)
 
 ## `npm run lint`
 
-`rtk lint` itself failed to run in this environment ("Failed to run eslint... program not found" —
+`rtk lint` still fails to run in this environment ("Failed to run eslint... program not found" —
 same known issue recorded in `sub-issue-81/review-results.md`), so `npm run lint` (`eslint . --fix`)
 was used directly:
 
@@ -23,10 +23,8 @@ E:\Git\...\src\composables\usePreferencesImport.spec.ts
 ✖ 9 problems (9 errors, 0 warnings)
 ```
 
-All 9 errors are in `usePreferencesExport.spec.ts`/`usePreferencesImport.spec.ts` — pre-existing,
-unrelated to this sub-issue's changed files. `npx eslint src/composables/useRepoConfig.ts
-netlify/functions/github-api-proxy/github-api-proxy.ts` (targeted run) reports zero errors —
-clean for the changed files.
+All 9 errors are pre-existing in unrelated spec files (same as the prior review round).
+`npx eslint src/composables/useRepoConfig.ts` (targeted run) reports zero errors — clean.
 
 ## `npm run type-check`
 
@@ -35,25 +33,26 @@ Passes cleanly — no output.
 ## Checklist
 
 - Security guidelines coverage:
-  - Rule 1 (never expose secret/token) — ✓. `useRepoConfig.ts` never touches the token; `github-api-proxy.ts`'s new `repoCheck` path reuses the same header-building code as `read`, which never logs or returns the token.
-  - Rule 2 (cookie flags) — N/A, this sub-issue does not touch cookie issuance.
-  - Rule 3 (state round-trip) — N/A, no OAuth flow code touched.
-  - Rule 4 (forward owner/repo/path exactly, no server-side cross-check) — ✓. The new `repoCheck` branch forwards `owner`/`repo` exactly as supplied by the SPA, percent-encoded only for URL hygiene (`contentsUrl`, github-api-proxy.ts:151-161), consistent with the existing `read`/`write` branches.
-  - Rule 5 (401 clears cookie server-side, composable surfaces a re-auth prompt) — **✗, see Finding 1.** Server-side half is fine (`unauthorizedResponse` clears the cookie for the new `repoCheck` path exactly as it already did for `read`/`write`), but the composable half is not self-contained.
-  - Rule 6 (token never reaches the SPA) — ✓. `checkProxyReachable` only reads `response.status`, never the body, for both the file check and the repo check.
+  - Rule 1 (never expose secret/token) — ✓, unchanged from prior round.
+  - Rule 2 (cookie flags) — N/A.
+  - Rule 3 (state round-trip) — N/A.
+  - Rule 4 (forward owner/repo/path exactly) — ✓, unchanged from prior round (`github-api-proxy.ts` not touched this round).
+  - Rule 5 (401 clears cookie server-side, composable surfaces a re-auth prompt) — ✓, **Finding 1 resolved.** `notifyUnauthorized` (`useRepoConfig.ts:101-108`) now always resolves to `SESSION_EXPIRED_MESSAGE`, independent of whether `onUnauthorized` was passed and independent of that callback throwing (wrapped in `try/catch`). The re-auth prompt is now guaranteed by this composable alone, matching the wording already used by `useGitHubAuth.ts`'s own `SESSION_EXPIRED_MESSAGE`.
+  - Rule 6 (token never reaches the SPA) — ✓, unchanged.
 
-- Object Calisthenics — mostly ✓ (guard clauses only, no `else`, discriminated-union domain types for `ProxyCheckResult`/`ContentsRequest`, no abbreviations, `useRepoConfig()`'s own body-length exception already documented in its header comment matching `useGitHubAuth.ts`/`useStationStorage.ts` precedent). **One gap, see Finding 2.**
-- Business spec match — ✓. Rule 2 (save always persists; validation only when authenticated; human-readable error on failure) is implemented exactly, including the "file exists OR repo reachable" two-step check the rule names. Rule 1/3/4 correctly left to Sub-Issues A/E/F as scoped in `technical-specifications.md`.
+- Object Calisthenics:
+  - **Finding 2 resolved.** `resolveValidationError`'s guard-clause chain now has a documented exception, both inline (`useRepoConfig.ts:110-115`) and in `technical-specifications.md` ("Object Calisthenics exceptions"), matching the `validateCallbackRequest` precedent.
+  - **New finding, see below (Finding 1).** The new `latestSaveRequestId` module-level counter is a third piece of shared module state in this file (alongside `repoConfig` and `validationError`), where the ≤2-variable guideline and this codebase's own precedent (`useGitHubAuth.ts` keeps exactly 2: `isAuthenticated`, `authError`) both point to 2. No exception is documented for it.
+  - Otherwise ✓ — guard clauses only, no `else`, no abbreviations, discriminated-union domain types unchanged.
+
+- Business spec match — ✓. Sub-Issue B rule 2 still implemented exactly (save always persists — the new `requestId` guard only gates the `validationError` write, never `persistRepoConfig`/`repoConfig.value`, so "saving always persists to IndexedDB" still holds unconditionally). No scope creep: the race-condition guard fixes a self-identified bug, not a new feature.
 - No dead code/unused imports — ✓.
-- Naming clarity — ✓, no abbreviations found in either changed file.
-- Vue/TS pitfalls — no destructuring of reactive state (all access is via qualified `draft.field` paths, so reactivity is preserved), no `reactive()` on a primitive, composable returns a plain object of refs/functions (not wrapped in `reactive()`), no `any`, no non-null `!` assertions, all parameters typed, all functions except `useRepoConfig()` itself have explicit return types (that one omission matches `useGitHubAuth()`/`useStationStorage()`'s existing pattern, not a regression). `useRepoConfig` takes no reactive args, so `toValue()`/`toRef()` normalization doesn't apply. No side effects requiring `onUnmounted` cleanup. `URLSearchParams` used correctly for query-string building (no raw string concatenation, no `new URL()` parse-failure risk since it's never constructed from an untrusted absolute string).
+- Naming clarity — ✓. `requestId`, `latestSaveRequestId` are clear, no abbreviations.
+- Vue/TS pitfalls — ✓, same as prior round: no reactive destructuring, no `reactive()` on a primitive, no `any`, no non-null `!`, all parameters and exported functions typed (aside from `useRepoConfig()` itself, matching existing precedent). The new `try/catch` in `notifyUnauthorized` and the `requestId` check in `saveRepoConfig` don't introduce any of the listed pitfalls.
 
 ### Findings
 
-1. **`saveRepoConfig`'s `onUnauthorized` callback is optional, so security-guidelines.md rule 5's UI-prompt requirement isn't guaranteed by this composable alone.**
-   `src/composables/useRepoConfig.ts:91-94,124-136` — `notifyUnauthorized` calls `onUnauthorized?.()` and always resolves to `null`. If a caller invokes `saveRepoConfig` without passing `onUnauthorized` (or passes a no-op), a 401 from the validation call resolves `validationError.value` to `null` — i.e. the UI shows *no error at all* for an expired/revoked session, which is the opposite of "surface a re-authentication prompt in the UI." Rule 5 explicitly names "the composable that calls the proxy" as responsible for the UI prompt, but that responsibility is entirely outsourced to correct call-site wiring with no fallback. Recommend either making `onUnauthorized` a required parameter, or having `resolveValidationError` set a dedicated message (mirroring `useGitHubAuth.ts`'s `SESSION_EXPIRED_MESSAGE`) in addition to invoking the callback, so the guideline holds even if a future caller forgets to wire it.
-
-2. **`resolveValidationError`'s guard-clause chain exceeds the 5-line Object Calisthenics guideline without a documented exception.**
-   `src/composables/useRepoConfig.ts:96-112` — 12 lines of sequential guard clauses (owner/repo format, file-path presence, file-check outcomes, repo-check outcomes). This is the same shape as `github-auth-callback.ts`'s `validateCallbackRequest` from Sub-Issue F, which received an explicit documented exception in that sub-issue's `technical-specifications.md` ("splitting further would fragment one coherent validation into indirection without improving readability"). No equivalent note exists in this sub-issue's `technical-specifications.md`. Low severity — add the same documented-exception note for consistency with the established precedent.
+1. **Undocumented Object Calisthenics deviation: `latestSaveRequestId` is a third module-level state variable in a file that otherwise holds to 2.**
+   `src/composables/useRepoConfig.ts:53` — `repoConfig` and `validationError` were already documented (implicitly, by precedent) as this composable's 2 pieces of shared state, matching `useGitHubAuth.ts`'s own 2 (`isAuthenticated`, `authError`). `latestSaveRequestId` adds a third, with no exception note in `technical-specifications.md`'s "Object Calisthenics exceptions" section (which already documents the file's other two deviations). Low severity — either add a documented-exception note there (the counter exists solely to guard against a stale concurrent `saveRepoConfig` call overwriting `validationError`, and isn't part of the composable's public reactive surface), for consistency with how the two prior deviations in this same file were handled.
 
 status: changes requested

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/technical-specifications.md
@@ -74,6 +74,11 @@
   Splitting it further would fragment that one rule into indirection without improving
   readability — same documented exception already given to `github-auth-callback.ts`'s
   `validateCallbackRequest` in Sub-Issue F.
+- `latestSaveRequestId` is a third module-level variable in this file, beyond the two
+  (`repoConfig`, `validationError`) that match the `isAuthenticated`/`authError` precedent set
+  by `useGitHubAuth.ts`. It exists solely to guard against a stale, slower `saveRepoConfig`
+  call overwriting `validationError` after a newer call already resolved; it is never part of
+  the composable's returned reactive surface, unlike the other two.
 
 ## Review-feedback fixes applied (review-results.md, changes requested)
 
@@ -103,5 +108,23 @@
    `validationError` after a later request already set it, showing a stale message. Added a
    `latestSaveRequestId` counter so only the most recently started `saveRepoConfig` call is
    allowed to write `validationError`.
+
+## Second review-feedback fix applied (review-results.md, changes requested)
+
+1. **Finding 1 (undocumented Object Calisthenics deviation — third module-level variable).**
+   Added the exception note above for `latestSaveRequestId`, plus a matching inline comment in
+   `useRepoConfig.ts`, for consistency with how the file's other two deviations are documented.
+
+## Self-review fixes applied (this pass)
+
+1. `saveRepoConfig` — `repoConfig.value = draft` was neither guarded by `latestSaveRequestId`
+   (unlike `validationError`, a few lines below it) nor copied. A slower, stale save could
+   overwrite the reactive `repoConfig` with older data after a newer save already resolved,
+   and the exact object reference passed by the caller was aliased into the singleton's
+   state — if the caller kept mutating that same object (e.g. a form model bound with
+   `v-model`) after calling `saveRepoConfig`, those mutations would silently leak into
+   `repoConfig.value` without another explicit save. Guarded the assignment with the same
+   `requestId` check already used for `validationError`, and assign a shallow copy (`{ ...draft
+   }`), matching `persistRepoConfig`'s existing `{ ...toRaw(draft) }` copy-before-use pattern.
 
 status: ready

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/technical-specifications.md
@@ -68,5 +68,40 @@
 
 - `useRepoConfig()`'s returned function body groups multiple operations in one composable, same
   documented framework exception already used in `useGitHubAuth.ts` and `useStationStorage.ts`.
+- `resolveValidationError`'s guard-clause chain exceeds five lines because it walks one
+  coherent sequential business rule (owner/repo format, then file-path presence, then the
+  file-exists-or-repo-reachable check `business-specifications.md` Sub-Issue B rule 2 names).
+  Splitting it further would fragment that one rule into indirection without improving
+  readability — same documented exception already given to `github-auth-callback.ts`'s
+  `validateCallbackRequest` in Sub-Issue F.
+
+## Review-feedback fixes applied (review-results.md, changes requested)
+
+1. **Finding 1 (security-guidelines.md rule 5 not self-contained).** `notifyUnauthorized` used
+   to always resolve to `null`, so a 401 during validation surfaced no error unless a future
+   caller remembered to pass `onUnauthorized`. It now always resolves to
+   `SESSION_EXPIRED_MESSAGE`, with the callback invocation wrapped in `try/catch` so a failure
+   in that optional notification can't prevent the message from being set — the re-auth prompt
+   no longer depends on correct call-site wiring.
+2. **Finding 2 (undocumented Object Calisthenics exception).** Added the exception note above,
+   matching the precedent set for `validateCallbackRequest` in Sub-Issue F.
+
+## Additional self-review fixes (this pass)
+
+1. `notifyUnauthorized` — the `onUnauthorized?.()` call was unguarded; if that callback throws
+   (e.g. a future `handleUnauthorized` implementation that persists to IndexedDB and rejects),
+   the rejection would propagate out of `resolveValidationError`/`saveRepoConfig` instead of
+   still surfacing `SESSION_EXPIRED_MESSAGE`. Wrapped in `try/catch`.
+2. `resolveValidationError` — a generic `fileCheck === 'error'` outcome (GitHub 5xx, rate
+   limiting, or a network failure reaching the proxy) used to fall through to a second,
+   redundant repo-level network call before landing on the same `VALIDATION_UNAVAILABLE_MESSAGE`
+   it would have reached immediately. Added an explicit `'error'` branch so only the genuinely
+   ambiguous `'notFound'` outcome triggers the fallback check, per the "file check first, repo
+   check only as fallback" design already documented above.
+3. `saveRepoConfig` — concurrent calls (e.g. a user editing then re-saving before the first
+   validation round-trip resolves) could let an earlier, slower request's result overwrite
+   `validationError` after a later request already set it, showing a stale message. Added a
+   `latestSaveRequestId` counter so only the most recently started `saveRepoConfig` call is
+   allowed to write `validationError`.
 
 status: ready

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/technical-specifications.md
@@ -1,0 +1,72 @@
+# Technical Specifications — Sub-Issue B (#83): Repo Configuration
+
+## Summary of files created/changed
+
+- `src/composables/useRepoConfig.ts` — new. Singleton composable owning the `RepoConfigDraft`
+  (`owner/repo`, file path, `revalidate-cache-days`): `loadRepoConfig` reads it from IndexedDB
+  (defaulting `revalidateCacheDays` to 7 per business-specifications.md Sub-Issue C rule 1),
+  `saveRepoConfig` always persists to IndexedDB and, only when the caller reports the user as
+  authenticated, validates the config against the `github-api-proxy` Netlify function.
+- `netlify/functions/github-api-proxy/github-api-proxy.ts` — changed. The existing GET path now
+  accepts a request with `owner`/`repo` but no `path`, treated as a repo-level reachability check
+  (`GET /repos/{owner}/{repo}` instead of the Contents API). Existing `read`/`write` behavior for
+  requests that include `path` is unchanged.
+
+## Non-trivial decisions
+
+- **Extending `github-api-proxy` instead of adding a new Netlify function.**
+  `business-specifications.md` Sub-Issue B rule 2 names "the Netlify proxy" as the validation
+  mechanism, and the rule requires confirming *either* "the file path exists" *or* "the repo is
+  reachable." A single GET-with-path call can't distinguish "repo doesn't exist" from "repo
+  exists but the file hasn't been created yet" — both return 404 from the Contents API — yet
+  Sub-Issue D rule 2 explicitly treats a missing file as a normal, non-error first-write state.
+  Resolving that required a second, repo-level check (`GET /repos/{owner}/{repo}`, no `path`),
+  and reusing the existing proxy (rather than a new function) keeps the single GitHub-facing
+  proxy security-guidelines.md rule 4 already governs, instead of duplicating cookie/token
+  handling in a second function.
+- **Validation order: file check first, repo check only as fallback.** Checking the file path
+  first means the common case (file already exists) resolves in one network call; the repo-level
+  check only runs when the file check comes back 404, which is exactly the ambiguous case that
+  needs disambiguating.
+- **`'error' vs 'notFound'` kept distinct in the repo-level check.** A definitive 404 on the repo
+  itself produces "repo introuvable ou inaccessible"; any other non-2xx outcome (rate limiting,
+  GitHub outage, local network failure) produces a separate "unable to verify right now" message
+  instead of incorrectly blaming the repo's existence for what may be a transient failure —
+  found and fixed during self-review.
+- **`onUnauthorized` passed as an optional callback parameter, not called by importing
+  `useGitHubAuth()` directly.** Per this command's composable-caller-responsibility rule,
+  composables may not call another composable from inside a plain/async function. The owning
+  component calls both `useGitHubAuth()` and `useRepoConfig()` in its own `setup()` and passes
+  `handleUnauthorized` through, matching the pattern `useGitHubAuth.ts` already documents for
+  its own `handleUnauthorized` export.
+- **No inline validation of `revalidateCacheDays` (positive-integer check) in this composable.**
+  `business-specifications.md` assigns that rule explicitly to Sub-Issue E ("rejected with an
+  inline validation message," rule 2 under Sub-Issue E). Sub-Issue B rule 2 only requires that
+  saving "always persists the configuration to IndexedDB" — adding a second validation layer
+  here would duplicate a rule owned by a different sub-issue.
+- **`ownerRepo`/`filePath` are trimmed only inside `resolveValidationError`, not before
+  persisting.** Persistence stores exactly what the caller passed in (Sub-Issue E's form is the
+  source of truth for what "saved" means); trimming is applied only where its absence would
+  cause a wrong validation verdict — found and fixed during self-review after noticing
+  `useGitHubAuth.ts`'s own `hasRequiredRepoConfig` already trims for the same reason.
+
+## Self-code review fixes applied
+
+1. `resolveValidationError` — an empty (or whitespace-only) `filePath` was silently reinterpreted
+   as "no path," which made `checkProxyReachable` run the repo-level check instead of failing
+   clearly. Added an explicit empty-path guard returning `MISSING_FILE_PATH_MESSAGE`.
+2. `splitOwnerRepo` — did not trim the input, so a value like `"alice/my-stations "` (trailing
+   whitespace) would pass the split check and then fail the GitHub call with a misleading "repo
+   not reachable" error instead of being caught as a formatting issue closer to its source. Now
+   trims before splitting.
+3. Repo-level check treated every non-200 status (403 rate limit, 5xx, network failure) as
+   equivalent to "repo not found," which blames the repo for failures that are actually transient
+   or on the caller's own network. Split `'notFound'` (definitive 404 → repo/access error) from
+   `'error'` (anything else → a distinct "try again later" message).
+
+## Object Calisthenics exceptions
+
+- `useRepoConfig()`'s returned function body groups multiple operations in one composable, same
+  documented framework exception already used in `useGitHubAuth.ts` and `useStationStorage.ts`.
+
+status: ready

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/test-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-83/test-results.md
@@ -1,0 +1,23 @@
+# Test Results — Issue #64: GitHub Repository Preferences (Sub-Issue B, #83)
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.0) from the `feat/repo-configuration` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md), plus the full existing
+suite (`src/composables/useRepoConfig.spec.ts` alongside every other `*.spec.ts` file in the
+repo).
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+295 test files, 349 tests total — all passed.
+
+- Duration: ~5 seconds
+
+status: passed

--- a/netlify/functions/github-api-proxy/github-api-proxy.ts
+++ b/netlify/functions/github-api-proxy/github-api-proxy.ts
@@ -1,8 +1,10 @@
-// GET/PUT — proxies GitHub Contents API reads and writes using the token from the
-// `gh_token` cookie. `owner`/`repo`/`path` are forwarded exactly as supplied by the SPA;
-// there is no server-side cross-check (security-guidelines.md rule 4) — GitHub's own
-// OAuth token scope is the authorization boundary. A 401 from GitHub clears the cookie
-// so the SPA can prompt re-authentication instead of retrying with a dead token.
+// GET/PUT — proxies GitHub Contents API reads and writes, plus a repo-level
+// reachability check (GET without `path`, used by Sub-Issue B's config
+// validation), using the token from the `gh_token` cookie. `owner`/`repo`/`path`
+// are forwarded exactly as supplied by the SPA; there is no server-side
+// cross-check (security-guidelines.md rule 4) — GitHub's own OAuth token scope
+// is the authorization boundary. A 401 from GitHub clears the cookie so the
+// SPA can prompt re-authentication instead of retrying with a dead token.
 import type { Handler, HandlerEvent, HandlerResponse } from '@netlify/functions'
 import { buildExpiredCookie, isHttpsRequest, parseCookies } from '../lib/cookies'
 import { jsonResponse } from '../lib/http-responses'
@@ -19,6 +21,12 @@ interface ReadContentsRequest {
   path: string
 }
 
+interface RepoCheckRequest {
+  kind: 'repoCheck'
+  owner: string
+  repo: string
+}
+
 interface WriteContentsRequest {
   kind: 'write'
   owner: string
@@ -29,7 +37,7 @@ interface WriteContentsRequest {
   sha?: string
 }
 
-type ContentsRequest = ReadContentsRequest | WriteContentsRequest
+type ContentsRequest = ReadContentsRequest | RepoCheckRequest | WriteContentsRequest
 
 export const handler: Handler = async (event: HandlerEvent) => {
   if (event.httpMethod !== 'GET' && event.httpMethod !== 'PUT') {
@@ -43,7 +51,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
 
   const contentsRequest = buildContentsRequest(event)
   if (!contentsRequest) {
-    return jsonResponse(400, { error: 'Missing owner, repo, path, message, or content' })
+    return jsonResponse(400, { error: 'Missing owner/repo, or (for writes) message/content' })
   }
 
   return forwardToGithub(contentsRequest, accessToken, isHttpsRequest(event))
@@ -56,12 +64,17 @@ function buildContentsRequest(event: HandlerEvent): ContentsRequest | null {
   return buildWriteRequest(event)
 }
 
-function buildReadRequest(event: HandlerEvent): ReadContentsRequest | null {
+// A `path` query param requests a file read; omitting it requests a
+// repo-level reachability check (used by Sub-Issue B's config validation).
+function buildReadRequest(event: HandlerEvent): ReadContentsRequest | RepoCheckRequest | null {
   const owner = event.queryStringParameters?.owner
   const repo = event.queryStringParameters?.repo
   const path = event.queryStringParameters?.path
-  if (!owner || !repo || !path) {
+  if (!owner || !repo) {
     return null
+  }
+  if (!path) {
+    return { kind: 'repoCheck', owner, repo }
   }
   return { kind: 'read', owner, repo, path }
 }
@@ -125,22 +138,26 @@ function fetchGithubContents(contentsRequest: ContentsRequest, accessToken: stri
     Accept: GITHUB_ACCEPT_HEADER,
     'User-Agent': USER_AGENT,
   }
-  if (contentsRequest.kind === 'read') {
-    return fetch(url, { headers })
+  if (contentsRequest.kind === 'write') {
+    return fetch(url, {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(writeBody(contentsRequest)),
+    })
   }
-  return fetch(url, {
-    method: 'PUT',
-    headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(writeBody(contentsRequest)),
-  })
+  return fetch(url, { headers })
 }
 
 // Percent-encoding each segment prevents a value like `../other-repo` from escaping
-// the intended /repos/{owner}/{repo}/contents/{path} shape.
+// the intended /repos/{owner}/{repo}[/contents/{path}] shape.
 function contentsUrl(contentsRequest: ContentsRequest): string {
-  const { owner, repo, path } = contentsRequest
-  const encodedPath = path.split('/').map(encodeURIComponent).join('/')
-  return `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodedPath}`
+  const { owner, repo } = contentsRequest
+  const repoUrl = `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
+  if (contentsRequest.kind === 'repoCheck') {
+    return repoUrl
+  }
+  const encodedPath = contentsRequest.path.split('/').map(encodeURIComponent).join('/')
+  return `${repoUrl}/contents/${encodedPath}`
 }
 
 // Omitting `sha` tells GitHub to create the file; including it updates the existing

--- a/src/composables/useRepoConfig.spec.ts
+++ b/src/composables/useRepoConfig.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for useRepoConfig composable — Sub-Issue B, issue #64.
+ *
+ * useRepoConfig is a singleton composable (ADR-002): the module-level refs
+ * are shared across all consumers. vi.resetModules() + dynamic import() is
+ * used to get a fresh module instance (and therefore fresh reactive state)
+ * for each test, following the pattern established in useGitHubAuth.spec.ts.
+ *
+ * IndexedDB is mocked with an in-memory Map via vi.mock, same pattern as
+ * useGitHubAuth.spec.ts / useStationStorage.spec.ts.
+ *
+ * `validationError`'s exact message text is not part of the composable's
+ * public API (the constants are module-private), but is asserted verbatim
+ * here to match the source — keep in sync with REPO_NOT_REACHABLE_MESSAGE in
+ * useRepoConfig.ts if it changes.
+ *
+ * Only the scenarios satisfiable by this sub-issue's implementation (the
+ * composable itself, with no Settings UI yet — that is Sub-Issue E) are
+ * covered here. B-1 and B-5 describe Settings-page field enabled/disabled
+ * states, which belong to Sub-Issue E's component.
+ *
+ * Scenarios covered (test-cases.md, Sub-Issue B):
+ *   B-2 — valid repo config saves without validation while unauthenticated
+ *   B-3 — saved config persists across reloads and after login
+ *   B-4 — invalid repo config shows human-readable error once authenticated
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RepoConfigDraft } from '@/types/repo-config'
+
+// ---------------------------------------------------------------------------
+// In-memory IndexedDB mock
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, unknown>()
+
+vi.mock('@/utils/indexedDb', () => ({
+  get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+  set: vi.fn((key: string, value: unknown) => {
+    store.set(key, value)
+    return Promise.resolve()
+  }),
+  del: vi.fn((key: string) => {
+    store.delete(key)
+    return Promise.resolve()
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Constants mirrored from useRepoConfig.ts (module-private, not exported)
+// ---------------------------------------------------------------------------
+
+const REPO_CONFIG_KEY = 'repoConfig'
+const REPO_NOT_REACHABLE_MESSAGE =
+  "Le dépôt GitHub est introuvable ou inaccessible. Vérifiez son nom et vos droits d'accès."
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: RepoConfigDraft = {
+  ownerRepo: 'alice/my-stations',
+  filePath: 'stations.json',
+  revalidateCacheDays: 7,
+}
+
+async function freshComposable() {
+  vi.resetModules()
+  const mod = await import('./useRepoConfig')
+  return mod.useRepoConfig()
+}
+
+beforeEach(() => {
+  store.clear()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+// ---------------------------------------------------------------------------
+// B-2: Valid repo config saves without validation while unauthenticated
+// ---------------------------------------------------------------------------
+
+describe('B-2: valid repo config saves without validation while unauthenticated', () => {
+  it('persists the draft to IndexedDB, clears validationError, and never calls fetch', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(VALID_CONFIG, false)
+
+    expect(store.get(REPO_CONFIG_KEY)).toEqual(VALID_CONFIG)
+    expect(validationError.value).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// B-3: Saved config persists across reloads and after login
+// ---------------------------------------------------------------------------
+
+describe('B-3: saved config persists across reloads and after login', () => {
+  it('is readable via loadRepoConfig from a fresh composable instance, before and after login', async () => {
+    const saver = await freshComposable()
+    await saver.saveRepoConfig(VALID_CONFIG, false)
+
+    const beforeLogin = await freshComposable()
+    await beforeLogin.loadRepoConfig()
+    expect(beforeLogin.repoConfig.value).toEqual(VALID_CONFIG)
+
+    const afterLogin = await freshComposable()
+    await afterLogin.loadRepoConfig()
+    expect(afterLogin.repoConfig.value).toEqual(VALID_CONFIG)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// B-4: Invalid repo config shows human-readable error once authenticated
+// ---------------------------------------------------------------------------
+
+describe('B-4: invalid repo config shows human-readable error once authenticated', () => {
+  it('sets validationError to a human-readable message once the proxy reports the repo unreachable', async () => {
+    const invalidDraft: RepoConfigDraft = {
+      ownerRepo: 'nonexistent-user/nonexistent-repo',
+      filePath: 'stations.json',
+      revalidateCacheDays: 7,
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ status: 404 }),
+    )
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(invalidDraft, true)
+
+    expect(store.get(REPO_CONFIG_KEY)).toEqual(invalidDraft)
+    expect(validationError.value).toBe(REPO_NOT_REACHABLE_MESSAGE)
+  })
+})

--- a/src/composables/useRepoConfig.ts
+++ b/src/composables/useRepoConfig.ts
@@ -1,0 +1,144 @@
+/**
+ * Singleton composable for the GitHub repo-sync configuration draft
+ * (Sub-Issue B, issue #64): `owner/repo`, file path, `revalidate-cache-days`.
+ *
+ * Saving always persists to IndexedDB (ADR-008), regardless of auth state.
+ * Server-side validation (does the file exist, or failing that, is the repo
+ * itself reachable) only runs when the caller reports the user as
+ * authenticated — unauthenticated requests have no access token to call the
+ * `github-api-proxy` Netlify function with.
+ *
+ * Per the composable-caller-responsibility convention, this composable never
+ * calls `useGitHubAuth()` itself. A 401 from the proxy is reported back to
+ * the caller via the optional `onUnauthorized` callback, which the component
+ * wires to `useGitHubAuth().handleUnauthorized` in its own `setup()`.
+ *
+ * Object Calisthenics exception: the composable function body exceeds five
+ * lines because Vue composable conventions require grouping all returned
+ * reactive state and operations in one function — documented framework
+ * exception (see useGitHubAuth.ts, useStationStorage.ts).
+ */
+
+import { ref, toRaw } from 'vue'
+import type { Ref } from 'vue'
+import { get, set } from '@/utils/indexedDb'
+import type { RepoConfigDraft } from '@/types/repo-config'
+
+const REPO_CONFIG_KEY = 'repoConfig'
+const DEFAULT_REVALIDATE_CACHE_DAYS = 7
+const PROXY_PATH = '/.netlify/functions/github-api-proxy'
+const INVALID_FORMAT_MESSAGE =
+  'Le format attendu pour le dépôt est "proprietaire/depot" (ex. alice/mes-stations).'
+const MISSING_FILE_PATH_MESSAGE = 'Le chemin du fichier est requis.'
+const REPO_NOT_REACHABLE_MESSAGE =
+  "Le dépôt GitHub est introuvable ou inaccessible. Vérifiez son nom et vos droits d'accès."
+const VALIDATION_UNAVAILABLE_MESSAGE =
+  'Impossible de vérifier le dépôt GitHub pour le moment. Réessayez plus tard.'
+
+type ProxyCheckResult = 'ok' | 'notFound' | 'unauthorized' | 'error'
+type UnauthorizedCallback = (() => void | Promise<void>) | undefined
+
+interface OwnerRepo {
+  owner: string
+  repo: string
+}
+
+// Module-level state — all consumers share the same reference (ADR-002).
+const repoConfig: Ref<RepoConfigDraft> = ref(emptyRepoConfig())
+const validationError: Ref<string | null> = ref(null)
+
+function emptyRepoConfig(): RepoConfigDraft {
+  return { ownerRepo: '', filePath: '', revalidateCacheDays: DEFAULT_REVALIDATE_CACHE_DAYS }
+}
+
+function normalizeStoredConfig(stored: RepoConfigDraft | undefined): RepoConfigDraft {
+  if (!stored) return emptyRepoConfig()
+  return {
+    ownerRepo: stored.ownerRepo,
+    filePath: stored.filePath,
+    revalidateCacheDays: stored.revalidateCacheDays ?? DEFAULT_REVALIDATE_CACHE_DAYS,
+  }
+}
+
+function splitOwnerRepo(ownerRepo: string): OwnerRepo | null {
+  const [owner, repo, ...rest] = ownerRepo.trim().split('/')
+  if (!owner || !repo || rest.length > 0) return null
+  return { owner, repo }
+}
+
+function buildProxyUrl(ownerRepo: OwnerRepo, path?: string): string {
+  const params = new URLSearchParams({ owner: ownerRepo.owner, repo: ownerRepo.repo })
+  if (path) params.set('path', path)
+  return `${PROXY_PATH}?${params.toString()}`
+}
+
+function classifyProxyResponse(status: number): ProxyCheckResult {
+  if (status === 200) return 'ok'
+  if (status === 401) return 'unauthorized'
+  if (status === 404) return 'notFound'
+  return 'error'
+}
+
+async function checkProxyReachable(ownerRepo: OwnerRepo, path?: string): Promise<ProxyCheckResult> {
+  try {
+    const response = await fetch(buildProxyUrl(ownerRepo, path))
+    return classifyProxyResponse(response.status)
+  } catch {
+    return 'error'
+  }
+}
+
+async function notifyUnauthorized(onUnauthorized: UnauthorizedCallback): Promise<null> {
+  await onUnauthorized?.()
+  return null
+}
+
+async function resolveValidationError(
+  draft: RepoConfigDraft,
+  onUnauthorized: UnauthorizedCallback,
+): Promise<string | null> {
+  const ownerRepo = splitOwnerRepo(draft.ownerRepo)
+  if (!ownerRepo) return INVALID_FORMAT_MESSAGE
+  const filePath = draft.filePath.trim()
+  if (!filePath) return MISSING_FILE_PATH_MESSAGE
+  const fileCheck = await checkProxyReachable(ownerRepo, filePath)
+  if (fileCheck === 'ok') return null
+  if (fileCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  const repoCheck = await checkProxyReachable(ownerRepo)
+  if (repoCheck === 'ok') return null
+  if (repoCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  if (repoCheck === 'notFound') return REPO_NOT_REACHABLE_MESSAGE
+  return VALIDATION_UNAVAILABLE_MESSAGE
+}
+
+async function persistRepoConfig(draft: RepoConfigDraft): Promise<void> {
+  await set(REPO_CONFIG_KEY, { ...toRaw(draft) })
+}
+
+export function useRepoConfig() {
+  const loadRepoConfig = async (): Promise<void> => {
+    const stored = await get<RepoConfigDraft>(REPO_CONFIG_KEY)
+    repoConfig.value = normalizeStoredConfig(stored)
+  }
+
+  const saveRepoConfig = async (
+    draft: RepoConfigDraft,
+    isAuthenticated: boolean,
+    onUnauthorized?: () => void | Promise<void>,
+  ): Promise<void> => {
+    await persistRepoConfig(draft)
+    repoConfig.value = draft
+    if (!isAuthenticated) {
+      validationError.value = null
+      return
+    }
+    validationError.value = await resolveValidationError(draft, onUnauthorized)
+  }
+
+  return {
+    repoConfig,
+    validationError,
+    loadRepoConfig,
+    saveRepoConfig,
+  }
+}

--- a/src/composables/useRepoConfig.ts
+++ b/src/composables/useRepoConfig.ts
@@ -50,6 +50,11 @@ interface OwnerRepo {
 // Module-level state — all consumers share the same reference (ADR-002).
 const repoConfig: Ref<RepoConfigDraft> = ref(emptyRepoConfig())
 const validationError: Ref<string | null> = ref(null)
+
+// Object Calisthenics exception: a third module-level variable, beyond the two above.
+// It exists solely to guard against a stale, slower `saveRepoConfig` call overwriting
+// `validationError` after a newer call already resolved — it is not part of the composable's
+// public reactive surface (unlike `repoConfig`/`validationError`, it is never returned).
 let latestSaveRequestId = 0
 
 function emptyRepoConfig(): RepoConfigDraft {
@@ -149,7 +154,7 @@ export function useRepoConfig() {
   ): Promise<void> => {
     const requestId = ++latestSaveRequestId
     await persistRepoConfig(draft)
-    repoConfig.value = draft
+    if (requestId === latestSaveRequestId) repoConfig.value = { ...draft }
     if (!isAuthenticated) {
       if (requestId === latestSaveRequestId) validationError.value = null
       return

--- a/src/composables/useRepoConfig.ts
+++ b/src/composables/useRepoConfig.ts
@@ -9,9 +9,12 @@
  * `github-api-proxy` Netlify function with.
  *
  * Per the composable-caller-responsibility convention, this composable never
- * calls `useGitHubAuth()` itself. A 401 from the proxy is reported back to
- * the caller via the optional `onUnauthorized` callback, which the component
- * wires to `useGitHubAuth().handleUnauthorized` in its own `setup()`.
+ * calls `useGitHubAuth()` itself. A 401 from the proxy always resolves
+ * `validationError` to a re-authentication message (security-guidelines.md
+ * rule 5) regardless of wiring; the optional `onUnauthorized` callback is an
+ * additional notification the caller can wire to
+ * `useGitHubAuth().handleUnauthorized` in its own `setup()` to also update
+ * the shared auth state.
  *
  * Object Calisthenics exception: the composable function body exceeds five
  * lines because Vue composable conventions require grouping all returned
@@ -34,6 +37,7 @@ const REPO_NOT_REACHABLE_MESSAGE =
   "Le dépôt GitHub est introuvable ou inaccessible. Vérifiez son nom et vos droits d'accès."
 const VALIDATION_UNAVAILABLE_MESSAGE =
   'Impossible de vérifier le dépôt GitHub pour le moment. Réessayez plus tard.'
+const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
 
 type ProxyCheckResult = 'ok' | 'notFound' | 'unauthorized' | 'error'
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
@@ -46,6 +50,7 @@ interface OwnerRepo {
 // Module-level state — all consumers share the same reference (ADR-002).
 const repoConfig: Ref<RepoConfigDraft> = ref(emptyRepoConfig())
 const validationError: Ref<string | null> = ref(null)
+let latestSaveRequestId = 0
 
 function emptyRepoConfig(): RepoConfigDraft {
   return { ownerRepo: '', filePath: '', revalidateCacheDays: DEFAULT_REVALIDATE_CACHE_DAYS }
@@ -88,11 +93,26 @@ async function checkProxyReachable(ownerRepo: OwnerRepo, path?: string): Promise
   }
 }
 
-async function notifyUnauthorized(onUnauthorized: UnauthorizedCallback): Promise<null> {
-  await onUnauthorized?.()
-  return null
+// Always resolves to SESSION_EXPIRED_MESSAGE — even without an onUnauthorized callback, or
+// if that callback throws — so security-guidelines.md rule 5's UI prompt cannot be silently
+// skipped by a call site that forgets to wire the callback or whose callback fails. The
+// callback itself is an additional notification for the auth composable, not the sole
+// mechanism for surfacing the re-auth prompt.
+async function notifyUnauthorized(onUnauthorized: UnauthorizedCallback): Promise<string> {
+  try {
+    await onUnauthorized?.()
+  } catch {
+    // The session-expired message below is returned regardless of callback failures.
+  }
+  return SESSION_EXPIRED_MESSAGE
 }
 
+// Object Calisthenics exception: this guard-clause chain exceeds five lines because it
+// walks a sequential business rule (owner/repo format, then file-path presence, then the
+// file-exists-or-repo-reachable check business-specifications.md Sub-Issue B rule 2 names) —
+// splitting it further would fragment one coherent validation into indirection without
+// improving readability. Same documented exception as github-auth-callback.ts's
+// validateCallbackRequest (Sub-Issue F).
 async function resolveValidationError(
   draft: RepoConfigDraft,
   onUnauthorized: UnauthorizedCallback,
@@ -104,6 +124,7 @@ async function resolveValidationError(
   const fileCheck = await checkProxyReachable(ownerRepo, filePath)
   if (fileCheck === 'ok') return null
   if (fileCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  if (fileCheck === 'error') return VALIDATION_UNAVAILABLE_MESSAGE
   const repoCheck = await checkProxyReachable(ownerRepo)
   if (repoCheck === 'ok') return null
   if (repoCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
@@ -126,13 +147,15 @@ export function useRepoConfig() {
     isAuthenticated: boolean,
     onUnauthorized?: () => void | Promise<void>,
   ): Promise<void> => {
+    const requestId = ++latestSaveRequestId
     await persistRepoConfig(draft)
     repoConfig.value = draft
     if (!isAuthenticated) {
-      validationError.value = null
+      if (requestId === latestSaveRequestId) validationError.value = null
       return
     }
-    validationError.value = await resolveValidationError(draft, onUnauthorized)
+    const error = await resolveValidationError(draft, onUnauthorized)
+    if (requestId === latestSaveRequestId) validationError.value = error
   }
 
   return {


### PR DESCRIPTION
## Summary
- Add `useRepoConfig` composable (singleton, ADR-002) owning the repo-sync draft (`owner/repo`, file path, `revalidate-cache-days`)
- `saveRepoConfig` always persists to IndexedDB; validates against `github-api-proxy` only when authenticated (file-exists check first, repo-reachability check as fallback)
- Extend the `github-api-proxy` Netlify function to support a repo-level reachability check (GET without `path`)
- Guard against a stale-save race condition overwriting the composable's reactive state

## Test plan
- [x] `useRepoConfig.spec.ts` — B-2, B-3, B-4 scenarios from test-cases.md
- [x] Full suite: 295 files / 349 tests passing
- [x] `vue-tsc --build` clean
- [x] Targeted `eslint` clean on changed files

Closes #83
