### PR TITLE
Add settings UI for GitHub repo config and cache parameter

### DIFF
--- a/docs/prompts/tasks/issue-64-github-repo-preferences/business-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/business-specifications.md
@@ -160,11 +160,12 @@ page. Until then, verify the login-readiness check and auth state directly.)*
 ### How to test locally
 
 1. Start the app with `netlify dev`.
-2. Navigate to the Settings page while unauthenticated; confirm all GitHub Sync fields (`owner/repo`, file path, `revalidate-cache-days`) are enabled.
-3. Log in (Sub-Issue A); confirm `owner/repo` and file path become disabled while `revalidate-cache-days` stays enabled.
-4. Enter `0` or a negative number in `revalidate-cache-days`; confirm an inline validation error appears and the form cannot be saved.
-5. Enter a valid positive integer (e.g. `7`); confirm it saves successfully.
-6. Log out; confirm `owner/repo` and file path become enabled again.
+2. Navigate to the Settings page while unauthenticated with empty fields; confirm all GitHub Sync fields (`owner/repo`, file path, `revalidate-cache-days`) are enabled and the "Login with GitHub" button is disabled.
+3. Fill in `owner/repo`, file path, and a valid `revalidate-cache-days`; confirm the "Login with GitHub" button becomes enabled (Sub-Issue A, rule 1).
+4. Log in (Sub-Issue A); confirm `owner/repo` and file path become disabled while `revalidate-cache-days` stays enabled.
+5. Enter `0` or a negative number in `revalidate-cache-days`; confirm an inline validation error appears and the form cannot be saved.
+6. Enter a valid positive integer (e.g. `7`); confirm it saves successfully.
+7. Log out; confirm `owner/repo` and file path become enabled again.
 
 #### Going live
 

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/review-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/review-results.md
@@ -1,0 +1,113 @@
+# Review Results: Sub-Issue E — Settings UI for Repo Config and Cache Parameter
+
+## `rtk lint`
+
+`rtk lint` failed on this machine for reasons unrelated to the code under review:
+
+```
+Error: Failed to run eslint. Is it installed? Try: pip install eslint (or npm/pnpm for JS linters)
+
+Caused by:
+    program not found
+```
+
+`rtk` is not resolving the project-local `node_modules/.bin/eslint` binary (environment/PATH
+issue, not a code defect). Fell back to `npm run lint` (`eslint . --fix`) to still get lint
+coverage:
+
+```
+E:\...\src\composables\usePreferencesExport.spec.ts
+  39:5  error  'lastDownloaded' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+E:\...\src\composables\usePreferencesImport.spec.ts
+   36:15  error  'PreferencesDiff' is defined but never used       @typescript-eslint/no-unused-vars
+   71:33  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   72:36  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+   72:50  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   73:42  error  '_label' is defined but never used                @typescript-eslint/no-unused-vars
+  433:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  466:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  468:11  error  'externalUrl' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+✖ 9 problems (9 errors, 0 warnings)
+```
+
+All 9 errors are pre-existing, in `src/composables/usePreferencesExport.spec.ts` and
+`usePreferencesImport.spec.ts` — files untouched by this task. None of the changed files
+(`GitHubSyncSettings.vue`, `settings.vue`, `AppFooter.vue`) have any lint errors.
+
+## `npm run type-check`
+
+Passed cleanly, no output:
+
+```
+> vue-boilerplate-jli@0.0.0 type-check
+> vue-tsc --build
+```
+
+## Checklist
+
+- ✓ Every rule in `security-guidelines.md` (parent issue #64) is verifiably addressed:
+  - Rules 1, 2, 3, 4, 6 concern the Netlify functions (`github-auth-callback`,
+    `github-auth-start`, `github-api-proxy`) — none of those files are touched by this
+    sub-issue's changes, so they are not applicable here.
+  - Rule 5 ("treat any 401 as a signal to clear the cookie and prompt re-authentication"):
+    `GitHubSyncSettings.vue` wires `useGitHubAuth().handleUnauthorized` through to
+    `saveRepoConfig(currentDraft.value, isAuthenticated.value, handleUnauthorized)` in both
+    `onSave` and `onLogin`, matching the composable-caller-responsibility convention documented
+    in `useRepoConfig.ts` (the composable itself never calls `useGitHubAuth`). `useRepoConfig`'s
+    `resolveValidationError` already guarantees the re-auth message and callback invocation on a
+    401 (merged and reviewed in #83) — this component correctly supplies the callback rather
+    than omitting it.
+- ✓ Object Calisthenics respected:
+  - No `else`, no `reactive()` on primitives, no getters/setters.
+  - Domain type `RepoConfigDraft` used for the draft shape instead of loose fields.
+  - The 4 `ref`/`computed` bindings at module scope of `setup()` exceed the ≤2-instance-variable
+    guideline; the file documents this as the same framework exception already used in
+    `StationManagerTable.vue` (verified: that file declares 5 top-level `ref`s), so the
+    exception is consistent with existing project convention, not a new one-off.
+  - No abbreviations in any identifier (`ownerRepoDraft`, `filePathDraft`, `cacheDaysDraft`,
+    `currentDraft`, `cacheDaysError`, `loginReady`, `isSaving`, `onSave`, `onLogin`, `onLogout`).
+- ✓ Implementation matches business spec — Sub-Issue E rules 1–4, cross-checked against
+  test cases E-1 through E-7:
+  - Rule 1 (GitHub Sync section with login/logout + three fields): present.
+  - Rule 2 (`revalidate-cache-days` positive-integer validation, ≤0 rejected inline):
+    `parseCacheDays` rejects non-integers (including decimals) and `cacheDaysError` flags any
+    non-empty value that isn't a positive integer; the Save/Login buttons are disabled while
+    `cacheDaysError` is set. An empty field is deliberately not flagged as an inline error (only
+    blocks login-readiness) — this matches the documented decision and `useGitHubAuth`'s
+    existing `hasValidCacheDays` semantics (`!== null`), not a gap.
+  - Rule 3 (`owner/repo`/file path disabled once authenticated, log-out message,
+    `revalidate-cache-days` always editable): `:disabled="isAuthenticated"` on the first two
+    inputs only; the cache-days input carries no `:disabled` binding at all, so it stays
+    editable in both auth states.
+  - Rule 4 (login button gated by Sub-Issue A's `canInitiateLogin`): `loginReady` computed
+    calls `canInitiateLogin(currentDraft.value)` reactively.
+  - Post-review fix (draft persisted before OAuth navigation): confirmed present — `onLogin`
+    awaits `saveRepoConfig` before calling `login()`, gated behind `loginReady` so only a
+    complete/valid draft is persisted.
+  - No scope creep: the diff is limited to the new component, the new page, and the one-line
+    footer link addition.
+- ✓ No dead code, unused imports, or unreachable branches.
+- ✓ Naming clarity — no abbreviations, no single-letter variables.
+- ✓ Vue/TS pitfalls (checked against the fetched Vue reactivity-fundamentals and
+  reusability/composables guides):
+  - `useGitHubAuth()` and `useRepoConfig()` each return a plain object of individual `ref`s
+    (not a `reactive()`-wrapped object), so destructuring them in `GitHubSyncSettings.vue`
+    (`const { isAuthenticated, authError, ... } = useGitHubAuth()`) preserves reactivity per
+    Vue's documented composable convention — this is not the "destructuring a reactive object
+    loses reactivity" pitfall.
+  - No reactive property is watched directly (no `watch()` calls in this file), so the
+    getter-vs-direct-reactive-property pitfall does not apply.
+  - No props exist on this component (it has none defined), so no prop-mutation risk.
+  - No `reactive()` calls anywhere in the file.
+  - No `any`/`unknown`, no non-null `!` assertions; `parseCacheDays`, `onSave`, `onLogin`,
+    `onLogout` all carry explicit return types.
+  - No new composable is defined here (only consumed), so the `use`-prefix/`toValue()`/
+    `toRef()` conventions don't apply. No DOM event listeners or other side effects are
+    registered directly in this component, so no `onUnmounted` cleanup is needed.
+  - `<script async setup>` (enabling the top-level `await Promise.all([...])`) matches the
+    existing async-component + `<Suspense>` convention already used in
+    `StationManagerTable.vue` and `StationPricesContent.vue`.
+
+status: approved

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/review-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/review-results.md
@@ -1,4 +1,8 @@
-# Review Results: Sub-Issue E — Settings UI for Repo Config and Cache Parameter
+# Review Results: Sub-Issue E — Settings UI for Repo Config and Cache Parameter (re-review)
+
+This re-review covers the loop-back fix recorded in `technical-specifications.md`'s
+"Post-test-failure fix: revalidate-cache-days type mismatch crashed on user input" section
+(`src/components/GitHubSyncSettings.vue`), following the failures recorded in `test-results.md`.
 
 ## `rtk lint`
 
@@ -33,8 +37,8 @@ E:\...\src\composables\usePreferencesImport.spec.ts
 ```
 
 All 9 errors are pre-existing, in `src/composables/usePreferencesExport.spec.ts` and
-`usePreferencesImport.spec.ts` — files untouched by this task. None of the changed files
-(`GitHubSyncSettings.vue`, `settings.vue`, `AppFooter.vue`) have any lint errors.
+`usePreferencesImport.spec.ts` — files untouched by this task. `GitHubSyncSettings.vue` has no
+lint errors.
 
 ## `npm run type-check`
 
@@ -47,67 +51,49 @@ Passed cleanly, no output:
 
 ## Checklist
 
-- ✓ Every rule in `security-guidelines.md` (parent issue #64) is verifiably addressed:
-  - Rules 1, 2, 3, 4, 6 concern the Netlify functions (`github-auth-callback`,
-    `github-auth-start`, `github-api-proxy`) — none of those files are touched by this
-    sub-issue's changes, so they are not applicable here.
-  - Rule 5 ("treat any 401 as a signal to clear the cookie and prompt re-authentication"):
-    `GitHubSyncSettings.vue` wires `useGitHubAuth().handleUnauthorized` through to
-    `saveRepoConfig(currentDraft.value, isAuthenticated.value, handleUnauthorized)` in both
-    `onSave` and `onLogin`, matching the composable-caller-responsibility convention documented
-    in `useRepoConfig.ts` (the composable itself never calls `useGitHubAuth`). `useRepoConfig`'s
-    `resolveValidationError` already guarantees the re-auth message and callback invocation on a
-    401 (merged and reviewed in #83) — this component correctly supplies the callback rather
-    than omitting it.
+- ✓ Every rule in `security-guidelines.md` (parent issue #64) is verifiably addressed — no
+  change since the prior approved review: this fix touches only local form-state typing/parsing
+  inside `GitHubSyncSettings.vue` (`cacheDaysDraft`'s type, `parseCacheDays`, `cacheDaysError`).
+  None of the five security rules concern client-side form parsing of an already-client-only
+  value (`revalidate-cache-days` is never sent to a Netlify function directly; it only reaches
+  `saveRepoConfig`, unchanged).
 - ✓ Object Calisthenics respected:
-  - No `else`, no `reactive()` on primitives, no getters/setters.
-  - Domain type `RepoConfigDraft` used for the draft shape instead of loose fields.
-  - The 4 `ref`/`computed` bindings at module scope of `setup()` exceed the ≤2-instance-variable
-    guideline; the file documents this as the same framework exception already used in
-    `StationManagerTable.vue` (verified: that file declares 5 top-level `ref`s), so the
-    exception is consistent with existing project convention, not a new one-off.
-  - No abbreviations in any identifier (`ownerRepoDraft`, `filePathDraft`, `cacheDaysDraft`,
-    `currentDraft`, `cacheDaysError`, `loginReady`, `isSaving`, `onSave`, `onLogin`, `onLogout`).
-- ✓ Implementation matches business spec — Sub-Issue E rules 1–4, cross-checked against
-  test cases E-1 through E-7:
-  - Rule 1 (GitHub Sync section with login/logout + three fields): present.
-  - Rule 2 (`revalidate-cache-days` positive-integer validation, ≤0 rejected inline):
-    `parseCacheDays` rejects non-integers (including decimals) and `cacheDaysError` flags any
-    non-empty value that isn't a positive integer; the Save/Login buttons are disabled while
-    `cacheDaysError` is set. An empty field is deliberately not flagged as an inline error (only
-    blocks login-readiness) — this matches the documented decision and `useGitHubAuth`'s
-    existing `hasValidCacheDays` semantics (`!== null`), not a gap.
-  - Rule 3 (`owner/repo`/file path disabled once authenticated, log-out message,
-    `revalidate-cache-days` always editable): `:disabled="isAuthenticated"` on the first two
-    inputs only; the cache-days input carries no `:disabled` binding at all, so it stays
-    editable in both auth states.
-  - Rule 4 (login button gated by Sub-Issue A's `canInitiateLogin`): `loginReady` computed
-    calls `canInitiateLogin(currentDraft.value)` reactively.
-  - Post-review fix (draft persisted before OAuth navigation): confirmed present — `onLogin`
-    awaits `saveRepoConfig` before calling `login()`, gated behind `loginReady` so only a
-    complete/valid draft is persisted.
-  - No scope creep: the diff is limited to the new component, the new page, and the one-line
-    footer link addition.
+  - `parseCacheDays(raw: string | number): number | null` keeps one level of indentation, no
+    `else`, an early-return guard clause, and an explicit return type.
+  - `ref<string | number>(...)` uses Vue's own documented pattern for a union-typed ref
+    (confirmed against the fetched TypeScript-with-Composition-API guide: `const year =
+    ref<string | number>('2020')` is the exact idiom used here for `cacheDaysDraft`).
+  - No abbreviations introduced (`raw`, `trimmed`, `parsed` are pre-existing local names, not
+    new abbreviations).
+  - The one added comment explains a non-obvious framework behavior (Vue's `type="number"`
+    v-model auto-cast) rather than restating what the code does — consistent with the project's
+    "only comment on non-obvious WHY" convention.
+- ✓ Implementation matches business spec — no missing requirements, no scope creep: the fix is
+  scoped to the exact defect the failing tests identified (E-1, E-2, E-3, E-6, E-7), with no
+  unrelated changes. Re-verified against `test-cases.md`:
+  - E-1 (valid positive integer saves): `String(7).trim()` → `"7"` → `Number.isInteger(7)` →
+    saves; no regression.
+  - E-2/E-3 (zero/negative rejected): `String(0)`/`String(-3)` are non-empty, so the
+    empty-field short-circuit in `cacheDaysError` no longer swallows them; the inline error
+    still renders as before the crash was introduced.
+  - E-6 (fields retain values after logout): no longer crashes on re-render once `isAuthenticated`
+    flips, since `parseCacheDays`/`cacheDaysError` now tolerate whichever type
+    `cacheDaysDraft.value` holds.
+  - E-7 (login button reflects readiness): `parseCacheDays(7)` (number, as delivered by Vue's
+    real v-model cast after `setValue('7')`) now resolves correctly instead of throwing.
 - ✓ No dead code, unused imports, or unreachable branches.
 - ✓ Naming clarity — no abbreviations, no single-letter variables.
-- ✓ Vue/TS pitfalls (checked against the fetched Vue reactivity-fundamentals and
-  reusability/composables guides):
-  - `useGitHubAuth()` and `useRepoConfig()` each return a plain object of individual `ref`s
-    (not a `reactive()`-wrapped object), so destructuring them in `GitHubSyncSettings.vue`
-    (`const { isAuthenticated, authError, ... } = useGitHubAuth()`) preserves reactivity per
-    Vue's documented composable convention — this is not the "destructuring a reactive object
-    loses reactivity" pitfall.
-  - No reactive property is watched directly (no `watch()` calls in this file), so the
-    getter-vs-direct-reactive-property pitfall does not apply.
-  - No props exist on this component (it has none defined), so no prop-mutation risk.
-  - No `reactive()` calls anywhere in the file.
-  - No `any`/`unknown`, no non-null `!` assertions; `parseCacheDays`, `onSave`, `onLogin`,
-    `onLogout` all carry explicit return types.
-  - No new composable is defined here (only consumed), so the `use`-prefix/`toValue()`/
-    `toRef()` conventions don't apply. No DOM event listeners or other side effects are
-    registered directly in this component, so no `onUnmounted` cleanup is needed.
-  - `<script async setup>` (enabling the top-level `await Promise.all([...])`) matches the
-    existing async-component + `<Suspense>` convention already used in
-    `StationManagerTable.vue` and `StationPricesContent.vue`.
+- ✓ Vue/TS pitfalls (checked against the fetched reactivity-fundamentals,
+  reusability/composables, and TypeScript-with-Composition-API guides):
+  - The union-typed ref (`Ref<string | number>`) matches Vue's own documented idiom for a ref
+    holding more than one type, and matches `Input.vue`'s own declared prop type
+    (`modelValue?: string | number`), so `cacheDaysDraft` is now consistent with the component
+    it's bound to via `v-model` rather than assuming a narrower type than the DOM/runtime can
+    actually deliver.
+  - No destructuring-loses-reactivity issue: unchanged from the prior review — both composables
+    still return plain refs, not `reactive()`-wrapped objects.
+  - No `any`/`unknown`; the fix replaces an implicit "assume it's a string" bug with an
+    explicit, accurate union type instead of loosening to `any`.
+  - No new composables, side effects, or lifecycle hooks introduced by this fix.
 
 status: approved

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/technical-specifications.md
@@ -1,0 +1,37 @@
+# Technical Specifications — Sub-Issue E: Settings UI for Repo Config and Cache Parameter
+
+## Files changed
+
+- `src/components/GitHubSyncSettings.vue` (new) — the "GitHub Sync" section: login/logout control, `owner/repo` field, file path field, `revalidate-cache-days` field, inline validation, and the log-out-to-edit message. Wires Sub-Issue A's `useGitHubAuth` and Sub-Issue B's `useRepoConfig` together at the top level of its `setup()`.
+- `src/pages/settings.vue` (new) — the `/settings` route (file-based routing). Thin page shell (back-to-home link, heading) delegating to `GitHubSyncSettings`, wrapped in `<Suspense>` per the existing `StationManager`/`StationManagerTable` async-component convention.
+- `src/components/layout/AppFooter.vue` — added a `Paramètres` link to `/settings`, following the existing `Mentions légales` link pattern. Without it the new page would be unreachable from the UI.
+
+No new types were added: `RepoConfigDraft` (`src/types/repo-config.ts`, from Sub-Issue B) already covers the three-field contract this UI edits.
+
+## Non-trivial decisions
+
+- **Manual `@input`/`v-model` handling instead of `vee-validate`/`AppFormField`**: `AppFormField.vue` (vee-validate-based) is unused everywhere else in the codebase — the established, actively-used pattern for form fields is plain refs + computed validation (`StationManagerTable.vue`). Followed that convention instead of reviving the unused vee-validate path.
+- **shadcn `Input`/`Label`/`Button` components instead of raw `<input>`**: these are already auto-imported and used elsewhere (`Button` in `PreferencesDiffDialog.vue`); using them keeps styling Tailwind-only with no new custom CSS, per the project's styling convention. `Input.vue` has no declared `type`/`disabled`/`id` props, so those pass through to the root `<input>` via Vue's automatic attribute fallthrough — the same mechanism `PreferencesDiffDialog.vue` already relies on for `Button`'s `:disabled`.
+- **Explicit "Enregistrer" button rather than per-field blur-save**: the three fields form one `RepoConfigDraft` object persisted together via `saveRepoConfig`, and test cases (E-1/E-2/E-3) describe an explicit "save" action — unlike the station list, there's no natural single-field save unit here.
+- **`revalidate-cache-days` inline validation is reactive (`computed`), not blur-triggered**: gives immediate feedback as the user types and is trivially re-checked at save time, so a single source of truth (`cacheDaysError`) drives both the inline message and the Save button's disabled state — no separate imperative validation call needed.
+- **Empty `revalidate-cache-days` is not an inline error, but blocks login-readiness**: business-specifications.md only mandates a message for `≤ 0`; treating "not yet typed" as silently invalid-but-unblocking (rather than flashing an error on an untouched field) matches `useGitHubAuth`'s existing `hasValidCacheDays` check (`!== null`), which already treats `null` as "not ready" without needing a UI-level error string.
+- **`Promise.all` for the two initial loads**: `initializeAuthState()` (auth flag) and `loadRepoConfig()` (repo config) read independent IndexedDB keys with no data dependency between them, so they run concurrently instead of sequentially.
+- **Local `isSaving` guard around `saveRepoConfig`**: prevents a double-click from firing two concurrent GitHub-proxy validation calls; `useRepoConfig`'s own `latestSaveRequestId` guard already prevents a stale response from corrupting `repoConfig`/`validationError`, but does not prevent the redundant network calls themselves — the UI-level guard closes that gap without touching the already-merged (#83) composable.
+
+## Post-review fix: draft lost on login
+
+**Reported behavior**: filling in `owner/repo` and file path, then clicking "Se connecter avec GitHub" without first clicking "Enregistrer", left both fields empty after the OAuth round-trip — nothing was ever written to IndexedDB.
+
+**Root cause**: `login()` (`useGitHubAuth`) performs a full-page navigation to GitHub (`window.location.href = ...`), which is required by the Authorization Code flow (ADR-011) but destroys the component instance and any draft only held in `ownerRepoDraft`/`filePathDraft`/`cacheDaysDraft`. The Settings page never got a chance to persist it.
+
+**Fix**: `onLogin()` now calls `saveRepoConfig(currentDraft.value, ...)` and awaits it before calling `login()`. This is gated behind the same `loginReady` check that already enables the button, so it only ever persists a draft that's already complete and valid — it doesn't silently save partial/invalid data.
+
+## Note on a spec/implementation discrepancy inherited from Sub-Issue B (not blocking)
+
+business-specifications.md, Sub-Issue B rule 3, states "For users who have never authenticated, all three fields are empty." However `useRepoConfig.ts`'s `emptyRepoConfig()` (merged in #83) defaults `revalidateCacheDays` to `7`, not empty — consistent with Sub-Issue C rule 1 ("default: 7 days, editable from Settings UI"). This UI reads whatever `useRepoConfig` returns, so first-time users see `revalidate-cache-days` pre-filled with `7` rather than blank. No Sub-Issue E test case (E-1 through E-7) tests the first-load value of this field, so this does not block any test case here — flagging it for awareness rather than as a blocking incoherence, since resolving it would mean changing Sub-Issue B's already-reviewed, already-tested composable.
+
+## Also noted, not fixed (out of scope)
+
+Each "Enregistrer" click while authenticated re-runs full server-side validation (`resolveValidationError`) of `owner/repo` and file path even when only `revalidate-cache-days` changed, costing up to two GitHub API calls per save. Fixing this would require changing `useRepoConfig.saveRepoConfig`'s signature/behavior (Sub-Issue B, already merged and tested in #83) — left untouched to avoid an undocumented cross-scope change.
+
+status: ready

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/technical-specifications.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/technical-specifications.md
@@ -26,6 +26,40 @@ No new types were added: `RepoConfigDraft` (`src/types/repo-config.ts`, from Sub
 
 **Fix**: `onLogin()` now calls `saveRepoConfig(currentDraft.value, ...)` and awaits it before calling `login()`. This is gated behind the same `loginReady` check that already enables the button, so it only ever persists a draft that's already complete and valid — it doesn't silently save partial/invalid data.
 
+## Post-test-failure fix: revalidate-cache-days type mismatch crashed on user input
+
+**Reported behavior**: `GitHubSyncSettings.spec.ts` (5 scenarios: E-1, E-2, E-3, E-6, E-7) failed
+with `TypeError: ....trim is not a function`, thrown from `parseCacheDays` and `cacheDaysError`.
+
+**Root cause**: `cacheDaysDraft` was declared as `Ref<string>` and both `parseCacheDays(raw:
+string)` and `cacheDaysError` called `.trim()` on it directly. Vue's native `v-model` runtime
+auto-casts the bound value to `Number` for any `<input>` whose `type` attribute is `"number"` —
+this happens whether or not a `.number` modifier is present. Since `Input.vue`'s internal
+`<input v-model="modelValue">` inherits `type="number"` via attribute fallthrough from
+`<Input id="revalidateCacheDays" type="number" ... v-model="cacheDaysDraft" />`
+(`GitHubSyncSettings.vue`), every real edit to that field — not just the test's `setValue()` —
+delivers a `number` to `cacheDaysDraft`, not the `string` its original type declared. This was a
+genuine runtime defect reproducible in a real browser, not a wrong test assertion: typing a
+value into "Fréquence de synchronisation (jours)" would have thrown immediately.
+
+**Fix**: `cacheDaysDraft` is now typed `Ref<string | number>`, matching what Vue's runtime
+actually delivers. `parseCacheDays` now accepts `string | number` and normalizes via
+`String(raw).trim()` instead of `raw.trim()`; `cacheDaysError` does the same
+(`String(cacheDaysDraft.value).trim()`). This preserves the deliberate `type="number"` input
+(native numeric keypad on mobile, spinner UI, `min="1"` semantics) rather than switching to
+`type="text"`, while making the two call sites tolerant of either type Vue may hand them.
+
+**Self-review — two additional cases checked, no further defect found**:
+- Garbage non-numeric text (e.g. `"7abc"`) still correctly resolves `parseCacheDays` to `null`
+  and `cacheDaysError` to the inline error message — `String("7abc").trim()` is non-empty, so
+  the empty-field short-circuit in `cacheDaysError` does not swallow it.
+- A native `<input type="number">` returns `""` from its own `.value` getter for a
+  syntactically-incomplete entry (e.g. the user has typed only `"-"`), independent of this
+  component's code — a browser-level quirk of `type="number"` inputs, not fixable at this
+  layer without dropping the native numeric input type; `revalidate-cache-days` is not listed
+  in `test-cases.md` as needing to handle that specific incomplete-entry state, so it is
+  flagged for awareness rather than changed.
+
 ## Note on a spec/implementation discrepancy inherited from Sub-Issue B (not blocking)
 
 business-specifications.md, Sub-Issue B rule 3, states "For users who have never authenticated, all three fields are empty." However `useRepoConfig.ts`'s `emptyRepoConfig()` (merged in #83) defaults `revalidateCacheDays` to `7`, not empty — consistent with Sub-Issue C rule 1 ("default: 7 days, editable from Settings UI"). This UI reads whatever `useRepoConfig` returns, so first-time users see `revalidate-cache-days` pre-filled with `7` rather than blank. No Sub-Issue E test case (E-1 through E-7) tests the first-load value of this field, so this does not block any test case here — flagging it for awareness rather than as a blocking incoherence, since resolving it would mean changing Sub-Issue B's already-reviewed, already-tested composable.

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/test-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/test-results.md
@@ -1,0 +1,85 @@
+# Test Results — Issue #64: Sub-Issue E — Settings UI for Repo Config and Cache Parameter
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.0) from the
+`french-gas-stations-scraper_feat-settings-ui-repo-config-cache` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md), plus the full existing
+suite (303 test files, 356 tests total).
+
+## Results
+
+### Failures
+
+All 5 failures are in `src/components/GitHubSyncSettings.spec.ts` and share the same root
+cause: `TypeError: ....trim is not a function` — the value flowing into `cacheDaysDraft` /
+`parseCacheDays` is a `number`, not a `string`, once the `revalidate-cache-days` `<Input
+type="number">` is edited. `cacheDaysDraft` is a `Ref<string>` and `parseCacheDays(raw: string)`
+calls `raw.trim()` unconditionally, but Vue 3's native `v-model` runtime auto-casts to `Number`
+for any native `<input>` whose `type` attribute is `"number"` — regardless of a `.number`
+modifier being present or not. `Input.vue`'s internal `<input v-model="modelValue" ...>`
+inherits `type="number"` via attribute fallthrough from `GitHubSyncSettings.vue`'s
+`<Input type="number" ... v-model="cacheDaysDraft" />`, so every edit to that field, in a real
+browser, delivers a `number` to `cacheDaysDraft`, not the `string` its type declares. This is a
+code defect, not a wrong test assertion — the tests correctly simulate a user typing into the
+field via `setValue()`, matching real `<input type="number">` behavior in the browser (and in
+happy-dom).
+
+#### E-1: revalidate-cache-days field accepts valid positive integer — saves successfully with no validation error shown
+
+- File: `src/components/GitHubSyncSettings.spec.ts`
+- Error:
+```
+TypeError: cacheDaysDraft.value.trim is not a function
+    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
+```
+
+#### E-2: revalidate-cache-days field rejects zero — shows an inline validation error and does not save
+
+- File: `src/components/GitHubSyncSettings.spec.ts`
+- Error:
+```
+TypeError: cacheDaysDraft.value.trim is not a function
+    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
+```
+
+#### E-3: revalidate-cache-days field rejects negative numbers — shows an inline validation error and does not save
+
+- File: `src/components/GitHubSyncSettings.spec.ts`
+- Error:
+```
+TypeError: cacheDaysDraft.value.trim is not a function
+    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
+```
+
+#### E-6: owner/repo and file path fields re-enabled after logout — re-enables owner/repo and file path, retaining their values, after clicking logout
+
+- File: `src/components/GitHubSyncSettings.spec.ts`
+- Error:
+```
+TypeError: raw.trim is not a function
+    at parseCacheDays (src/components/GitHubSyncSettings.vue:51:23)
+    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:60:24)
+```
+
+#### E-7: login button reflects the login-readiness check — is disabled while revalidate-cache-days is empty, and enabled once it is filled in
+
+- File: `src/components/GitHubSyncSettings.spec.ts`
+- Error:
+```
+TypeError: cacheDaysDraft.value.trim is not a function
+    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
+```
+
+### Test Summary
+
+303 test files, 356 tests total — 5 failed.
+
+- Test files: 297 passed, 1 failed
+- Tests: 351 passed (5 failed)
+- Duration: ~4 seconds
+
+status: failed

--- a/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/test-results.md
+++ b/docs/prompts/tasks/issue-64-github-repo-preferences/sub-issue-84/test-results.md
@@ -12,74 +12,12 @@ suite (303 test files, 356 tests total).
 
 ## Results
 
-### Failures
-
-All 5 failures are in `src/components/GitHubSyncSettings.spec.ts` and share the same root
-cause: `TypeError: ....trim is not a function` — the value flowing into `cacheDaysDraft` /
-`parseCacheDays` is a `number`, not a `string`, once the `revalidate-cache-days` `<Input
-type="number">` is edited. `cacheDaysDraft` is a `Ref<string>` and `parseCacheDays(raw: string)`
-calls `raw.trim()` unconditionally, but Vue 3's native `v-model` runtime auto-casts to `Number`
-for any native `<input>` whose `type` attribute is `"number"` — regardless of a `.number`
-modifier being present or not. `Input.vue`'s internal `<input v-model="modelValue" ...>`
-inherits `type="number"` via attribute fallthrough from `GitHubSyncSettings.vue`'s
-`<Input type="number" ... v-model="cacheDaysDraft" />`, so every edit to that field, in a real
-browser, delivers a `number` to `cacheDaysDraft`, not the `string` its type declares. This is a
-code defect, not a wrong test assertion — the tests correctly simulate a user typing into the
-field via `setValue()`, matching real `<input type="number">` behavior in the browser (and in
-happy-dom).
-
-#### E-1: revalidate-cache-days field accepts valid positive integer — saves successfully with no validation error shown
-
-- File: `src/components/GitHubSyncSettings.spec.ts`
-- Error:
-```
-TypeError: cacheDaysDraft.value.trim is not a function
-    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
-```
-
-#### E-2: revalidate-cache-days field rejects zero — shows an inline validation error and does not save
-
-- File: `src/components/GitHubSyncSettings.spec.ts`
-- Error:
-```
-TypeError: cacheDaysDraft.value.trim is not a function
-    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
-```
-
-#### E-3: revalidate-cache-days field rejects negative numbers — shows an inline validation error and does not save
-
-- File: `src/components/GitHubSyncSettings.spec.ts`
-- Error:
-```
-TypeError: cacheDaysDraft.value.trim is not a function
-    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
-```
-
-#### E-6: owner/repo and file path fields re-enabled after logout — re-enables owner/repo and file path, retaining their values, after clicking logout
-
-- File: `src/components/GitHubSyncSettings.spec.ts`
-- Error:
-```
-TypeError: raw.trim is not a function
-    at parseCacheDays (src/components/GitHubSyncSettings.vue:51:23)
-    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:60:24)
-```
-
-#### E-7: login button reflects the login-readiness check — is disabled while revalidate-cache-days is empty, and enabled once it is filled in
-
-- File: `src/components/GitHubSyncSettings.spec.ts`
-- Error:
-```
-TypeError: cacheDaysDraft.value.trim is not a function
-    at ComputedRefImpl.fn (src/components/GitHubSyncSettings.vue:68:28)
-```
+All tests passed. No failures.
 
 ### Test Summary
 
-303 test files, 356 tests total — 5 failed.
+303 test files, 356 tests total — all passed.
 
-- Test files: 297 passed, 1 failed
-- Tests: 351 passed (5 failed)
-- Duration: ~4 seconds
+- Duration: ~8 seconds
 
-status: failed
+status: passed

--- a/src/components/GitHubSyncSettings.spec.ts
+++ b/src/components/GitHubSyncSettings.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for GitHubSyncSettings.vue — Sub-Issue E, issue #64.
+ *
+ * `useGitHubAuth` and `useRepoConfig` are mocked (same pattern as
+ * StationManagerTable.spec.ts mocking useStationStorage): the component
+ * consumes both composables directly at the top level of its `setup()`, so
+ * this test only exercises the component's own wiring/rendering logic, not
+ * the composables themselves (already covered by useGitHubAuth.spec.ts and
+ * useRepoConfig.spec.ts).
+ *
+ * `canInitiateLogin` is mocked with a faithful copy of the real rule
+ * (non-empty ownerRepo/filePath, positive-integer revalidateCacheDays) so
+ * E-7 can verify the component reacts to it, without re-testing the rule
+ * itself (already covered by useGitHubAuth.spec.ts A-1/A-2).
+ *
+ * Scenarios covered (test-cases.md, Sub-Issue E):
+ *   E-1 — revalidate-cache-days field accepts valid positive integer
+ *   E-2 — revalidate-cache-days field rejects zero
+ *   E-3 — revalidate-cache-days field rejects negative numbers
+ *   E-4 — all GitHub Sync fields enabled when unauthenticated
+ *   E-5 — owner/repo and file path fields disabled after login
+ *   E-6 — owner/repo and file path fields re-enabled after logout
+ *   E-7 — login button reflects the login-readiness check
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { defineComponent, ref } from 'vue'
+import type { Ref } from 'vue'
+import GitHubSyncSettings from './GitHubSyncSettings.vue'
+import type { RepoConfigDraft } from '@/types/repo-config'
+
+// ---------------------------------------------------------------------------
+// Mock useGitHubAuth
+// ---------------------------------------------------------------------------
+
+const mockIsAuthenticated: Ref<boolean> = ref(false)
+const mockAuthError: Ref<string | null> = ref(null)
+const mockInitializeAuthState = vi.fn().mockResolvedValue(undefined)
+const mockLogin = vi.fn()
+const mockLogout = vi.fn().mockImplementation(async () => {
+  mockIsAuthenticated.value = false
+})
+const mockHandleUnauthorized = vi.fn().mockResolvedValue(undefined)
+
+function canInitiateLoginImpl(config: RepoConfigDraft): boolean {
+  const hasRequiredRepoConfig = config.ownerRepo.trim().length > 0 && config.filePath.trim().length > 0
+  const hasValidCacheDays = config.revalidateCacheDays !== null && config.revalidateCacheDays > 0
+  return hasRequiredRepoConfig && hasValidCacheDays
+}
+const mockCanInitiateLogin = vi.fn(canInitiateLoginImpl)
+
+vi.mock('@/composables/useGitHubAuth', () => ({
+  useGitHubAuth: () => ({
+    isAuthenticated: mockIsAuthenticated,
+    authError: mockAuthError,
+    initializeAuthState: mockInitializeAuthState,
+    canInitiateLogin: mockCanInitiateLogin,
+    login: mockLogin,
+    logout: mockLogout,
+    handleUnauthorized: mockHandleUnauthorized,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock useRepoConfig
+// ---------------------------------------------------------------------------
+
+const mockRepoConfig: Ref<RepoConfigDraft> = ref({
+  ownerRepo: '',
+  filePath: '',
+  revalidateCacheDays: 7,
+})
+const mockValidationError: Ref<string | null> = ref(null)
+const mockLoadRepoConfig = vi.fn().mockResolvedValue(undefined)
+const mockSaveRepoConfig = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/composables/useRepoConfig', () => ({
+  useRepoConfig: () => ({
+    repoConfig: mockRepoConfig,
+    validationError: mockValidationError,
+    loadRepoConfig: mockLoadRepoConfig,
+    saveRepoConfig: mockSaveRepoConfig,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount GitHubSyncSettings inside a <Suspense> boundary.
+ * GitHubSyncSettings uses a top-level await — Vue requires a Suspense ancestor.
+ */
+function mountComponent() {
+  const Wrapper = defineComponent({
+    components: { GitHubSyncSettings },
+    template: '<Suspense><GitHubSyncSettings /></Suspense>',
+  })
+  return mount(Wrapper)
+}
+
+function findButtonByText(wrapper: VueWrapper, text: string) {
+  const buttons = wrapper.findAll('button')
+  const match = buttons.find((button) => button.text().includes(text))
+  if (!match) throw new Error(`No button found with text containing "${text}"`)
+  return match
+}
+
+function inputElement(wrapper: VueWrapper, id: string): HTMLInputElement {
+  return wrapper.find(`#${id}`).element as HTMLInputElement
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsAuthenticated.value = false
+  mockAuthError.value = null
+  mockRepoConfig.value = { ownerRepo: '', filePath: '', revalidateCacheDays: 7 }
+  mockValidationError.value = null
+  mockInitializeAuthState.mockResolvedValue(undefined)
+  mockLoadRepoConfig.mockResolvedValue(undefined)
+  mockSaveRepoConfig.mockResolvedValue(undefined)
+  mockLogin.mockReset()
+  mockLogout.mockImplementation(async () => {
+    mockIsAuthenticated.value = false
+  })
+  mockHandleUnauthorized.mockResolvedValue(undefined)
+  mockCanInitiateLogin.mockImplementation(canInitiateLoginImpl)
+})
+
+// ---------------------------------------------------------------------------
+// E-1: revalidate-cache-days field accepts valid positive integer
+// ---------------------------------------------------------------------------
+
+describe('E-1: revalidate-cache-days field accepts valid positive integer', () => {
+  it('saves successfully with no validation error shown', async () => {
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: null }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    await wrapper.find('#revalidateCacheDays').setValue('7')
+    await findButtonByText(wrapper, 'Enregistrer').trigger('click')
+    await flushPromises()
+
+    expect(mockSaveRepoConfig).toHaveBeenCalledWith(
+      { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 },
+      false,
+      mockHandleUnauthorized,
+    )
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// E-2: revalidate-cache-days field rejects zero
+// ---------------------------------------------------------------------------
+
+describe('E-2: revalidate-cache-days field rejects zero', () => {
+  it('shows an inline validation error and does not save', async () => {
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    await wrapper.find('#revalidateCacheDays').setValue('0')
+    const saveButton = findButtonByText(wrapper, 'Enregistrer')
+    await saveButton.trigger('click')
+    await flushPromises()
+
+    expect(saveButton.attributes('disabled')).toBeDefined()
+    expect(mockSaveRepoConfig).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Le nombre de jours doit être un entier positif.')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// E-3: revalidate-cache-days field rejects negative numbers
+// ---------------------------------------------------------------------------
+
+describe('E-3: revalidate-cache-days field rejects negative numbers', () => {
+  it('shows an inline validation error and does not save', async () => {
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    await wrapper.find('#revalidateCacheDays').setValue('-3')
+    const saveButton = findButtonByText(wrapper, 'Enregistrer')
+    await saveButton.trigger('click')
+    await flushPromises()
+
+    expect(saveButton.attributes('disabled')).toBeDefined()
+    expect(mockSaveRepoConfig).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Le nombre de jours doit être un entier positif.')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// E-4: All GitHub Sync fields enabled when unauthenticated
+// ---------------------------------------------------------------------------
+
+describe('E-4: all GitHub Sync fields enabled when unauthenticated', () => {
+  it('renders owner/repo, file path, and revalidate-cache-days without a disabled attribute', async () => {
+    mockIsAuthenticated.value = false
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(inputElement(wrapper, 'ownerRepo').disabled).toBe(false)
+    expect(inputElement(wrapper, 'filePath').disabled).toBe(false)
+    expect(inputElement(wrapper, 'revalidateCacheDays').disabled).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// E-5: Owner, Repo, and file path GitHub Sync fields disabled after login
+// ---------------------------------------------------------------------------
+
+describe('E-5: owner/repo and file path fields disabled after login', () => {
+  it('disables owner/repo and file path but keeps revalidate-cache-days enabled', async () => {
+    mockIsAuthenticated.value = true
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(inputElement(wrapper, 'ownerRepo').disabled).toBe(true)
+    expect(inputElement(wrapper, 'filePath').disabled).toBe(true)
+    expect(inputElement(wrapper, 'revalidateCacheDays').disabled).toBe(false)
+    expect(wrapper.text()).toContain('Déconnectez-vous pour modifier le dépôt et le chemin du fichier.')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// E-6: Owner, Repo, and file path fields re-enabled after logout
+// ---------------------------------------------------------------------------
+
+describe('E-6: owner/repo and file path fields re-enabled after logout', () => {
+  it('re-enables owner/repo and file path, retaining their values, after clicking logout', async () => {
+    mockIsAuthenticated.value = true
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    await findButtonByText(wrapper, 'Se déconnecter').trigger('click')
+    await flushPromises()
+
+    expect(mockLogout).toHaveBeenCalled()
+    expect(inputElement(wrapper, 'ownerRepo').disabled).toBe(false)
+    expect(inputElement(wrapper, 'filePath').disabled).toBe(false)
+    expect(inputElement(wrapper, 'ownerRepo').value).toBe('alice/repo')
+    expect(inputElement(wrapper, 'filePath').value).toBe('stations.json')
+    expect(inputElement(wrapper, 'revalidateCacheDays').disabled).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// E-7: Login button reflects the login-readiness check
+// ---------------------------------------------------------------------------
+
+describe('E-7: login button reflects the login-readiness check', () => {
+  it('is disabled while revalidate-cache-days is empty, and enabled once it is filled in', async () => {
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: null }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const loginButton = findButtonByText(wrapper, 'Se connecter avec GitHub')
+    expect(loginButton.attributes('disabled')).toBeDefined()
+
+    await wrapper.find('#revalidateCacheDays').setValue('7')
+
+    expect(findButtonByText(wrapper, 'Se connecter avec GitHub').attributes('disabled')).toBeUndefined()
+  })
+})

--- a/src/components/GitHubSyncSettings.vue
+++ b/src/components/GitHubSyncSettings.vue
@@ -1,0 +1,160 @@
+<script async setup lang="ts">
+/**
+ * Settings-page section for GitHub sync (Sub-Issue E, issue #64): renders the
+ * login/logout control and the `owner/repo`, file path, and
+ * `revalidate-cache-days` fields, wiring Sub-Issue A's `useGitHubAuth` and
+ * Sub-Issue B's `useRepoConfig` composables together.
+ *
+ * Per the composable-caller-responsibility convention, both composables are
+ * called only here, at the top level of `setup()`; `handleUnauthorized` is
+ * passed into `saveRepoConfig` so a 401 during validation also updates the
+ * shared auth state, without `useRepoConfig` ever calling `useGitHubAuth`
+ * itself.
+ *
+ * Object Calisthenics exception: four `ref`/`computed` bindings are declared
+ * at module scope of this `setup()` (beyond the two-instance-variable
+ * guideline) because Vue's Composition API requires each piece of reactive
+ * form state to be its own binding — documented framework exception, as in
+ * StationManagerTable.vue.
+ */
+
+import { ref, computed } from 'vue'
+import { useGitHubAuth } from '@/composables/useGitHubAuth'
+import { useRepoConfig } from '@/composables/useRepoConfig'
+import type { RepoConfigDraft } from '@/types/repo-config'
+
+const CACHE_DAYS_ERROR_MESSAGE = 'Le nombre de jours doit être un entier positif.'
+
+const {
+  isAuthenticated,
+  authError,
+  initializeAuthState,
+  canInitiateLogin,
+  login,
+  logout,
+  handleUnauthorized,
+} = useGitHubAuth()
+const { repoConfig, validationError, loadRepoConfig, saveRepoConfig } = useRepoConfig()
+
+// The auth flag and the repo config live under separate IndexedDB keys with
+// no data dependency between them, so loading them in parallel halves the
+// wait before this component resolves compared to sequential awaits.
+await Promise.all([initializeAuthState(), loadRepoConfig()])
+
+const ownerRepoDraft = ref(repoConfig.value.ownerRepo)
+const filePathDraft = ref(repoConfig.value.filePath)
+const cacheDaysDraft = ref(
+  repoConfig.value.revalidateCacheDays === null ? '' : String(repoConfig.value.revalidateCacheDays),
+)
+
+function parseCacheDays(raw: string): number | null {
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  const parsed = Number(trimmed)
+  return Number.isInteger(parsed) ? parsed : null
+}
+
+const currentDraft = computed<RepoConfigDraft>(() => ({
+  ownerRepo: ownerRepoDraft.value,
+  filePath: filePathDraft.value,
+  revalidateCacheDays: parseCacheDays(cacheDaysDraft.value),
+}))
+
+// An empty field is treated as "not yet set" (no error, but login-readiness
+// still gates on it via `currentDraft`) — only a non-empty value that fails
+// to parse as a positive integer (garbage text, "0", a negative number) is
+// reported as an inline error.
+const cacheDaysError = computed<string>(() => {
+  if (cacheDaysDraft.value.trim() === '') return ''
+  const parsed = currentDraft.value.revalidateCacheDays
+  if (parsed !== null && parsed > 0) return ''
+  return CACHE_DAYS_ERROR_MESSAGE
+})
+
+const loginReady = computed(() => canInitiateLogin(currentDraft.value))
+const isSaving = ref(false)
+
+async function onSave(): Promise<void> {
+  if (cacheDaysError.value !== '' || isSaving.value) return
+  isSaving.value = true
+  try {
+    await saveRepoConfig(currentDraft.value, isAuthenticated.value, handleUnauthorized)
+  } finally {
+    isSaving.value = false
+  }
+}
+
+// Logging in navigates the browser away to GitHub (ADR-011's Authorization
+// Code flow) and never returns to this component instance — any unsaved
+// draft still only in these refs would be lost. The login button is only
+// enabled once the draft is already complete and valid (`loginReady`), so
+// persisting it here before navigating is safe and expected, not a surprise
+// side effect.
+async function onLogin(): Promise<void> {
+  if (!loginReady.value || isSaving.value) return
+  isSaving.value = true
+  try {
+    await saveRepoConfig(currentDraft.value, isAuthenticated.value, handleUnauthorized)
+  } finally {
+    isSaving.value = false
+  }
+  login()
+}
+
+async function onLogout(): Promise<void> {
+  await logout()
+}
+</script>
+
+<template>
+  <section class="flex flex-col gap-4 w-full">
+    <h2 class="text-xl font-semibold">Synchronisation GitHub</h2>
+
+    <p v-if="authError" role="alert" class="text-sm text-red-600">{{ authError }}</p>
+    <p v-if="validationError" role="alert" class="text-sm text-red-600">{{ validationError }}</p>
+
+    <div class="flex flex-col gap-1">
+      <Label for="ownerRepo">Dépôt (owner/repo)</Label>
+      <Input
+        id="ownerRepo"
+        type="text"
+        placeholder="alice/mes-stations"
+        v-model="ownerRepoDraft"
+        :disabled="isAuthenticated"
+      />
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <Label for="filePath">Chemin du fichier</Label>
+      <Input
+        id="filePath"
+        type="text"
+        placeholder="stations.json"
+        v-model="filePathDraft"
+        :disabled="isAuthenticated"
+      />
+    </div>
+
+    <p v-if="isAuthenticated" class="text-sm text-gray-600">
+      Déconnectez-vous pour modifier le dépôt et le chemin du fichier.
+    </p>
+
+    <div class="flex flex-col gap-1">
+      <Label for="revalidateCacheDays">Fréquence de synchronisation (jours)</Label>
+      <Input id="revalidateCacheDays" type="number" min="1" v-model="cacheDaysDraft" />
+      <span v-if="cacheDaysError" role="alert" class="text-xs text-red-500">{{
+        cacheDaysError
+      }}</span>
+    </div>
+
+    <div class="flex gap-3">
+      <Button :disabled="cacheDaysError !== '' || isSaving" @click="onSave">
+        {{ isAuthenticated ? 'Enregistrer la fréquence' : 'Enregistrer les paramètres' }}
+      </Button>
+      <Button v-if="!isAuthenticated" :disabled="!loginReady || isSaving" @click="onLogin">
+        Se connecter avec GitHub
+      </Button>
+      <Button v-else variant="outline" @click="onLogout">Se déconnecter</Button>
+    </div>
+  </section>
+</template>

--- a/src/components/GitHubSyncSettings.vue
+++ b/src/components/GitHubSyncSettings.vue
@@ -43,12 +43,16 @@ await Promise.all([initializeAuthState(), loadRepoConfig()])
 
 const ownerRepoDraft = ref(repoConfig.value.ownerRepo)
 const filePathDraft = ref(repoConfig.value.filePath)
-const cacheDaysDraft = ref(
+// Vue's native v-model runtime auto-casts to Number for any <input> whose
+// `type` attribute is "number" (with or without a `.number` modifier), so
+// this ref receives a `number` after the user edits the field even though it
+// is seeded with a string — the type reflects that real runtime contract.
+const cacheDaysDraft = ref<string | number>(
   repoConfig.value.revalidateCacheDays === null ? '' : String(repoConfig.value.revalidateCacheDays),
 )
 
-function parseCacheDays(raw: string): number | null {
-  const trimmed = raw.trim()
+function parseCacheDays(raw: string | number): number | null {
+  const trimmed = String(raw).trim()
   if (trimmed === '') return null
   const parsed = Number(trimmed)
   return Number.isInteger(parsed) ? parsed : null
@@ -65,7 +69,7 @@ const currentDraft = computed<RepoConfigDraft>(() => ({
 // to parse as a positive integer (garbage text, "0", a negative number) is
 // reported as an inline error.
 const cacheDaysError = computed<string>(() => {
-  if (cacheDaysDraft.value.trim() === '') return ''
+  if (String(cacheDaysDraft.value).trim() === '') return ''
   const parsed = currentDraft.value.revalidateCacheDays
   if (parsed !== null && parsed > 0) return ''
   return CACHE_DAYS_ERROR_MESSAGE

--- a/src/components/layout/AppFooter.vue
+++ b/src/components/layout/AppFooter.vue
@@ -14,5 +14,7 @@
     <AppLink to="https://www.netlify.com/">Hébergé sur Netlify</AppLink>
     <span>|</span>
     <AppLink to="/mentions-legales">Mentions légales</AppLink>
+    <span>|</span>
+    <AppLink to="/settings">Paramètres</AppLink>
   </footer>
 </template>

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="flex flex-col w-full">
+    <RouterLink
+      to="/"
+      class="fixed top-4 left-4 z-10 inline-flex items-center bg-white border border-gray-300 rounded-full px-3 py-1 text-sm shadow hover:bg-gray-50"
+    >
+      ← Accueil
+    </RouterLink>
+
+    <div class="max-w-2xl mx-auto px-4 py-8 pt-16 w-full">
+      <h1 class="text-2xl font-bold mb-4 text-center">Paramètres</h1>
+      <Suspense>
+        <GitHubSyncSettings />
+        <template #fallback>
+          <AppLoader />
+        </template>
+      </Suspense>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import GitHubSyncSettings from '@/components/GitHubSyncSettings.vue'
+</script>


### PR DESCRIPTION
## Summary

- Adds the "GitHub Sync" section to the Settings page (`GitHubSyncSettings.vue` + new `/settings` route): login/logout control, `owner/repo` field, file path field, and a `revalidate-cache-days` field with inline validation, wiring Sub-Issue A's `useGitHubAuth` and Sub-Issue B's `useRepoConfig` composables together.
- `owner/repo` and file path become read-only once authenticated (with a log-out-to-edit message); `revalidate-cache-days` stays editable in both states and rejects zero/negative values inline.
- The "Login with GitHub" button is gated by Sub-Issue A's login-readiness check, evaluated against the current draft.
- Fixes a real runtime bug found by the test suite: Vue's native `v-model` auto-casts to `Number` for any `<input type="number">` (with or without the `.number` modifier), so `cacheDaysDraft` needed to be typed `string | number` (matching `Input.vue`'s own prop type) instead of assuming a plain `string`.

## Test plan

- [x] `npx vitest run` — 303 test files, 356 tests, all passing
- [x] `npm run type-check` (`vue-tsc --build`) — clean
- [x] `eslint` — no errors in changed files (pre-existing unrelated errors in two `.spec.ts` files noted separately)
- [x] Code review completed and approved (`review-results.md`)

Closes #84
