### PR TITLE
feat: save daily favorite-station prices to history.csv

### DIFF
--- a/.env.proton-pass-example
+++ b/.env.proton-pass-example
@@ -4,3 +4,15 @@
 # to it. Gitignored: these IDs are specific to this Proton Pass account.
 GITHUB_CLIENT_ID=pass://[share-id-of-target-vault]/[item-id-in-target-vault]/Client ID
 GITHUB_CLIENT_SECRET=pass://[share-id-of-target-vault]/[item-id-in-target-vault]/Client Secret
+
+# Fixed, single-repo configuration for the scheduled daily price-history
+# function (issue #112, ADR-014) — independent of the OAuth app above, since
+# a cron-triggered function has no browser session. HISTORY_GITHUB_PAT is a
+# fine-grained GitHub PAT scoped to only the target repo with Contents
+# read/write permission (see ADR-014's "PAT Setup Guide" for how to create
+# it); the other three mirror whatever owner/repo/path you configured in the
+# app's Settings UI.
+HISTORY_GITHUB_PAT=pass://[share-id-of-target-vault]/[item-id-in-target-vault]/Fine-grained PAT
+HISTORY_GITHUB_OWNER=[github-owner-of-target-repo]
+HISTORY_GITHUB_REPO=[target-repo-name]
+HISTORY_PREFS_FILE_PATH=[same-path-as-settings-ui-filepath]

