### PR TITLE
ci(commands): fix rtk lint resolution and trim review verbosity in jli-reviews-code

### DIFF
--- a/.claude/commands/jli-reviews-code.md
+++ b/.claude/commands/jli-reviews-code.md
@@ -27,7 +27,7 @@ Run exactly these two commands from the worktree (they are guaranteed to exist i
 `package.json`; do not inspect `package.json` first). Include their output in your findings:
 
 ```bash
-rtk lint           # eslint . --fix, grouped, token-optimized
+npm run lint       # eslint . --fix
 npm run type-check # vue-tsc --build (no rtk equivalent)
 ```
 
@@ -61,10 +61,13 @@ Before reviewing Vue/TypeScript issues, fetch these reference pages to ground th
 
 ## Output contract
 
-Create `[task-folder]/review-results.md`:
-- Show the `rtk lint` and `npm run type-check` output (in fenced blocks if there are errors;
-  otherwise state they passed cleanly for the changed files).
-- A Checklist section: mark each item ✓, or list details per failing item.
+Create `[task-folder]/review-results.md`. Be terse about what's fine and detailed only about
+what `/jli-codes` must act on:
+- Lint/type-check: if both pass cleanly, one line each (`lint: clean`, `type-check: clean`).
+  If either fails, its full output in a fenced block.
+- Checklist: list only the items with findings, each with the concrete file/line and what's
+  wrong. Collapse every passing item into a single closing line (`All other checklist items
+  ✓`) — do not restate what is correct or already compliant.
 - No summary section.
 - End with `status: approved` as the last line. If any finding exists, use
   `status: changes requested` instead. The status line is always last.

--- a/docs/prompts/tasks/issue-101-rtk-lint-fails-eslint/README.md
+++ b/docs/prompts/tasks/issue-101-rtk-lint-fails-eslint/README.md
@@ -1,0 +1,25 @@
+Worktree: E:/Git/GitHub/french-gas-stations-scraper_fix-rtk-lint-fails-eslint
+
+# fix(pipeline): rtk lint fails to find eslint during /jli-reviews-code
+
+## Problem
+During `/jli-reviews-code`, the mandated `rtk lint` command (per `.claude/commands/jli-reviews-code.md`) fails:
+
+    Error: Failed to run eslint. Is it installed? Try: pip install eslint (or npm/pnpm for JS linters)
+    Caused by:
+        program not found
+
+`eslint` is a local devDependency and `npm run lint` (`eslint . --fix`) runs correctly and finds real errors. This means `rtk` isn't resolving the project's local eslint binary in this worktree, so lint results reported by the review pipeline are silently missing/wrong until a manual fallback to `npm run lint` is used.
+
+## Repro
+    cd <worktree>
+    rtk lint
+    # -> "program not found"
+    npm run lint
+    # -> works, reports real lint errors
+
+## Expected
+`rtk lint` should resolve and run the project's local `eslint` (via `node_modules/.bin` or `npx`), consistent with the rest of the pipeline's reliance on it.
+
+## Impact
+`/jli-reviews-code` review-results.md can under-report lint issues if the fallback isn't performed manually.


### PR DESCRIPTION
## Summary

- `rtk lint` fails to resolve the local `eslint` binary in this worktree ("program not found"), while `npm run lint` works correctly, so `/jli-reviews-code` now runs `npm run lint` directly instead of silently under-reporting lint issues.
- Trims `review-results.md` output: passing lint/type-check runs and passing checklist items now collapse to one line each; only findings that `/jli-codes` must act on get full detail.

## Files changed

- `.claude/commands/jli-reviews-code.md` — swap `rtk lint` for `npm run lint`; terser output contract
- `docs/prompts/tasks/issue-101-rtk-lint-fails-eslint/README.md` — issue writeup with repro

## Test plan

- [ ] Run `/jli-reviews-code` on a real task folder and confirm lint runs via `npm run lint` without error
- [ ] Confirm `review-results.md` output is terse on a clean pass and detailed only on findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)