--- a/docs/decisions/ADR-014-scheduled-function-pat-auth.md
+++ b/docs/decisions/ADR-014-scheduled-function-pat-auth.md
@@ -1,0 +1,135 @@
+# ADR-014: Scheduled Netlify Function with Fine-Grained PAT for Daily Price History
+
+**Date:** 2026-07-23
+**Status:** Proposed
+
+## Context
+
+Issue #112 needs a daily, unattended snapshot of every favorite station's fuel prices, appended
+to `history.csv` in the user's configured GitHub repository (the same repository ADR-012 already
+syncs `favoriteStations` to).
+
+Every GitHub write today is initiated by an active browser session: ADR-011 issues an HTTP-only
+OAuth cookie tied to that session, and ADR-012's `github-api-proxy` reads that cookie to call the
+GitHub Contents API on the user's behalf. A scheduled (cron-triggered) function has no browser
+session, no cookie, and no access to the IndexedDB values (`ownerRepo`, `filePath`) the Settings
+UI writes client-side — none of the existing auth or config plumbing is reachable from it.
+
+Netlify Scheduled Functions also only support fixed cron expressions in UTC, but the business
+requirement (business-specifications.md, issue #112) is 21:00 **French local time**, which shifts
+between UTC+1 (CET) and UTC+2 (CEST) twice a year — a fixed single cron entry cannot satisfy that
+without a biannual manual edit.
+
+## Decision
+
+### Authentication
+
+Use a **fixed, fine-grained GitHub Personal Access Token (PAT)**, scoped to only the target
+repository with **Contents: Read and write** permission and nothing else, stored as a Netlify
+environment variable (`HISTORY_GITHUB_PAT`). This credential is entirely independent of the
+ADR-011 OAuth cookie: it is not issued by a user login, is not affected by logout or cookie
+expiry, and is the only thing the scheduled function needs to call the GitHub Contents API
+directly (no proxy function involved, since there is no browser request to proxy).
+
+Companion fixed environment variables give the function everything else the browser-session flow
+normally supplies:
+
+- `HISTORY_GITHUB_OWNER`, `HISTORY_GITHUB_REPO` — the target repository, mirroring the value the
+  user set as `ownerRepo` in the Settings UI (ADR-012's `RepoConfigDraft`).
+- `HISTORY_PREFS_FILE_PATH` — the path to the synced preferences JSON file, mirroring the
+  Settings UI's `filePath`, so the function can read `favoriteStations` the same way the SPA
+  does. This must be kept in sync manually if the user ever changes the path in Settings.
+
+`history.csv` itself is written at a fixed path (repo root) — not user-configurable — per the
+issue's literal request for a file named `history.csv`.
+
+### Scheduling Mechanism (DST handling)
+
+The Netlify Scheduled Function's cron trigger fires **twice** a day, at 19:00 and 20:00 UTC —
+covering both possible UTC offsets of 21:00 French local time. On each invocation, the function
+computes the current wall-clock hour in the `Europe/Paris` time zone and exits immediately,
+without touching `history.csv`, unless that hour is 21. This guarantees exactly one effective run
+per day at true French local 21:00 year-round, with no manual cron edit needed at DST changeovers.
+
+## Consequences
+
+### Positive
+
+- ✅ Fully decoupled from user browser sessions — the daily snapshot keeps running regardless of
+  login state, cookie expiry, or whether anyone opens the app that day.
+- ✅ Least-privilege credential: fine-grained PAT scoped to one repo, one permission, unlike the
+  broader `repo`/`public_repo` OAuth scope already granted to browser sessions.
+- ✅ DST-correct scheduling without recurring maintenance (no biannual cron edit).
+- ✅ No new proxy function needed — the scheduled function calls the GitHub Contents API
+  directly, since there's no browser request to shield the token from.
+
+### Negative
+
+- ⚠️ Fine-grained PATs expire after at most 1 year — requires a manual renewal; there is no
+  refresh mechanism (same limitation ADR-011 already accepts for the OAuth token, but here with
+  no user present to react to a 401).
+- ⚠️ A silent-failure risk: an expired or revoked PAT makes the run fail with nobody watching
+  unless Netlify function logs/alerts are checked deliberately.
+- ⚠️ Two extra environment variables (`HISTORY_GITHUB_OWNER`, `HISTORY_PREFS_FILE_PATH`) must be
+  kept manually in sync with whatever the user has configured in the Settings UI — they will
+  silently drift if the user changes the Settings UI values without updating Netlify.
+- ⚠️ Firing the scheduled trigger twice daily (to cover both DST offsets) means one invocation
+  per day does no useful work beyond checking the clock and exiting — a minor, accepted overhead.
+- ⚠️ This design is explicitly single-user/single-repo. Generalizing to multiple app users would
+  require a fundamentally different config/credential storage approach (out of scope here).
+
+## Alternatives Considered
+
+1. **Reuse the ADR-011 OAuth cookie somehow**: Not possible — the cookie is scoped to a specific
+   browser request/response cycle and does not exist outside of one; there is no session to draw
+   it from in a cron context.
+2. **Store a long-lived OAuth refresh token instead of a PAT**: GitHub OAuth Apps (ADR-011) do not
+   issue refresh tokens for this flow type — would require switching to a GitHub App
+   (installation tokens), a much larger change rejected as overkill for a single personal repo,
+   same reasoning as ADR-011's own rejection of GitHub Apps.
+3. **Classic PAT instead of fine-grained**: Simpler (optional expiration, one-time setup) but
+   grants access to every repository the account can reach — rejected in favor of the narrower
+   fine-grained scope for a single fixed target repo.
+4. **Two static cron entries, manually swapped at DST changeovers**: Avoids the twice-daily
+   no-op invocation but requires a human to remember and edit `netlify.toml` twice a year —
+   rejected as an ongoing maintenance burden versus a self-adjusting runtime check.
+5. **Netlify Blobs / KV for storing owner/repo/path server-side**: Would let the Settings UI push
+   config to a place the function can read, avoiding manual env var sync — deferred as unneeded
+   complexity for a single-user, single-repo scope; worth revisiting if this ever needs to
+   generalize to multiple users.
+
+## Notes
+
+### PAT Setup Guide
+
+1. Go to **github.com/settings/personal-access-tokens/new** (Fine-grained tokens), signed in as
+   the account that owns the target repository.
+2. **Token name**: something identifiable, e.g. `french-gas-stations-history-writer`.
+3. **Expiration**: the maximum allowed (1 year). Set a calendar reminder ~2 weeks before expiry
+   to regenerate and update the Netlify environment variable ahead of time — done early enough,
+   this causes no downtime.
+4. **Resource owner**: the user/org that owns the target repository.
+5. **Repository access**: "Only select repositories" > choose exactly the one target repository.
+6. **Permissions** > Repository permissions > **Contents: Read and write**. Leave every other
+   permission at "No access".
+7. Click **Generate token** and copy the value immediately — GitHub shows it only once.
+8. In Netlify: Site settings > Environment variables > add `HISTORY_GITHUB_PAT` with the copied
+   value, scoped to Functions (not exposed to the client bundle). Add `HISTORY_GITHUB_OWNER`,
+   `HISTORY_GITHUB_REPO`, and `HISTORY_PREFS_FILE_PATH` alongside it.
+9. Redeploy the site so the scheduled function picks up the new environment variables.
+10. **If the token is ever leaked or the repo target changes**: revoke it immediately from the
+    same GitHub settings page, generate a replacement, and update the Netlify variable — there is
+    no automatic revocation.
+
+- This ADR extends ADR-011 (browser-session OAuth) and ADR-012 (GitHub repo as sync backend) with
+  a second, independent auth path for server-only, unattended writes. The two paths never share a
+  credential.
+- Should the app ever need to generalize to multiple users, this ADR's single-PAT/env-var design
+  would need to be superseded — see Alternatives Considered, item 4.
+
+## References
+
+- [GitHub fine-grained personal access tokens documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+- [Netlify Scheduled Functions documentation](https://docs.netlify.com/functions/scheduled-functions/)
+- [ADR-011: GitHub OAuth App Authentication](./ADR-011-github-oauth-app-auth.md)
+- [ADR-012: User-Owned GitHub Repository as Remote Sync Backend](./ADR-012-github-repo-as-sync-backend.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,7 @@ Status values: `Proposed` | `Accepted` | `Deprecated` | `Superseded by ADR-XXX`
 | [ADR-011](./ADR-011-github-oauth-app-auth.md)                     | GitHub OAuth App Authentication via Netlify Functions with HTTP-Only Cookie | Accepted | 2026-04-30 |
 | [ADR-012](./ADR-012-github-repo-as-sync-backend.md)               | User-Owned GitHub Repository as Remote Sync Backend             | Accepted | 2026-04-30 |
 | [ADR-013](./ADR-013-page-level-load-orchestrator.md)              | Page-Level Load Orchestrator for Shared Singleton State Under Async Mutation | Accepted | 2026-07-21 |
+| [ADR-014](./ADR-014-scheduled-function-pat-auth.md)               | Scheduled Netlify Function with Fine-Grained PAT for Daily Price History     | Proposed | 2026-07-23 |
 
 ## How to Add a New ADR
 

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/README.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/README.md
@@ -1,0 +1,9 @@
+Worktree: E:/Git/GitHub/french-gas-stations-scraper_feat-save-daily-price-history
+
+# Issue #112: Save daily prices for favorite stations
+
+Using a recurring netlify function, to a csv files the daily prices at end of day (9PM GMT+2) of favorite stations.
+
+The data is saved to the same repository the favorite stations are read from in a file "history.csv".
+
+Using recuring function example in https://github.com/JeremieLitzler/iamjeremie.me-with-hugo-theme-stack/blob/master/functions/recurring_publish/recurring_publish.mjs

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/business-specifications.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/business-specifications.md
@@ -1,0 +1,71 @@
+# Business Specifications — Issue #112: Save Daily Price History
+
+## Goal and Scope
+
+Once a day, automatically capture the current price of every favorite station's fuel types and
+append it to a durable, versioned history file (`history.csv`) in the user's configured GitHub
+repository (the same repository the app already syncs `favoriteStations` to, per ADR-012). No
+user interaction is required for this to happen — it runs on a schedule, independent of anyone
+having the app open.
+
+This is a single-user feature: the target repository is fixed configuration, not per-visitor.
+
+## Files to Create or Modify
+
+- A new **scheduled Netlify function** — triggered automatically once per day; not reachable via
+  any SPA action or HTTP call a user initiates. Owns the daily run end to end: read favorites,
+  scrape prices, update `history.csv`.
+- **Environment variable configuration** (documented alongside existing Netlify env vars) — holds
+  the fixed GitHub credential and target locations this function needs, since it has no browser
+  session to draw them from.
+- `history.csv`, in the user's configured repository — the durable output. Created on first run
+  if absent; updated on every subsequent run.
+
+## Rules
+
+**Runs daily at 21:00 French local time**, adjusting for daylight saving (19:00 UTC in summer,
+20:00 UTC in winter) — matching "end of day" in France year-round, not a fixed UTC offset.
+
+**Authenticates with a fixed, fine-grained GitHub Personal Access Token**, scoped to only the
+target repository with Contents read/write permission, stored as a Netlify environment variable.
+It does not use, and is not affected by, the browser OAuth session from ADR-011 — a user logging
+out of the app in their browser has no effect on this job. If the token is invalid or expired,
+the run fails without writing anything to `history.csv` (no partial file), and the failure is
+only visible in Netlify function logs since no user is present to be notified.
+
+**Reads favorite stations from the same remote preferences JSON file the SPA already syncs**
+(`favoriteStations`, per ADR-012), not from IndexedDB, since the scheduled function has no
+browser context to read local storage from. The GitHub owner/repo and the preferences file's
+path are fixed environment variables, kept in sync manually with whatever the user has set in
+the Settings UI — the scheduled function does not discover this value dynamically.
+
+**Scrapes each favorite station the same way the SPA does today.** If a station's page fails to
+scrape, or does not list a given fuel type that day, only that station (or that station/fuel
+pair) is omitted from the day's rows — every other favorite station or fuel type is still
+written normally.
+
+**Each written row records: date, station name, station URL, fuel type, and price** — one row
+per station/fuel-type combination present that day. Example: a station listing Gazole at 1,969
+on 2026-07-23 produces one row for that date, station, URL, "Gazole", and "1,969".
+
+**Re-running the job for a day that already has rows replaces those rows** rather than
+duplicating them: before appending, any existing rows dated today are removed, then the fresh
+snapshot is written. Running the job twice in the same day never produces duplicate entries for
+that day.
+
+**First run creates `history.csv`** (with a header row) if it does not already exist, using the
+same create-vs-update (`sha`-based) write mechanism already established for the preferences file
+in ADR-012.
+
+### ADR Required
+
+This introduces a new architectural pattern not covered by any existing ADR: a **time-triggered
+(scheduled/cron) Netlify function** that authenticates to GitHub independently of any browser
+session, using a fixed, long-lived Personal Access Token instead of the OAuth-cookie flow from
+ADR-011. Existing ADRs (011, 012) assume every GitHub write is initiated by, and authenticated
+through, an active user session — this feature breaks that assumption and should be documented
+as its own decision, including the PAT's scope, expiration/rotation caveats, and the fact that
+this design is explicitly single-user/single-repo (not a pattern to generalize to multi-tenant
+use without further decisions).
+
+status: ready

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/review-results.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/review-results.md
@@ -5,20 +5,10 @@ type-check: clean
 
 ## Checklist findings
 
-- **Duplicated `jsonResponse` instead of reusing the existing shared helper** —
-  `netlify/functions/scheduled-price-history/scheduled-price-history.ts:31-33` defines a local
-  `jsonResponse(statusCode, body)` that reimplements `netlify/functions/lib/http-responses.ts`'s
-  `jsonResponse` (same `Content-Type: application/json` header shape, same `JSON.stringify(body)`
-  body). That shared helper already lives in the same `netlify/functions/lib/` directory this
-  function already imports five other modules from (`scheduleGuards`, `stationUrlAllowlist`,
-  `stationHtmlParser`, `favoriteStationsParser`, `priceHistoryCsv`) — there is no project-reference
-  boundary excuse here, unlike the `src/`-mirrored files the technical spec justifies. It's also
-  the established convention: all four existing Netlify functions
-  (`github-api-proxy`, `github-auth-callback`, `github-auth-logout`, `github-auth-start`) import
-  `jsonResponse` from `lib/http-responses.ts` rather than defining their own. Replace the local
-  `jsonResponse` with `import { jsonResponse } from '../lib/http-responses'` (its optional
-  `setCookieValues` param defaults to `[]`, so call sites are unaffected).
+None. The previously flagged duplicated `jsonResponse` (review round 1) is now fixed —
+`scheduled-price-history.ts:10` imports it from `../lib/http-responses`, matching the other four
+Netlify functions' convention.
 
 All other checklist items ✓
 
-status: changes requested
+status: approved

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/review-results.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/review-results.md
@@ -1,0 +1,24 @@
+# Review Results — Issue #112: Save Daily Price History
+
+lint: clean (9 pre-existing failures in `usePreferencesExport.spec.ts` / `usePreferencesImport.spec.ts` — both untouched on this branch, confirmed via `git diff develop...HEAD` showing no changes to either file; unrelated to this feature)
+type-check: clean
+
+## Checklist findings
+
+- **Duplicated `jsonResponse` instead of reusing the existing shared helper** —
+  `netlify/functions/scheduled-price-history/scheduled-price-history.ts:31-33` defines a local
+  `jsonResponse(statusCode, body)` that reimplements `netlify/functions/lib/http-responses.ts`'s
+  `jsonResponse` (same `Content-Type: application/json` header shape, same `JSON.stringify(body)`
+  body). That shared helper already lives in the same `netlify/functions/lib/` directory this
+  function already imports five other modules from (`scheduleGuards`, `stationUrlAllowlist`,
+  `stationHtmlParser`, `favoriteStationsParser`, `priceHistoryCsv`) — there is no project-reference
+  boundary excuse here, unlike the `src/`-mirrored files the technical spec justifies. It's also
+  the established convention: all four existing Netlify functions
+  (`github-api-proxy`, `github-auth-callback`, `github-auth-logout`, `github-auth-start`) import
+  `jsonResponse` from `lib/http-responses.ts` rather than defining their own. Replace the local
+  `jsonResponse` with `import { jsonResponse } from '../lib/http-responses'` (its optional
+  `setCookieValues` param defaults to `[]`, so call sites are unaffected).
+
+All other checklist items ✓
+
+status: changes requested

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/security-guidelines.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/security-guidelines.md
@@ -1,0 +1,35 @@
+# Security Guidelines — Issue #112: Save Daily Price History
+
+1. **Secret handling for the fixed GitHub PAT.**
+   **What**: `HISTORY_GITHUB_PAT` (and its companion `HISTORY_GITHUB_OWNER`/`HISTORY_GITHUB_REPO`/
+   `HISTORY_PREFS_FILE_PATH` values) must never appear in logs, error responses, or any output
+   returned by the scheduled function; scope the variable to the Functions runtime only, never to
+   the client bundle. **Where**: the scheduled function and its Netlify environment-variable
+   configuration (ADR-014). **Why**: a leaked fine-grained PAT grants direct write access to the
+   target repository's contents.
+
+2. **Escape CSV output against formula and structure injection.**
+   **What**: values written into `history.csv` (station name, URL, fuel type) must be quoted/
+   escaped so a value beginning with `=`, `+`, `-`, or `@` cannot execute as a formula when the
+   file is opened in a spreadsheet application, and embedded commas or quotes cannot break a row
+   into extra fields. **Where**: the row-writing step of the scheduled function, before the write
+   to GitHub. **Why**: station names are user-supplied (via the Settings/Station Manager flow);
+   an unescaped value is a classic CSV/formula injection vector (CWE-1236) once the file is opened
+   locally.
+
+3. **Re-apply the existing domain allowlist to every scrape call this function makes.**
+   **What**: enforce the same host whitelist already required for `fetch-page` (ADR-006) when the
+   scheduled function fetches each favorite station's page — do not treat a URL from the remote
+   preferences file as pre-trusted. **Where**: the scheduled function's per-station scrape step.
+   **Why**: `favoriteStations` now originates from a GitHub-hosted JSON file (ADR-012) that could
+   be edited outside the app; without re-validation, a tampered file could make the server-side
+   function fetch an arbitrary or internal URL (SSRF).
+
+4. **Reject invocations that did not come from the Netlify scheduler.**
+   **What**: the function must verify it was invoked by the scheduled trigger (not a direct HTTP
+   request to its endpoint URL) before performing any GitHub write, and no-op otherwise.
+   **Where**: entry point of the scheduled function. **Why**: scheduled function endpoints remain
+   reachable by their normal URL; without this check, anyone who discovers it could trigger
+   unwanted privileged GitHub writes or burn the PAT's API rate limit on demand.
+
+status: ready

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/technical-specifications.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/technical-specifications.md
@@ -1,0 +1,98 @@
+# Technical Specifications — Issue #112: Save Daily Price History
+
+## Files Created
+
+- `netlify/functions/scheduled-price-history/scheduled-price-history.ts` — the scheduled function's
+  handler: guards, orchestrates reading favorites, scraping, and writing `history.csv`.
+- `netlify/functions/lib/scheduleGuards.ts` — verifies the invocation came from Netlify's scheduler
+  and that the current wall-clock hour in France is the target run hour.
+- `netlify/functions/lib/stationUrlAllowlist.ts` — re-validates a favorite station's URL against the
+  gas-station-price domain before it is ever fetched.
+- `netlify/functions/lib/csvEscaping.ts` — escapes CSV field values against formula and structural
+  injection.
+- `netlify/functions/lib/stationHtmlParser.ts` — Node-compatible mirror of the SPA's HTML fuel-price
+  parser, backed by `linkedom` instead of the browser's `DOMParser`.
+- `netlify/functions/lib/githubContentsClient.ts` — minimal GitHub Contents API GET/PUT client
+  authenticated with the fixed PAT.
+- `netlify/functions/lib/priceHistoryCsv.ts` — builds `history.csv`'s row/header format and applies
+  the same-day-replace rule.
+- `netlify/functions/lib/favoriteStationsParser.ts` — minimal shape validation for the
+  `favoriteStations` array read from the remote preferences file.
+
+## Files Modified
+
+- `netlify/functions/lib/environment.ts` — added `readHistoryConfig()`/`HistoryConfig`, reading the
+  four new fixed environment variables (`HISTORY_GITHUB_PAT`, `HISTORY_GITHUB_OWNER`,
+  `HISTORY_GITHUB_REPO`, `HISTORY_PREFS_FILE_PATH`) alongside the existing OAuth credential reader.
+- `.env.proton-pass-example` — documented the new environment variables for local `netlify dev`.
+- `package.json` / `package-lock.json` — added `linkedom` as a production dependency.
+
+## Non-Trivial Decisions
+
+**Duplicated parsing/validation logic instead of importing from `src/`.** `netlify/functions/**/*.ts`
+and `src/**/*.ts` are separate TypeScript project references (`tsconfig.node.json` vs
+`tsconfig.app.json`, both `composite: true`). Importing a `src/` file from a Netlify Function would
+violate `vue-tsc --build`'s project-reference boundaries. `stationHtmlParser.ts`,
+`stationUrlAllowlist.ts`, and `favoriteStationsParser.ts` are therefore small, intentional copies of
+existing browser-side logic (`src/utils/stationHtmlParser.ts`, `preferencesImport.ts`'s URL/station
+validators) — any change to the scrape selector or the allowed URL shape must be mirrored in both
+places.
+
+**`linkedom` for server-side HTML parsing.** The Node runtime has no native `DOMParser`. `linkedom`
+provides a `DOMParser`-compatible API, letting the Node-side parser reuse the exact same
+`querySelector` chain as the browser version instead of a regex-based reimplementation, which would
+be more fragile and harder to keep in sync. Verified via `npm audit` that adding it introduces no new
+vulnerabilities (it has zero transitive dependencies).
+
+**A separate GitHub Contents API client instead of extending `github-api-proxy.ts`.** The existing
+proxy forwards a browser's cookie-based OAuth token (ADR-011) and is already shipped/tested
+(issue #86). The scheduled function's PAT (ADR-014) is a fundamentally different, server-only
+credential with its own read/write needs (fixed owner/repo, no CORS/cookie concerns) — a small,
+separate client avoids mixing two different auth models into one file and avoids touching tested
+code for an unrelated auth path.
+
+**Twice-daily cron (`0 19,20 * * *`) plus a `Europe/Paris` hour check**, per ADR-014: Netlify cron
+schedules run in UTC and can't natively express "21:00 French local time" across DST changes without
+a runtime check.
+
+**`isScheduledInvocation` (checking for a `next_run` field) is kept as defense-in-depth** even though
+the installed `@netlify/functions` package's own type declarations document `schedule()`-wrapped
+functions as "not reachable via HTTP" — a detail discovered while implementing, not assumed at
+ADR-014 time. The check is cheap and still satisfies security-guidelines.md rule 4's intent whether or
+not the platform's own guarantee holds across versions.
+
+**CSV row-date matching via a comma-prefix scan, not a CSV parsing library.** The date column is
+always a plain, unescaped `YYYY-MM-DD` string (it can never contain a comma, quote, or
+formula-trigger character), so identifying "today's rows" to replace is a safe substring match — no
+need for a full CSV parser dependency for this one narrow operation.
+
+**Base64 via Node's `Buffer` rather than the browser's `btoa`/`atob` workaround.** The existing
+composables need a manual UTF-8 workaround because browsers' `atob`/`btoa` are Latin-1-only and don't
+tolerate GitHub's line-wrapped base64. Node's `Buffer.from(text, 'base64')` handles UTF-8 and ignores
+embedded whitespace natively, so the Netlify Function side is simpler by construction, not by
+omission.
+
+**`history.csv`'s path is a hardcoded constant, not an environment variable.** The spec names a fixed
+file, `history.csv`, at the repository root; no configurability for this specific path was
+requested (unlike the preferences file's path, which mirrors a value the user already configures in
+the Settings UI).
+
+## Self-Review Fixes
+
+1. **`scrapeStation` now wraps its body in `try`/`catch`.** Without it, a rejected `fetch()` promise
+   for one station (network error, timeout) would reject the whole `Promise.all` in
+   `scrapeAllStations`, discarding every other station's rows for the day — directly contradicting
+   the "only that station is omitted" rule.
+2. **`fetchStationHtml` now uses an `AbortController` with a 10-second timeout**, mirroring
+   `useRemotePreferencesSync.ts`'s existing pattern — an unresponsive station page could otherwise
+   stall the whole run indefinitely (and risk the Netlify Function's own execution timeout aborting
+   before any write happens).
+3. **`rowDate` now returns the whole line when no comma is found**, instead of an off-by-one
+   `slice(0, -1)` truncation, so a malformed existing CSV line is preserved as-is rather than
+   silently corrupted.
+
+No new ADR is required — every decision above elaborates on ADR-014's already-approved scope
+(fixed PAT, fixed env vars, DST-aware double-fire) rather than introducing a new architectural
+pattern.
+
+status: ready

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/technical-specifications.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/technical-specifications.md
@@ -91,6 +91,24 @@ the Settings UI).
    `slice(0, -1)` truncation, so a malformed existing CSV line is preserved as-is rather than
    silently corrupted.
 
+## Review-Loop Fixes (post `/jli-reviews-code`)
+
+4. **`scheduled-price-history.ts` now imports `jsonResponse` from `../lib/http-responses` instead
+   of defining its own copy.** `review-results.md` flagged the local duplicate — the shared helper
+   already lives in the same `netlify/functions/lib/` directory this file already imports five
+   other modules from (no project-reference boundary excuse applies here, unlike the `src/`-mirrored
+   files), and all four existing Netlify functions already use it.
+5. **`readExistingHistory(config)` now runs concurrently with `readFavoriteStations(config)`** via
+   `Promise.all`, instead of after the favorites read and the scrape pass. The existing-history read
+   has no data dependency on either — it only needed to happen before the CSV is assembled — so
+   running it in parallel shortens the run's wall-clock time by roughly its own latency, found during
+   self-review as a performance bottleneck.
+6. **`runDailySnapshot` now skips the GitHub write when `csvContent === existing.content`.** Found
+   during self-review: without this check, a day with zero favorite stations, or a day where every
+   station fails to scrape, still produced an identical PUT — a no-op GitHub commit and a spent write
+   call for zero effect. The `null`-vs-string comparison still lets the true first-run case (file
+   doesn't exist yet) through, since `existing.content` is `null` and `csvContent` is never `null`.
+
 No new ADR is required — every decision above elaborates on ADR-014's already-approved scope
 (fixed PAT, fixed env vars, DST-aware double-fire) rather than introducing a new architectural
 pattern.

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/test-cases.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/test-cases.md
@@ -1,0 +1,105 @@
+# Test Cases — Issue #112: Save Daily Price History
+
+## Scheduling and Trigger
+
+1. **Correct local time in summer (CEST)**: the scheduled trigger fires at 19:00 UTC during a
+   period when French local time is UTC+2. Action: the function runs. Expected: the run proceeds
+   and updates `history.csv`, since 19:00 UTC is 21:00 French local time.
+
+2. **Off-hour invocation skipped in summer**: the scheduled trigger fires at 20:00 UTC during the
+   same UTC+2 period (22:00 French local time). Action: the function runs. Expected: the function
+   exits without touching `history.csv` — it is not the target local hour.
+
+3. **Correct local time in winter (CET)**: the scheduled trigger fires at 20:00 UTC during a
+   period when French local time is UTC+1. Action: the function runs. Expected: the run proceeds
+   and updates `history.csv`, since 20:00 UTC is 21:00 French local time.
+
+4. **Off-hour invocation skipped in winter**: the scheduled trigger fires at 19:00 UTC during the
+   same UTC+1 period (20:00 French local time). Action: the function runs. Expected: the function
+   exits without touching `history.csv`.
+
+## Authentication and Configuration
+
+5. **Invalid or expired PAT**: the configured GitHub token is invalid or expired. Action: the
+   scheduled run fires at the correct local time. Expected: the run fails, `history.csv` is left
+   completely unchanged (no partial write), and the failure is only observable in the function's
+   own logs — no user-facing notification occurs.
+
+6. **Preferences file missing or unreadable**: the remote preferences JSON file (at the
+   configured path) does not exist or cannot be parsed at run time. Action: the scheduled run
+   fires at the correct local time. Expected: the run fails without writing to `history.csv`,
+   since the list of favorite stations cannot be determined.
+
+## Reading Favorite Stations
+
+7. **Stations come from the remote file, not local storage**: the remote preferences JSON file
+   lists a set of favorite stations. Action: a scheduled run executes. Expected: exactly the
+   stations listed in the remote file are scraped that day — the run does not depend on, or
+   reference, any browser-side IndexedDB state.
+
+8. **No favorite stations configured**: the remote preferences JSON file lists zero favorite
+   stations. Action: a scheduled run executes. Expected: the run completes without error and adds
+   no price rows for that day (an existing `history.csv` is left otherwise unchanged for that
+   date).
+
+## Scraping and Partial Failures
+
+9. **One station fails to scrape**: of several favorite stations, one station's page cannot be
+   scraped (e.g. unreachable page). Action: a scheduled run executes. Expected: rows for every
+   other favorite station are still written for that day; the failing station contributes no rows
+   and does not stop the run.
+
+10. **A station does not list a given fuel type that day**: a favorite station's page is scraped
+    successfully but does not show one of the fuel types it sometimes lists. Action: a scheduled
+    run executes. Expected: no row is written for that station/fuel-type pair that day; rows for
+    the station's other listed fuel types are written normally.
+
+## Row Content and File Structure
+
+11. **Row shape for a normal result**: a favorite station lists a fuel type and price on the day
+    of the run. Action: a scheduled run executes successfully. Expected: `history.csv` gains one
+    row containing that day's date, the station's name, its URL, the fuel type, and the price —
+    matching the values the SPA would otherwise display for that station.
+
+12. **First-ever run creates the file**: `history.csv` does not yet exist in the target
+    repository. Action: a scheduled run executes successfully. Expected: `history.csv` is created
+    with a header row followed by that day's price rows.
+
+13. **Subsequent run updates the existing file**: `history.csv` already exists with prior days'
+    rows. Action: a scheduled run executes successfully on a new day. Expected: the prior rows are
+    preserved unchanged, and the new day's rows are added.
+
+## Re-run Idempotency
+
+14. **Re-running the same day replaces its rows**: `history.csv` already contains rows for
+    today's date from an earlier run today. Action: the scheduled function runs again the same
+    day (e.g. manual retry). Expected: today's previously written rows are removed and replaced
+    by the fresh snapshot — today's date ends up with exactly one set of rows, not duplicated
+    entries, while all other days' rows are untouched.
+
+## Security — CSV Content Safety
+
+15. **Station name contains a formula-triggering character**: a favorite station's configured
+    name begins with a character such as `=`, `+`, `-`, or `@`. Action: a scheduled run writes a
+    row for that station. Expected: the value is written in a form that a spreadsheet application
+    would display as literal text, not execute as a formula.
+
+16. **Station name contains a comma or quote**: a favorite station's configured name contains a
+    comma or a quotation mark. Action: a scheduled run writes a row for that station. Expected:
+    the row is quoted/escaped so the value stays within its own field — it does not split into
+    extra columns or corrupt the row structure.
+
+## Security — Scrape Target Validation
+
+17. **Remote file lists a URL outside the allowed domain**: the preferences JSON file (editable
+    directly on GitHub, outside the app) contains a favorite station URL whose host is not the
+    allowed gas-station-price domain. Action: a scheduled run executes. Expected: that URL is not
+    fetched; no row is produced for it, and the run continues normally for the remaining stations.
+
+## Security — Invocation Source
+
+18. **Direct call to the function's endpoint**: the function's URL is invoked directly over HTTP
+    (not by the Netlify scheduler). Action: the request is made. Expected: no GitHub write occurs
+    and `history.csv` is left unchanged.
+
+status: ready

--- a/docs/prompts/tasks/issue-112-save-daily-price-history/test-results.md
+++ b/docs/prompts/tasks/issue-112-save-daily-price-history/test-results.md
@@ -1,0 +1,22 @@
+# Test Results — Issue #112: Save Daily Price History
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.0) from the
+`french-gas-stations-scraper_feat-save-daily-price-history` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md).
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+356 test files, 422 tests total — all passed.
+
+- Duration: ~5 seconds
+
+status: passed

--- a/netlify/functions/lib/csvEscaping.spec.ts
+++ b/netlify/functions/lib/csvEscaping.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for csvEscaping — issue #112, test-cases.md scenarios 15-16.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { toCsvField } from './csvEscaping'
+
+// ---------------------------------------------------------------------------
+// Scenario 15: Station name contains a formula-triggering character
+// ---------------------------------------------------------------------------
+
+describe('Scenario 15: a formula-triggering leading character is neutralized', () => {
+  it.each(['=', '+', '-', '@'])('prefixes a value starting with "%s" with a literal quote', (char) => {
+    expect(toCsvField(`${char}SUM(A1:A10)`)).toBe(`'${char}SUM(A1:A10)`)
+  })
+
+  it('leaves a value with no formula-triggering character unchanged', () => {
+    expect(toCsvField('Station Total')).toBe('Station Total')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 16: Station name contains a comma or quotation mark
+// ---------------------------------------------------------------------------
+
+describe('Scenario 16: a comma or quote is quoted/escaped so the field stays intact', () => {
+  it('wraps a value containing a comma in double quotes', () => {
+    expect(toCsvField('Station, Annex')).toBe('"Station, Annex"')
+  })
+
+  it('wraps a value containing a quotation mark in double quotes and doubles the quote', () => {
+    expect(toCsvField('Station "Le Relais"')).toBe('"Station ""Le Relais"""')
+  })
+
+  it('applies both the formula guard and the quoting when both conditions apply', () => {
+    expect(toCsvField('=Station, Annex')).toBe('"\'=Station, Annex"')
+  })
+})

--- a/netlify/functions/lib/csvEscaping.ts
+++ b/netlify/functions/lib/csvEscaping.ts
@@ -1,0 +1,22 @@
+// CSV field escaping for history.csv (issue #112, security-guidelines.md
+// rule 2): guards against formula injection (a value opened in a
+// spreadsheet app must never be interpreted as a formula) and against
+// structural injection (a comma or quote inside a value must never split a
+// row into extra fields).
+const FORMULA_TRIGGER_CHARACTERS = /^[=+\-@]/
+const NEEDS_QUOTING = /["\n\r,]/
+
+export function toCsvField(value: string): string {
+  const guarded = guardAgainstFormula(value)
+  if (NEEDS_QUOTING.test(guarded)) return quote(guarded)
+  return guarded
+}
+
+function guardAgainstFormula(value: string): string {
+  if (FORMULA_TRIGGER_CHARACTERS.test(value)) return `'${value}`
+  return value
+}
+
+function quote(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`
+}

--- a/netlify/functions/lib/environment.ts
+++ b/netlify/functions/lib/environment.ts
@@ -12,3 +12,24 @@ export function readGithubOAuthCredentials(): GithubOAuthCredentials | null {
   }
   return { clientId, clientSecret }
 }
+
+// Reads the fixed, single-repo configuration the scheduled price-history
+// function uses (ADR-014) — independent of the OAuth cookie above, since a
+// cron-triggered function has no browser session to read it from.
+export interface HistoryConfig {
+  githubPat: string
+  owner: string
+  repo: string
+  preferencesFilePath: string
+}
+
+export function readHistoryConfig(): HistoryConfig | null {
+  const githubPat = process.env.HISTORY_GITHUB_PAT
+  const owner = process.env.HISTORY_GITHUB_OWNER
+  const repo = process.env.HISTORY_GITHUB_REPO
+  const preferencesFilePath = process.env.HISTORY_PREFS_FILE_PATH
+  if (!githubPat || !owner || !repo || !preferencesFilePath) {
+    return null
+  }
+  return { githubPat, owner, repo, preferencesFilePath }
+}

--- a/netlify/functions/lib/favoriteStationsParser.spec.ts
+++ b/netlify/functions/lib/favoriteStationsParser.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for favoriteStationsParser — issue #112, test-cases.md scenarios 6-8.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseFavoriteStations } from './favoriteStationsParser'
+
+// ---------------------------------------------------------------------------
+// Scenario 6: Preferences file missing or unreadable
+// ---------------------------------------------------------------------------
+
+describe('Scenario 6: the remote preferences content cannot be parsed', () => {
+  it('returns null when the content is not valid JSON', () => {
+    expect(parseFavoriteStations('not json')).toBeNull()
+  })
+
+  it('returns null when favoriteStations is missing from the parsed object', () => {
+    expect(parseFavoriteStations(JSON.stringify({ fuelTypeDefault: 'Gazole' }))).toBeNull()
+  })
+
+  it('returns null when favoriteStations is not an array', () => {
+    expect(parseFavoriteStations(JSON.stringify({ favoriteStations: 'oops' }))).toBeNull()
+  })
+
+  it('returns null when a station entry is missing name or url', () => {
+    const json = JSON.stringify({
+      favoriteStations: [{ name: 'Intermarché Apprieu' }],
+    })
+
+    expect(parseFavoriteStations(json)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 7: Stations come from the remote file, not local storage
+// ---------------------------------------------------------------------------
+
+describe('Scenario 7: exactly the stations listed in the remote file are returned', () => {
+  it('returns the name/url pairs from favoriteStations unchanged', () => {
+    const json = JSON.stringify({
+      favoriteStations: [
+        { name: 'Intermarché Apprieu', url: 'https://www.prix-carburants.gouv.fr/station/12345' },
+        { name: 'Intermarché Aoste', url: 'https://www.prix-carburants.gouv.fr/station/67890' },
+      ],
+    })
+
+    expect(parseFavoriteStations(json)).toEqual([
+      { name: 'Intermarché Apprieu', url: 'https://www.prix-carburants.gouv.fr/station/12345' },
+      { name: 'Intermarché Aoste', url: 'https://www.prix-carburants.gouv.fr/station/67890' },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 8: No favorite stations configured
+// ---------------------------------------------------------------------------
+
+describe('Scenario 8: zero favorite stations configured', () => {
+  it('returns an empty array, not null, for an empty favoriteStations list', () => {
+    expect(parseFavoriteStations(JSON.stringify({ favoriteStations: [] }))).toEqual([])
+  })
+})

--- a/netlify/functions/lib/favoriteStationsParser.ts
+++ b/netlify/functions/lib/favoriteStationsParser.ts
@@ -1,0 +1,43 @@
+// Minimal favoriteStations shape validation for the remote preferences file
+// (ADR-012), read server-side by the scheduled price-history function.
+// Reduced from `src/utils/preferencesImport.ts`'s validateFavoriteStations
+// (Netlify Functions do not import from `src/`, see
+// technical-specifications.md) — this only needs the station list, not the
+// full PreferencesFile shape (fuelTypeDefault is irrelevant here).
+export interface FavoriteStation {
+  name: string
+  url: string
+}
+
+export function parseFavoriteStations(jsonText: string): FavoriteStation[] | null {
+  const parsed = parseJson(jsonText)
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const record = parsed as Record<string, unknown>
+  return validateStations(record.favoriteStations)
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function validateStations(value: unknown): FavoriteStation[] | null {
+  if (!Array.isArray(value)) return null
+  const stations: FavoriteStation[] = []
+  for (const item of value) {
+    const station = validateStation(item)
+    if (station === null) return null
+    stations.push(station)
+  }
+  return stations
+}
+
+function validateStation(value: unknown): FavoriteStation | null {
+  if (typeof value !== 'object' || value === null) return null
+  const record = value as Record<string, unknown>
+  if (typeof record.name !== 'string' || typeof record.url !== 'string') return null
+  return { name: record.name, url: record.url }
+}

--- a/netlify/functions/lib/githubContentsClient.ts
+++ b/netlify/functions/lib/githubContentsClient.ts
@@ -1,0 +1,88 @@
+// Minimal GitHub Contents API client authenticated with the fixed,
+// repo-scoped PAT (issue #112, ADR-014) — a separate, simpler client than
+// github-api-proxy.ts's cookie-forwarding proxy, since this function calls
+// GitHub directly with its own credential rather than proxying a browser
+// request. Base64 conversion uses Node's Buffer directly (available in the
+// Netlify Functions runtime), unlike the browser-side composables which
+// need a btoa/atob-based workaround.
+const GITHUB_API_BASE = 'https://api.github.com'
+const GITHUB_ACCEPT_HEADER = 'application/vnd.github+json'
+const USER_AGENT = 'french-gas-stations-scraper/1.0'
+
+export interface RemoteFile {
+  content: string
+  sha: string
+}
+
+type ReadOutcome = { found: true; file: RemoteFile } | { found: false }
+
+export function encodeBase64(text: string): string {
+  return Buffer.from(text, 'utf-8').toString('base64')
+}
+
+// GitHub's Contents API wraps base64 content at 60 characters with embedded
+// newlines; unlike the browser's atob() (used by the composables), Node's
+// Buffer base64 decoder already ignores embedded whitespace, so no
+// pre-stripping is needed here.
+export function decodeBase64(base64: string): string {
+  return Buffer.from(base64, 'base64').toString('utf-8')
+}
+
+function authHeaders(githubPat: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${githubPat}`,
+    Accept: GITHUB_ACCEPT_HEADER,
+    'User-Agent': USER_AGENT,
+  }
+}
+
+// Percent-encoding each segment prevents a value like `../other-repo` from
+// escaping the intended /repos/{owner}/{repo}/contents/{path} shape.
+function contentsUrl(owner: string, repo: string, path: string): string {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+  const encodedOwner = encodeURIComponent(owner)
+  const encodedRepo = encodeURIComponent(repo)
+  return `${GITHUB_API_BASE}/repos/${encodedOwner}/${encodedRepo}/contents/${encodedPath}`
+}
+
+export async function readRemoteFile(
+  githubPat: string,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<ReadOutcome> {
+  const url = contentsUrl(owner, repo, path)
+  const response = await fetch(url, { headers: authHeaders(githubPat) })
+  if (response.status === 404) return { found: false }
+  if (!response.ok) throw new Error(`GitHub read failed with status ${response.status}.`)
+  return { found: true, file: await parseRemoteFile(response) }
+}
+
+async function parseRemoteFile(response: Response): Promise<RemoteFile> {
+  const body = (await response.json()) as Record<string, unknown>
+  if (typeof body.content !== 'string' || typeof body.sha !== 'string') {
+    throw new Error('Missing base64 content or sha in GitHub response.')
+  }
+  return { content: body.content, sha: body.sha }
+}
+
+// Omitting `sha` (JSON.stringify drops undefined-valued properties) tells
+// GitHub to create the file; including it updates the existing one and
+// enforces optimistic concurrency, mirroring github-api-proxy.ts.
+export async function writeRemoteFile(
+  githubPat: string,
+  owner: string,
+  repo: string,
+  path: string,
+  message: string,
+  base64Content: string,
+  sha: string | undefined,
+): Promise<void> {
+  const url = contentsUrl(owner, repo, path)
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: { ...authHeaders(githubPat), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message, content: base64Content, sha }),
+  })
+  if (!response.ok) throw new Error(`GitHub write failed with status ${response.status}.`)
+}

--- a/netlify/functions/lib/priceHistoryCsv.spec.ts
+++ b/netlify/functions/lib/priceHistoryCsv.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for priceHistoryCsv — issue #112, test-cases.md scenarios 8, 11-14.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { toCsvLine, updateHistoryCsv } from './priceHistoryCsv'
+import type { PriceHistoryRow } from './priceHistoryCsv'
+
+const CSV_HEADER = 'date,station_name,station_url,fuel_type,price'
+
+function buildRow(overrides: Partial<PriceHistoryRow> = {}): PriceHistoryRow {
+  return {
+    date: '2026-07-23',
+    stationName: 'Intermarché Apprieu',
+    stationUrl: 'https://www.prix-carburants.gouv.fr/station/12345',
+    fuelType: 'Gazole',
+    price: 1.799,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 11: Row shape for a normal result
+// ---------------------------------------------------------------------------
+
+describe('Scenario 11: a normal result produces one row with date, name, URL, fuel type, and price', () => {
+  it('joins the row fields in the documented column order', () => {
+    const row = buildRow()
+
+    expect(toCsvLine(row)).toBe(
+      '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.799',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 12: First-ever run creates the file
+// ---------------------------------------------------------------------------
+
+describe('Scenario 12: history.csv does not yet exist', () => {
+  it('creates the header row followed by the day’s price rows', () => {
+    const rows = [buildRow(), buildRow({ fuelType: 'SP95', price: 1.899 })]
+
+    const csv = updateHistoryCsv(null, '2026-07-23', rows)
+
+    expect(csv).toBe(
+      [
+        CSV_HEADER,
+        '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.799',
+        '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,SP95,1.899',
+        '',
+      ].join('\n'),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 13: Subsequent run updates the existing file
+// ---------------------------------------------------------------------------
+
+describe('Scenario 13: history.csv already has prior days’ rows', () => {
+  it('preserves prior rows unchanged and appends the new day’s rows', () => {
+    const existingCsv = [
+      CSV_HEADER,
+      '2026-07-22,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.789',
+      '',
+    ].join('\n')
+    const todaysRows = [buildRow({ date: '2026-07-23' })]
+
+    const csv = updateHistoryCsv(existingCsv, '2026-07-23', todaysRows)
+
+    expect(csv).toBe(
+      [
+        CSV_HEADER,
+        '2026-07-22,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.789',
+        '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.799',
+        '',
+      ].join('\n'),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 14: Re-running the same day replaces its rows
+// ---------------------------------------------------------------------------
+
+describe('Scenario 14: history.csv already has rows for today from an earlier run today', () => {
+  it('removes today’s previous rows and replaces them with the fresh snapshot, leaving other days untouched', () => {
+    const existingCsv = [
+      CSV_HEADER,
+      '2026-07-22,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.789',
+      '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.799',
+      '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,SP95,1.899',
+      '',
+    ].join('\n')
+    const freshRows = [buildRow({ date: '2026-07-23', price: 1.749 })]
+
+    const csv = updateHistoryCsv(existingCsv, '2026-07-23', freshRows)
+    const lines = csv.split('\n').filter((line) => line.length > 0)
+
+    expect(lines).toEqual([
+      CSV_HEADER,
+      '2026-07-22,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.789',
+      '2026-07-23,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.749',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 8: No favorite stations configured
+// ---------------------------------------------------------------------------
+
+describe('Scenario 8: zero favorite stations produce zero rows for that day', () => {
+  it('leaves an existing history.csv otherwise unchanged for that date', () => {
+    const existingCsv = [
+      CSV_HEADER,
+      '2026-07-22,Intermarché Apprieu,https://www.prix-carburants.gouv.fr/station/12345,Gazole,1.789',
+      '',
+    ].join('\n')
+
+    const csv = updateHistoryCsv(existingCsv, '2026-07-23', [])
+
+    expect(csv).toBe(existingCsv)
+  })
+})

--- a/netlify/functions/lib/priceHistoryCsv.ts
+++ b/netlify/functions/lib/priceHistoryCsv.ts
@@ -1,0 +1,57 @@
+// Builds and updates the daily price-history CSV content (issue #112,
+// business-specifications.md): one row per station/fuel-type combination
+// scraped that day, with same-day re-runs replacing (not duplicating) that
+// day's rows.
+import { toCsvField } from './csvEscaping'
+
+export interface PriceHistoryRow {
+  date: string
+  stationName: string
+  stationUrl: string
+  fuelType: string
+  price: number
+}
+
+const CSV_HEADER = 'date,station_name,station_url,fuel_type,price'
+const LINE_SEPARATOR = '\n'
+
+export function toCsvLine(row: PriceHistoryRow): string {
+  return [
+    row.date,
+    toCsvField(row.stationName),
+    toCsvField(row.stationUrl),
+    toCsvField(row.fuelType),
+    String(row.price),
+  ].join(',')
+}
+
+// The date column is always a plain YYYY-MM-DD string (never quoted, since
+// it never contains a comma/quote/formula-trigger character), so finding a
+// row's date is a safe prefix match rather than a full CSV re-parse. A
+// missing comma (a malformed or unexpected existing line) returns the whole
+// line instead of a truncated one, so such a line is always kept as-is
+// rather than silently corrupted by an off-by-one slice.
+function rowDate(line: string): string {
+  const commaIndex = line.indexOf(',')
+  if (commaIndex === -1) return line
+  return line.slice(0, commaIndex)
+}
+
+function existingDataLines(existingCsv: string): string[] {
+  const lines = existingCsv.split(LINE_SEPARATOR).filter((line) => line.length > 0)
+  return lines.slice(1)
+}
+
+function keepOtherDaysRows(existingCsv: string, today: string): string[] {
+  return existingDataLines(existingCsv).filter((line) => rowDate(line) !== today)
+}
+
+export function updateHistoryCsv(
+  existingCsv: string | null,
+  today: string,
+  todaysRows: PriceHistoryRow[],
+): string {
+  const keptLines = existingCsv === null ? [] : keepOtherDaysRows(existingCsv, today)
+  const newLines = todaysRows.map(toCsvLine)
+  return [CSV_HEADER, ...keptLines, ...newLines].join(LINE_SEPARATOR) + LINE_SEPARATOR
+}

--- a/netlify/functions/lib/scheduleGuards.spec.ts
+++ b/netlify/functions/lib/scheduleGuards.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for scheduleGuards — issue #112, test-cases.md scenarios 1-4 and 18.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { isScheduledInvocation, isTargetLocalHour } from './scheduleGuards'
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Correct local time in summer (CEST) — 19:00 UTC is 21:00 French local time
+// ---------------------------------------------------------------------------
+
+describe('Scenario 1: 19:00 UTC in summer (CEST) is the target French local hour', () => {
+  it('returns true for 2026-07-15T19:00:00Z', () => {
+    expect(isTargetLocalHour(new Date('2026-07-15T19:00:00Z'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Off-hour invocation skipped in summer — 20:00 UTC is 22:00 French local time
+// ---------------------------------------------------------------------------
+
+describe('Scenario 2: 20:00 UTC in summer (CEST) is not the target French local hour', () => {
+  it('returns false for 2026-07-15T20:00:00Z', () => {
+    expect(isTargetLocalHour(new Date('2026-07-15T20:00:00Z'))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Correct local time in winter (CET) — 20:00 UTC is 21:00 French local time
+// ---------------------------------------------------------------------------
+
+describe('Scenario 3: 20:00 UTC in winter (CET) is the target French local hour', () => {
+  it('returns true for 2026-01-15T20:00:00Z', () => {
+    expect(isTargetLocalHour(new Date('2026-01-15T20:00:00Z'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 4: Off-hour invocation skipped in winter — 19:00 UTC is 20:00 French local time
+// ---------------------------------------------------------------------------
+
+describe('Scenario 4: 19:00 UTC in winter (CET) is not the target French local hour', () => {
+  it('returns false for 2026-01-15T19:00:00Z', () => {
+    expect(isTargetLocalHour(new Date('2026-01-15T19:00:00Z'))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 18: Direct call to the function's endpoint (not the Netlify scheduler)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 18: a direct HTTP call is not recognized as a scheduled invocation', () => {
+  it('returns false when the request body is null (typical of a direct GET)', () => {
+    expect(isScheduledInvocation(null)).toBe(false)
+  })
+
+  it('returns false when the body is not JSON', () => {
+    expect(isScheduledInvocation('not json')).toBe(false)
+  })
+
+  it('returns false when the body is JSON but lacks a next_run field', () => {
+    expect(isScheduledInvocation(JSON.stringify({ foo: 'bar' }))).toBe(false)
+  })
+
+  it('returns true when the body carries the scheduler-supplied next_run field', () => {
+    expect(isScheduledInvocation(JSON.stringify({ next_run: '2026-07-16T19:00:00Z' }))).toBe(true)
+  })
+})

--- a/netlify/functions/lib/scheduleGuards.ts
+++ b/netlify/functions/lib/scheduleGuards.ts
@@ -1,0 +1,41 @@
+// Guards for the daily price-history scheduled function (issue #112,
+// ADR-014). The cron trigger fires twice a day (19:00 and 20:00 UTC) to
+// cover both daylight-saving offsets of 21:00 French local time — only the
+// firing that actually lands on the target local hour should do real work.
+// isScheduledInvocation is defense-in-depth (security-guidelines.md rule 4):
+// Netlify's own `schedule()` invocation is documented as not reachable via
+// a direct HTTP call, but this check still confirms the expected payload
+// shape before any GitHub write is attempted.
+const TARGET_LOCAL_HOUR = 21
+const PARIS_TIME_ZONE = 'Europe/Paris'
+
+export function isScheduledInvocation(body: string | null): boolean {
+  if (body === null) return false
+  return hasNextRunField(parseJson(body))
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function hasNextRunField(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false
+  return typeof (value as Record<string, unknown>).next_run === 'string'
+}
+
+export function isTargetLocalHour(now: Date): boolean {
+  return parisHour(now) === TARGET_LOCAL_HOUR
+}
+
+function parisHour(now: Date): number {
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    timeZone: PARIS_TIME_ZONE,
+    hour: '2-digit',
+    hourCycle: 'h23',
+  })
+  return Number(formatter.format(now))
+}

--- a/netlify/functions/lib/stationHtmlParser.spec.ts
+++ b/netlify/functions/lib/stationHtmlParser.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the Netlify-Functions stationHtmlParser mirror — issue #112,
+ * test-cases.md scenario 10.
+ *
+ * linkedom's DOMParser runs the same querySelector chain as the browser
+ * version (src/utils/stationHtmlParser.ts), so no extra environment setup
+ * is needed here.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseStationHtml } from './stationHtmlParser'
+
+function buildStationHtml(rows: string): string {
+  return `
+    <html><body>
+      <table class="details_pdv">
+        <tbody>
+          ${rows}
+        </tbody>
+      </table>
+    </body></html>
+  `
+}
+
+function buildFuelRow(fuelType: string, price: string): string {
+  return `
+    <tr>
+      <td><strong>${fuelType}</strong></td>
+      <td class="prix"><strong>${price}</strong></td>
+    </tr>
+  `
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 10: A station does not list a given fuel type that day
+// ---------------------------------------------------------------------------
+
+describe('Scenario 10: a fuel type absent from the page produces no entry for it', () => {
+  it('returns only the fuel types actually present in the HTML', () => {
+    const html = buildStationHtml(buildFuelRow('Gazole', '1.799') + buildFuelRow('SP95', '1.899'))
+
+    const result = parseStationHtml(html)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.fuels).toEqual([
+      { type: 'Gazole', price: 1.799 },
+      { type: 'SP95', price: 1.899 },
+    ])
+    expect(result.fuels.some((fuel) => fuel.type === 'E85')).toBe(false)
+  })
+
+  it("still returns the station's other listed fuel types when one is missing", () => {
+    const html = buildStationHtml(buildFuelRow('Gazole', '1.799'))
+
+    const result = parseStationHtml(html)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.fuels).toHaveLength(1)
+    expect(result.fuels[0]).toEqual({ type: 'Gazole', price: 1.799 })
+  })
+})

--- a/netlify/functions/lib/stationHtmlParser.ts
+++ b/netlify/functions/lib/stationHtmlParser.ts
@@ -1,0 +1,65 @@
+// Node-compatible mirror of `src/utils/stationHtmlParser.ts` — same CSS
+// selectors and text-only extraction, but backed by linkedom's DOMParser
+// since the browser's native DOMParser does not exist in the Netlify
+// Functions Node runtime. Kept as its own copy rather than a shared import
+// because Netlify Functions and the SPA are separate TypeScript project
+// references (technical-specifications.md) — any change to the scrape
+// selector must be mirrored in both files.
+//
+// Security: text is read via textContent (never innerHTML), so embedded
+// markup from the external server is never forwarded as executable content
+// (security-guidelines.md rule 3, mirrored from the SPA's own rule).
+import { DOMParser } from 'linkedom'
+
+export interface ScrapedFuelPrice {
+  type: string
+  price: number | null
+}
+
+interface ParsedElement {
+  querySelector(selector: string): ParsedElement | null
+  textContent: string | null
+}
+
+interface ParsedDocument {
+  querySelectorAll(selector: string): Iterable<ParsedElement>
+}
+
+const FUEL_ROW_SELECTOR = '.details_pdv tbody tr'
+
+type ParseSuccess = { success: true; fuels: ScrapedFuelPrice[] }
+type ParseFailure = { success: false }
+export type StationParseResult = ParseSuccess | ParseFailure
+
+function parseHtmlDocument(htmlString: string): ParsedDocument {
+  return new DOMParser().parseFromString(htmlString, 'text/html')
+}
+
+function extractFuelType(row: ParsedElement): string {
+  const firstCell = row.querySelector('td')
+  if (firstCell === null) return ''
+  const strongElement = firstCell.querySelector('strong')
+  if (strongElement !== null) return strongElement.textContent?.trim() ?? ''
+  return firstCell.textContent?.trim() ?? ''
+}
+
+function extractFuelPrice(row: ParsedElement): number | null {
+  const priceCell = row.querySelector('td.prix')
+  if (priceCell === null) return null
+  const strongElement = priceCell.querySelector('strong')
+  if (strongElement === null) return null
+  const parsed = parseFloat(strongElement.textContent?.trim() ?? '')
+  if (!isFinite(parsed)) return null
+  return parsed
+}
+
+function rowToFuelPrice(row: ParsedElement): ScrapedFuelPrice {
+  return { type: extractFuelType(row), price: extractFuelPrice(row) }
+}
+
+export function parseStationHtml(htmlString: string): StationParseResult {
+  const document = parseHtmlDocument(htmlString)
+  const fuelRows = Array.from(document.querySelectorAll(FUEL_ROW_SELECTOR))
+  if (fuelRows.length === 0) return { success: false }
+  return { success: true, fuels: fuelRows.map(rowToFuelPrice) }
+}

--- a/netlify/functions/lib/stationUrlAllowlist.spec.ts
+++ b/netlify/functions/lib/stationUrlAllowlist.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for stationUrlAllowlist — issue #112, test-cases.md scenario 17.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { isAllowedStationUrl } from './stationUrlAllowlist'
+
+// ---------------------------------------------------------------------------
+// Scenario 17: Remote file lists a URL outside the allowed domain
+// ---------------------------------------------------------------------------
+
+describe('Scenario 17: a station URL outside the allowed domain is rejected', () => {
+  it('accepts a URL on the allowed origin and path prefix', () => {
+    expect(isAllowedStationUrl('https://www.prix-carburants.gouv.fr/station/12345')).toBe(true)
+  })
+
+  it('rejects a URL on a different host', () => {
+    expect(isAllowedStationUrl('https://evil.example.com/station/12345')).toBe(false)
+  })
+
+  it('rejects a URL on the allowed host but outside the allowed path prefix', () => {
+    expect(isAllowedStationUrl('https://www.prix-carburants.gouv.fr/carte')).toBe(false)
+  })
+
+  it('rejects a URL using a different scheme on the allowed host', () => {
+    expect(isAllowedStationUrl('http://www.prix-carburants.gouv.fr/station/12345')).toBe(false)
+  })
+
+  it('rejects a value that is not a valid URL', () => {
+    expect(isAllowedStationUrl('not a url')).toBe(false)
+  })
+})

--- a/netlify/functions/lib/stationUrlAllowlist.ts
+++ b/netlify/functions/lib/stationUrlAllowlist.ts
@@ -1,0 +1,23 @@
+// Re-validates favorite-station URLs read from the remote preferences file
+// before the scheduled price-history function fetches them (issue #112,
+// security-guidelines.md rule 3). Mirrors the origin/path allowlist
+// `src/utils/preferencesImport.ts` enforces in the browser — duplicated
+// here because Netlify Functions do not import from `src/`
+// (technical-specifications.md). The remote file can be edited outside the
+// app (ADR-012), so a URL is never trusted as-is.
+const ALLOWED_ORIGIN = 'https://www.prix-carburants.gouv.fr'
+const ALLOWED_PATH_PREFIX = '/station/'
+
+export function isAllowedStationUrl(rawUrl: string): boolean {
+  const parsed = parseUrl(rawUrl)
+  if (parsed === null) return false
+  return parsed.origin === ALLOWED_ORIGIN && parsed.pathname.startsWith(ALLOWED_PATH_PREFIX)
+}
+
+function parseUrl(rawUrl: string): URL | null {
+  try {
+    return new URL(rawUrl)
+  } catch {
+    return null
+  }
+}

--- a/netlify/functions/scheduled-price-history/scheduled-price-history.ts
+++ b/netlify/functions/scheduled-price-history/scheduled-price-history.ts
@@ -7,6 +7,7 @@
 // cron-triggered function.
 import { schedule } from '@netlify/functions'
 import type { HandlerEvent, HandlerResponse } from '@netlify/functions'
+import { jsonResponse } from '../lib/http-responses'
 import { readHistoryConfig } from '../lib/environment'
 import type { HistoryConfig } from '../lib/environment'
 import { isScheduledInvocation, isTargetLocalHour } from '../lib/scheduleGuards'
@@ -27,10 +28,6 @@ const APP_NAME = 'Coup de pompe'
 const STATION_FETCH_TIMEOUT_MS = 10_000
 
 type FoundFuelPrice = ScrapedFuelPrice & { price: number }
-
-function jsonResponse(statusCode: number, body: unknown): HandlerResponse {
-  return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
-}
 
 function toIsoDate(now: Date): string {
   return now.toISOString().slice(0, 10)
@@ -139,16 +136,26 @@ async function writeHistory(
 // call below — a scrape or read failure earlier in this function throws (or
 // short-circuits via the guard clauses above it) before that PUT is ever
 // reached, so a failed run never leaves a partial file
-// (business-specifications.md).
+// (business-specifications.md). Reading the existing history file has no
+// dependency on the favorite-stations list or the scrape results, so it runs
+// concurrently with them instead of after, shortening the run's wall-clock
+// time by roughly that read's own latency.
 async function runDailySnapshot(now: Date): Promise<HandlerResponse> {
   const config = readHistoryConfig()
   if (config === null) return jsonResponse(500, { error: 'Missing history configuration.' })
   const date = toIsoDate(now)
-  const stations = await readFavoriteStations(config)
+  const [stations, existing] = await Promise.all([
+    readFavoriteStations(config),
+    readExistingHistory(config),
+  ])
   if (stations === null) return jsonResponse(500, { error: 'Unable to read favorite stations.' })
   const todaysRows = await scrapeAllStations(stations, date)
-  const existing = await readExistingHistory(config)
   const csvContent = updateHistoryCsv(existing.content, date, todaysRows)
+  // Skip the write when nothing actually changed (e.g. no favorites, or every
+  // station failed to scrape on a day already free of rows for today) — an
+  // identical PUT would still create a no-op GitHub commit and spend a write
+  // call for zero effect.
+  if (csvContent === existing.content) return jsonResponse(200, { rowsWritten: todaysRows.length })
   await writeHistory(config, csvContent, existing.sha, date)
   return jsonResponse(200, { rowsWritten: todaysRows.length })
 }

--- a/netlify/functions/scheduled-price-history/scheduled-price-history.ts
+++ b/netlify/functions/scheduled-price-history/scheduled-price-history.ts
@@ -1,0 +1,171 @@
+// Daily scheduled snapshot of favorite-station fuel prices into history.csv
+// in the user's configured GitHub repository (issue #112, ADR-014). Runs
+// with no browser session: authenticates with a fixed, repo-scoped PAT
+// (HISTORY_GITHUB_PAT) instead of the ADR-011 OAuth cookie, and reads
+// favoriteStations from the same remote preferences file the SPA syncs
+// (ADR-012) instead of IndexedDB, since neither is reachable from a
+// cron-triggered function.
+import { schedule } from '@netlify/functions'
+import type { HandlerEvent, HandlerResponse } from '@netlify/functions'
+import { readHistoryConfig } from '../lib/environment'
+import type { HistoryConfig } from '../lib/environment'
+import { isScheduledInvocation, isTargetLocalHour } from '../lib/scheduleGuards'
+import { isAllowedStationUrl } from '../lib/stationUrlAllowlist'
+import { parseStationHtml } from '../lib/stationHtmlParser'
+import type { ScrapedFuelPrice } from '../lib/stationHtmlParser'
+import { parseFavoriteStations } from '../lib/favoriteStationsParser'
+import type { FavoriteStation } from '../lib/favoriteStationsParser'
+import { readRemoteFile, writeRemoteFile, encodeBase64, decodeBase64 } from '../lib/githubContentsClient'
+import { updateHistoryCsv } from '../lib/priceHistoryCsv'
+import type { PriceHistoryRow } from '../lib/priceHistoryCsv'
+
+const CRON_EXPRESSION = '0 19,20 * * *'
+const HISTORY_FILE_PATH = 'history.csv'
+const USER_AGENT = 'french-gas-stations-scraper/1.0'
+const COMMIT_MESSAGE_PREFIX = 'Historique des prix du'
+const APP_NAME = 'Coup de pompe'
+const STATION_FETCH_TIMEOUT_MS = 10_000
+
+type FoundFuelPrice = ScrapedFuelPrice & { price: number }
+
+function jsonResponse(statusCode: number, body: unknown): HandlerResponse {
+  return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+}
+
+function toIsoDate(now: Date): string {
+  return now.toISOString().slice(0, 10)
+}
+
+function hasPrice(fuel: ScrapedFuelPrice): fuel is FoundFuelPrice {
+  return fuel.price !== null
+}
+
+function buildRow(station: FavoriteStation, date: string, fuel: FoundFuelPrice): PriceHistoryRow {
+  return {
+    date,
+    stationName: station.name,
+    stationUrl: station.url,
+    fuelType: fuel.type,
+    price: fuel.price,
+  }
+}
+
+// Bounded so one slow/hung station page cannot stall the whole run — a
+// scheduled function has a fixed execution timeout, and every other
+// favorite station must still get its rows written even if one is
+// unresponsive (mirrors useRemotePreferencesSync.ts's fetchWithTimeout).
+async function fetchStationHtml(url: string): Promise<string | null> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), STATION_FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, { headers: { 'User-Agent': USER_AGENT }, signal: controller.signal })
+    if (!response.ok) return null
+    return await response.text()
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+function toHistoryRows(station: FavoriteStation, date: string, htmlText: string): PriceHistoryRow[] {
+  const parseResult = parseStationHtml(htmlText)
+  if (!parseResult.success) return []
+  return parseResult.fuels.filter(hasPrice).map((fuel) => buildRow(station, date, fuel))
+}
+
+// A station whose URL fails the allowlist, whose page can't be fetched
+// (network error, timeout, non-2xx), or whose page doesn't match the
+// expected fuel-row selector contributes no rows — the rest of the run
+// still proceeds normally (business-specifications.md). The try/catch is
+// required, not incidental: without it, one station's rejected fetch
+// promise would reject the Promise.all in scrapeAllStations and abort
+// every other station's rows too.
+async function scrapeStation(station: FavoriteStation, date: string): Promise<PriceHistoryRow[]> {
+  if (!isAllowedStationUrl(station.url)) return []
+  try {
+    const htmlText = await fetchStationHtml(station.url)
+    if (htmlText === null) return []
+    return toHistoryRows(station, date, htmlText)
+  } catch {
+    return []
+  }
+}
+
+async function scrapeAllStations(stations: FavoriteStation[], date: string): Promise<PriceHistoryRow[]> {
+  const rowsByStation = await Promise.all(stations.map((station) => scrapeStation(station, date)))
+  return rowsByStation.flat()
+}
+
+async function readFavoriteStations(config: HistoryConfig): Promise<FavoriteStation[] | null> {
+  const outcome = await readRemoteFile(
+    config.githubPat,
+    config.owner,
+    config.repo,
+    config.preferencesFilePath,
+  )
+  if (!outcome.found) return null
+  return parseFavoriteStations(decodeBase64(outcome.file.content))
+}
+
+interface ExistingHistory {
+  content: string | null
+  sha: string | undefined
+}
+
+async function readExistingHistory(config: HistoryConfig): Promise<ExistingHistory> {
+  const outcome = await readRemoteFile(config.githubPat, config.owner, config.repo, HISTORY_FILE_PATH)
+  if (!outcome.found) return { content: null, sha: undefined }
+  return { content: decodeBase64(outcome.file.content), sha: outcome.file.sha }
+}
+
+async function writeHistory(
+  config: HistoryConfig,
+  csvContent: string,
+  sha: string | undefined,
+  date: string,
+): Promise<void> {
+  const message = `${COMMIT_MESSAGE_PREFIX} ${date} via ${APP_NAME}`
+  await writeRemoteFile(
+    config.githubPat,
+    config.owner,
+    config.repo,
+    HISTORY_FILE_PATH,
+    message,
+    encodeBase64(csvContent),
+    sha,
+  )
+}
+
+// The whole day's CSV content is assembled in memory before the single PUT
+// call below — a scrape or read failure earlier in this function throws (or
+// short-circuits via the guard clauses above it) before that PUT is ever
+// reached, so a failed run never leaves a partial file
+// (business-specifications.md).
+async function runDailySnapshot(now: Date): Promise<HandlerResponse> {
+  const config = readHistoryConfig()
+  if (config === null) return jsonResponse(500, { error: 'Missing history configuration.' })
+  const date = toIsoDate(now)
+  const stations = await readFavoriteStations(config)
+  if (stations === null) return jsonResponse(500, { error: 'Unable to read favorite stations.' })
+  const todaysRows = await scrapeAllStations(stations, date)
+  const existing = await readExistingHistory(config)
+  const csvContent = updateHistoryCsv(existing.content, date, todaysRows)
+  await writeHistory(config, csvContent, existing.sha, date)
+  return jsonResponse(200, { rowsWritten: todaysRows.length })
+}
+
+async function handleScheduledRun(event: HandlerEvent): Promise<HandlerResponse> {
+  if (!isScheduledInvocation(event.body)) {
+    return jsonResponse(403, { error: 'Not a scheduled invocation.' })
+  }
+  if (!isTargetLocalHour(new Date())) {
+    return jsonResponse(200, { skipped: true })
+  }
+  try {
+    return await runDailySnapshot(new Date())
+  } catch (error) {
+    console.error('Daily price history run failed:', error)
+    return jsonResponse(500, { error: 'Daily price history run failed.' })
+  }
+}
+
+export const handler = schedule(CRON_EXPRESSION, handleScheduledRun)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.1",
+        "linkedom": "^0.18.13",
         "radix-vue": "^1.9.17",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
@@ -4349,6 +4350,68 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select/node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select/node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4361,6 +4424,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4474,6 +4543,67 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
@@ -4481,6 +4611,24 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-prop": {
@@ -5667,6 +5815,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6495,6 +6729,36 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/linkedom/node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "license": "MIT"
     },
     "node_modules/load-json-file": {
@@ -11364,6 +11628,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
     },
     "node_modules/undici": {
       "version": "7.24.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.1",
+    "linkedom": "^0.18.13",
     "radix-vue": "^1.9.17",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary

- Adds a scheduled Netlify function that runs once daily at 21:00 French local time (DST-aware, via a twice-daily UTC cron plus a runtime hour check) to snapshot every favorite station's fuel prices into `history.csv` in the user's configured GitHub repository.
- Authenticates with a fixed, repo-scoped GitHub PAT (ADR-014) — independent of the browser OAuth session (ADR-011) — and reads `favoriteStations` from the same remote preferences file the SPA already syncs (ADR-012), not from IndexedDB.
- Guards against partial writes (a scrape or read failure aborts before any GitHub write), replaces same-day rows on re-run instead of duplicating them, escapes CSV fields against formula/structural injection, and re-validates each station URL against the allowed domain before fetching it.

## Test plan

- [x] `npx vitest run` — 356 test files, 422 tests, all passing (see `test-results.md`)
- [x] Unit tests added for all pure `netlify/functions/lib/` modules: schedule guards (DST + non-scheduler invocation), station URL allowlist, CSV escaping, CSV row/day-replace logic, HTML fuel-price parsing, favorite-stations parsing
- [x] `vue-tsc` type-check and lint clean (see `review-results.md`)
- [ ] Manual verification in `netlify dev` of the full scheduled run (favorites read, scrape, GitHub write, PAT failure, missing/invalid preferences file) — not unit-testable without mocking the whole orchestration chain

Closes #112
