### PR TITLE
UI/UX improvements: mobile settings layout, batched station saves

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -125,7 +125,7 @@ declare global {
   export type { FuelPrice } from './src/types/fuel-price'
   import('./src/types/fuel-price')
   // @ts-ignore
-  export type { PreferencesFile, DiffRowKind, StationDiffRow, FuelTypeDiff, PreferencesDiff, RemoteWritePreview } from './src/types/preferences'
+  export type { PreferencesFile, DiffRowKind, StationDiffRow, FuelTypeDiff, PreferencesDiff, StationFieldChange, StationChange, FuelTypeChange, RemoteWritePreview } from './src/types/preferences'
   import('./src/types/preferences')
   // @ts-ignore
   export type { PriceRow } from './src/types/price-row'

--- a/docs/decisions/ADR-012-github-repo-as-sync-backend.md
+++ b/docs/decisions/ADR-012-github-repo-as-sync-backend.md
@@ -73,6 +73,71 @@ On any preference change, the app writes optimistically to IndexedDB, then to th
 - The GitHub Contents API has a file size limit of 100 MB (well above any realistic preferences JSON).
 - If the user's repository is private, the `repo` OAuth scope is required. If public, `public_repo` suffices. Scope selection should be documented in the Settings UI setup guide.
 
+## Addendum (2026-08-03): Batched Write Trigger for Station List Edits (Issue #110)
+
+**Status:** Accepted
+
+### Context
+
+The original Write Flow pushes to GitHub on every single preference change — each station
+add/edit/delete in `StationManagerTable.vue` triggered its own immediate `PUT` and, when a
+remote file already existed, its own diff-confirmation dialog. Editing several stations in a
+row (e.g. renaming three stations one after another) produced three separate GitHub commits
+and three separate confirmation dialogs, and the dialog itself showed the full before/after
+JSON of the file rather than what had actually changed — both work against this ADR's
+"auditable" rationale (point 3) once a user makes more than one edit at a time.
+
+### Decision
+
+For station-list edits made in `StationManager`/`StationManagerTable.vue` only, the write flow
+changes from immediate-on-every-change to **batched and explicitly triggered**:
+
+- Adding, editing, or deleting a station still writes to IndexedDB immediately, unchanged.
+- The GitHub push is deferred: the app tracks that a push is pending since the last successful
+  write, without pushing yet.
+- A new "Enregistrer les modifications" button in `StationManager` is visible only while a push
+  is pending. Clicking it bundles every station-list change made since the last successful push
+  into a single diff/`PUT`, reusing the same `sha`-based optimistic concurrency (an absent `sha`
+  creates, a stale `sha` still 409s) and the same proxy/auth path this ADR already established.
+- The diff-confirmation dialog (`PreferencesDiffDialog.vue`) changes to render only the fields
+  that changed — added/removed stations by name, and per-station old → new values for edited
+  fields — instead of the full before/after JSON text. `RemoteWritePreview`
+  (`src/types/preferences.ts`) changes shape accordingly, from `{ beforeJson, afterJson }` to a
+  field-level diff representation.
+
+This ADR's core decision — the GitHub Contents API as the write mechanism, the Netlify proxy,
+and the `sha`-based concurrency model — is unchanged. Only the trigger point and
+confirmation-dialog content for `StationManager` edits change.
+
+**Out of scope:** the default fuel type save flow (`StationPricesContent.vue`) keeps pushing to
+GitHub immediately on every change, unaffected by this addendum.
+
+### Consequences
+
+#### Positive
+
+- ✅ Fewer GitHub commits and API calls for a burst of edits — one commit per logical batch of
+  changes instead of one per field.
+- ✅ The confirmation dialog stays readable and reviewable even when several stations are
+  edited before saving.
+- ✅ The audit trail becomes more meaningful — one commit per user-initiated save, not one per
+  blur event.
+
+#### Negative
+
+- ⚠️ Adds local "pending changes" state that must stay correct across page reloads/navigation —
+  a user who edits and then closes the tab without clicking "Enregistrer les modifications" has
+  a local/remote divergence until they return and save. Local edits are never lost (they are
+  already in IndexedDB); only the remote push is delayed.
+- ⚠️ Two different write-trigger behaviors now exist in the same app (immediate for default
+  fuel type, batched for the station list), which future contributors need to know when
+  extending either flow.
+
+### Notes
+
+- Reuses this ADR's existing `sha`-based conflict handling unchanged — a concurrent remote edit
+  during the batching window still surfaces as a 409 / `DIVERGED_MESSAGE`.
+
 ## References
 
 - [GitHub Contents API documentation](https://docs.github.com/en/rest/repos/contents)

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/README.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/README.md
@@ -1,0 +1,6 @@
+Worktree: E:/Git/GitHub/french-gas-stations-scraper_feat-ui-ux-improvements
+
+# Issue #110: UI and UX improvements
+
+- [ ] On setting page, the smartphone show the two buttons alongside rather the connection button to fall under the save button
+- [ ] The diff screen when saving to GitHub should be more user friendly (only show what is edited) and should appear when a "Enregistrer les modifications" is clicked. That is a new button to add to the `StationManager` component. The button appear as soon as a value is edited in the `StationManager` component.

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/business-specifications.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/business-specifications.md
@@ -1,0 +1,81 @@
+# Business Specifications — Issue #110: UI and UX improvements
+
+## Goal and Scope
+
+Two independent UI/UX fixes:
+
+1. **Settings page (mobile):** the "Enregistrer" button and the connect/disconnect GitHub button
+   must stack vertically on mobile viewports instead of sitting awkwardly in a row; they keep
+   sitting side-by-side on wider (tablet/desktop) viewports.
+2. **Station list saves (StationManager):** GitHub sync currently pushes on every single field
+   edit and shows a raw JSON before/after diff. This introduces an explicit
+   "Enregistrer les modifications" button that batches pending station-list changes into one
+   GitHub push, with a diff screen that shows only what changed.
+
+Out of scope: the default fuel type save flow (`StationPricesContent.vue`) keeps pushing to
+GitHub immediately on change — it is a separate component/flow from `StationManager` and the
+issue only scopes the new button to `StationManager`.
+
+## Files to Create or Modify
+
+- `src/components/GitHubSyncSettings.vue` — settings-page button row becomes responsive
+  (stacked on mobile, side-by-side on wider viewports).
+- `src/components/StationManager.vue` — hosts the new "Enregistrer les modifications" button
+  and its visible/hidden state.
+- `src/components/StationManagerTable.vue` — station add/edit/delete keep saving to IndexedDB
+  immediately, but stop triggering an immediate GitHub push; they instead mark the change as
+  pending.
+- State tracking for "pending station-list changes since the last successful GitHub push"
+  (new or extended composable — left to the technical spec) — exposes whether a push is
+  pending and bundles all pending changes into a single push when triggered.
+- `src/components/PreferencesDiffDialog.vue` — the GitHub write-confirmation section changes
+  from raw before/after JSON blocks to a per-field old → new comparison.
+- `src/types/preferences.ts` — `RemoteWritePreview` shape changes from full JSON text
+  (`beforeJson`/`afterJson`) to a field-level diff representation.
+
+## Rules
+
+### Settings page mobile layout
+
+- On mobile viewports, the "Enregistrer" button and the connect/disconnect button stack
+  vertically, each full-width, in their current order. On wider viewports they remain
+  side-by-side as today.
+  _Example: on a phone-width screen, "Enregistrer les paramètres" appears above
+  "Se connecter avec GitHub", each spanning the section's full width._
+
+### "Enregistrer les modifications" button
+
+- The button is added to `StationManager`, near the existing export/import buttons.
+- It is hidden while no station-list change is pending a GitHub push (on load, and right after
+  a successful push).
+- It becomes visible as soon as the user edits an existing station's name or URL, adds a new
+  station, or deletes a station — before that change has been pushed to GitHub.
+- Local persistence timing is unchanged: each edit still saves to IndexedDB immediately, as it
+  does today. Only the GitHub push is deferred until the button is clicked.
+- Clicking the button bundles every station-list change made since the last successful push (or
+  since load) into a single GitHub diff/push, instead of one push per edited field.
+  _Example: the user renames one station and adds another before clicking "Enregistrer les
+  modifications" — both changes appear together in one confirmation dialog and are pushed in a
+  single write._
+- If the user cancels the confirmation dialog, or the push fails, the pending changes are kept
+  and the button stays visible so the user can retry. If the push succeeds, the button becomes
+  hidden again.
+
+### GitHub diff screen readability
+
+- The write-confirmation dialog shows only what changed, as an old → new comparison per field
+  (e.g. "Nom : Ancien nom → Nouveau nom", "URL : ancienne-url → nouvelle-url"), plus stations
+  added or removed, listed by name — not the full JSON content of the file.
+  _Example: only the "Nom" field was edited on one station — the dialog shows that single
+  name change, not the entire station list._
+
+## ADR Required
+
+This spec changes the "Write Flow" documented in `ADR-012-github-repo-as-sync-backend.md`
+("On any preference change, the app writes optimistically to IndexedDB, then to the remote
+file...") from an always-immediate GitHub push to a batched, explicitly user-triggered push for
+station-list changes made in `StationManager`. This is a change to a previously accepted
+architectural decision, not just an implementation detail, so it needs an ADR update/addendum
+before implementation.
+
+status: ready

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/review-results.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/review-results.md
@@ -23,27 +23,44 @@ E:\...\src\composables\usePreferencesImport.spec.ts
 
 type-check: fails, but exactly as anticipated and documented in
 `technical-specifications.md`'s "Test impact for the next phase" section — the `RemoteWritePreview`
-shape change breaks two pre-existing assertions in
-`src/composables/useRemotePreferencesWrite.spec.ts` that `/jli-writes-tests` will rewrite.
+shape change and `pushPreferences`'s new `includeStationChanges` parameter break pre-existing
+assertions/call sites in `src/composables/useRemotePreferencesWrite.spec.ts` that `/jli-writes-tests`
+will rewrite.
 
 ```
+src/composables/useRemotePreferencesWrite.spec.ts(155,11): error TS2554: Expected 4-5 arguments, but got 3.
 src/composables/useRemotePreferencesWrite.spec.ts(158,29): error TS2339: Property 'beforeJson' does not exist on type 'RemoteWritePreview'.
 src/composables/useRemotePreferencesWrite.spec.ts(159,29): error TS2339: Property 'beforeJson' does not exist on type 'RemoteWritePreview'.
 src/composables/useRemotePreferencesWrite.spec.ts(160,29): error TS2339: Property 'afterJson' does not exist on type 'RemoteWritePreview'.
+src/composables/useRemotePreferencesWrite.spec.ts(178,11): error TS2554: Expected 4-5 arguments, but got 3.
 src/composables/useRemotePreferencesWrite.spec.ts(181,29): error TS2339: Property 'beforeJson' does not exist on type 'RemoteWritePreview'.
 src/composables/useRemotePreferencesWrite.spec.ts(182,29): error TS2339: Property 'afterJson' does not exist on type 'RemoteWritePreview'.
+src/composables/useRemotePreferencesWrite.spec.ts(201,11): error TS2554: Expected 4-5 arguments, but got 3.
+src/composables/useRemotePreferencesWrite.spec.ts(225,11): error TS2554: Expected 4-5 arguments, but got 3.
+src/composables/useRemotePreferencesWrite.spec.ts(251,11): error TS2554: Expected 4-5 arguments, but got 3.
+src/composables/useRemotePreferencesWrite.spec.ts(271,11): error TS2554: Expected 4-5 arguments, but got 3.
+src/composables/useRemotePreferencesWrite.spec.ts(294,11): error TS2554: Expected 4-5 arguments, but got 3.
+src/composables/useRemotePreferencesWrite.spec.ts(316,11): error TS2554: Expected 4-5 arguments, but got 3.
+src/composables/useRemotePreferencesWrite.spec.ts(338,11): error TS2554: Expected 4-5 arguments, but got 3.
 ```
 
 ## Checklist findings
 
-### 1. `pendingStationChanges` is a shared singleton consumed unconditionally by `pushPreferences`, leaking into the fuel-type flow the ADR addendum says is "unaffected"
+Previous finding (`pendingStationChanges` leaking from `StationManager` into the fuel-type push)
+verified fixed: `pushPreferences` now takes an explicit `includeStationChanges: boolean` (4th
+argument, `useRemotePreferencesWrite.ts:328-334`), `StationManager.vue:27-33` passes `true`,
+`StationPricesContent.vue:201-207` passes `false`. Traced the snapshot/clear path end to end —
+`stationChangesSnapshot = includeStationChanges ? pendingStationChanges.value : []`
+(`useRemotePreferencesWrite.ts:364`) — confirming a fuel-type-only push can no longer bundle,
+display, or clear a station edit still pending review in `StationManager`, matching
+business-specifications.md's "unaffected" scoping and test-cases.md TC-21. Also verified against
+security-guidelines.md rule 3 (snapshot taken before the `fetchExistingFile` GET, cleared by
+reference via `clearPendingStationChanges`, not a blind `= []`) and rule 1/2 (diff values sourced
+only from already-validated local state and the re-validated remote file; template uses text
+interpolation only, no `v-html`).
 
-- Where: `src/composables/useRemotePreferencesWrite.ts:356` (`stationChangesSnapshot = pendingStationChanges.value` inside `pushPreferences`), consumed by both call sites — `src/components/StationManager.vue:25-28` (`onSaveChanges`, the intended trigger) and `src/components/StationPricesContent.vue:199-202` (`pushFuelTypeChange`, called from `onSaveDefault`).
-- What's wrong: `pushPreferences` has no way to know which caller invoked it, so it always reads and bundles the *global* `pendingStationChanges` list — the one meant to represent "edits made in `StationManagerTable` since the last click of 'Enregistrer les modifications'". `StationPricesContent.vue`'s fuel-type save was never changed to exclude it (technical-specifications.md's decision #3 explicitly assumes "it naturally gets an empty stationChanges list" — that assumption doesn't hold once a station edit is pending at the time the user saves a fuel type).
-- Failure scenario: user edits a station's name in `StationManager` (saved to IndexedDB, `markStationChange` records it, "Enregistrer les modifications" becomes visible) but does not click it. They then go select a new default fuel type and click "Enregistrer" in `StationPricesContent` (same page, no navigation needed — both components render together, see `src/pages/index.spec.ts`). `onSaveDefault` → `pushFuelTypeChange` → `pushPreferences` silently scoops up the pending station edit: if no remote file exists yet it is pushed with zero review (`createRemoteFile`, no dialog per Sub-Issue D rule 2); if a remote file exists, the write-confirm dialog opens from the fuel-type "Enregistrer" click showing an unrelated station change the user never asked to review from that button. Either way, `clearPendingStationChanges` then hides "Enregistrer les modifications" in `StationManager` — even though the user never clicked it. This contradicts business-specifications.md's explicit scoping ("the issue only scopes the new button to `StationManager`") and ADR-012's addendum ("the default fuel type save flow... unaffected by this addendum").
-- Same root cause also works in reverse: because station-side diffing is now sourced only from the tracked `stationChanges` list (not derived by comparing before/after station arrays), a real station-list drift against the remote file that isn't currently sitting in `pendingStationChanges` (e.g. a previous push failed and was cleared, or the remote diverged from another device) will no longer surface in the fuel-type-triggered dialog at all, even though the full current station list is still included in the PUT content.
-- Suggested direction: give `pushPreferences` an explicit parameter (e.g. `includeStationChanges: boolean`, or have `StationPricesContent.vue` pass an empty array) so only the `StationManager`-triggered call bundles/clears `pendingStationChanges`, keeping the fuel-type flow's write scoped to `fuelTypeChange` only as the business spec requires.
+No new issues found.
 
 All other checklist items ✓
 
-status: changes requested
+status: approved

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/review-results.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/review-results.md
@@ -1,0 +1,49 @@
+# Review Results — Issue #110: UI and UX improvements
+
+lint: fails, but only on two files not in scope of this task (`usePreferencesExport.spec.ts`,
+`usePreferencesImport.spec.ts`) — confirmed via `git diff develop...HEAD` to be untouched by this
+branch; pre-existing from issues #63/#69. Not caused by this implementation.
+
+```
+E:\...\src\composables\usePreferencesExport.spec.ts
+  39:5  error  'lastDownloaded' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+E:\...\src\composables\usePreferencesImport.spec.ts
+   36:15  error  'PreferencesDiff' is defined but never used       @typescript-eslint/no-unused-vars
+   71:33  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   72:36  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+   72:50  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   73:42  error  '_label' is defined but never used                @typescript-eslint/no-unused-vars
+  433:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  466:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  468:11  error  'externalUrl' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+✖ 9 problems (9 errors, 0 warnings)
+```
+
+type-check: fails, but exactly as anticipated and documented in
+`technical-specifications.md`'s "Test impact for the next phase" section — the `RemoteWritePreview`
+shape change breaks two pre-existing assertions in
+`src/composables/useRemotePreferencesWrite.spec.ts` that `/jli-writes-tests` will rewrite.
+
+```
+src/composables/useRemotePreferencesWrite.spec.ts(158,29): error TS2339: Property 'beforeJson' does not exist on type 'RemoteWritePreview'.
+src/composables/useRemotePreferencesWrite.spec.ts(159,29): error TS2339: Property 'beforeJson' does not exist on type 'RemoteWritePreview'.
+src/composables/useRemotePreferencesWrite.spec.ts(160,29): error TS2339: Property 'afterJson' does not exist on type 'RemoteWritePreview'.
+src/composables/useRemotePreferencesWrite.spec.ts(181,29): error TS2339: Property 'beforeJson' does not exist on type 'RemoteWritePreview'.
+src/composables/useRemotePreferencesWrite.spec.ts(182,29): error TS2339: Property 'afterJson' does not exist on type 'RemoteWritePreview'.
+```
+
+## Checklist findings
+
+### 1. `pendingStationChanges` is a shared singleton consumed unconditionally by `pushPreferences`, leaking into the fuel-type flow the ADR addendum says is "unaffected"
+
+- Where: `src/composables/useRemotePreferencesWrite.ts:356` (`stationChangesSnapshot = pendingStationChanges.value` inside `pushPreferences`), consumed by both call sites — `src/components/StationManager.vue:25-28` (`onSaveChanges`, the intended trigger) and `src/components/StationPricesContent.vue:199-202` (`pushFuelTypeChange`, called from `onSaveDefault`).
+- What's wrong: `pushPreferences` has no way to know which caller invoked it, so it always reads and bundles the *global* `pendingStationChanges` list — the one meant to represent "edits made in `StationManagerTable` since the last click of 'Enregistrer les modifications'". `StationPricesContent.vue`'s fuel-type save was never changed to exclude it (technical-specifications.md's decision #3 explicitly assumes "it naturally gets an empty stationChanges list" — that assumption doesn't hold once a station edit is pending at the time the user saves a fuel type).
+- Failure scenario: user edits a station's name in `StationManager` (saved to IndexedDB, `markStationChange` records it, "Enregistrer les modifications" becomes visible) but does not click it. They then go select a new default fuel type and click "Enregistrer" in `StationPricesContent` (same page, no navigation needed — both components render together, see `src/pages/index.spec.ts`). `onSaveDefault` → `pushFuelTypeChange` → `pushPreferences` silently scoops up the pending station edit: if no remote file exists yet it is pushed with zero review (`createRemoteFile`, no dialog per Sub-Issue D rule 2); if a remote file exists, the write-confirm dialog opens from the fuel-type "Enregistrer" click showing an unrelated station change the user never asked to review from that button. Either way, `clearPendingStationChanges` then hides "Enregistrer les modifications" in `StationManager` — even though the user never clicked it. This contradicts business-specifications.md's explicit scoping ("the issue only scopes the new button to `StationManager`") and ADR-012's addendum ("the default fuel type save flow... unaffected by this addendum").
+- Same root cause also works in reverse: because station-side diffing is now sourced only from the tracked `stationChanges` list (not derived by comparing before/after station arrays), a real station-list drift against the remote file that isn't currently sitting in `pendingStationChanges` (e.g. a previous push failed and was cleared, or the remote diverged from another device) will no longer surface in the fuel-type-triggered dialog at all, even though the full current station list is still included in the PUT content.
+- Suggested direction: give `pushPreferences` an explicit parameter (e.g. `includeStationChanges: boolean`, or have `StationPricesContent.vue` pass an empty array) so only the `StationManager`-triggered call bundles/clears `pendingStationChanges`, keeping the fuel-type flow's write scoped to `fuelTypeChange` only as the business spec requires.
+
+All other checklist items ✓
+
+status: changes requested

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/security-guidelines.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/security-guidelines.md
@@ -1,0 +1,32 @@
+# Security Guidelines — Issue #110: UI and UX improvements
+
+## Rules
+
+1. **Compute the new field-level diff (added/removed stations, per-field old → new values) only
+   from data that has already passed existing validation — the remote file content validated
+   per `issue-64/security-guidelines.md` rule 8, and local station name/URL values validated by
+   `preferencesImport.ts`'s validators before they ever reach IndexedDB. Never build a diff row
+   from raw, not-yet-validated fetched text.**
+   - Where: the diff-computation logic feeding `PreferencesDiffDialog.vue`'s write-confirm
+     section, and the `RemoteWritePreview` type change in `src/types/preferences.ts`.
+   - Why: this is a new code path; sourcing it from unvalidated text instead of the already-
+     validated values would reopen the injection surface `issue-64` rule 8 closed.
+
+2. **Keep every value shown in the rebuilt write-confirm template — old and new — rendered
+   through Vue's default text interpolation, never `v-html` or raw DOM insertion.**
+   - Where: `PreferencesDiffDialog.vue` write-confirm section (currently `<pre>` blocks, being
+     replaced with per-field rows).
+   - Why: `issue-64` rule 8 established this for the same component; rewriting its template is
+     exactly the kind of change that regresses an established rule if not re-verified.
+
+3. **The bundled changes the user reviews in the confirmation dialog must be the exact snapshot
+   sent in the GitHub `PUT` — no recomputation of pending changes between "Confirmer l'envoi"
+   and the request.**
+   - Where: the pending-write state introduced for batching (extends `useRemotePreferencesWrite`'s
+     existing single-snapshot `pendingWrite` pattern to cover multiple bundled edits).
+   - Why: batching several edits into one push widens the window between "user reviews" and
+     "request is sent" compared to the current single-edit flow; without a frozen snapshot, a
+     late-arriving local change could be written to the user's repository without ever being
+     shown in the dialog they approved.
+
+status: ready

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/technical-specifications.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/technical-specifications.md
@@ -1,0 +1,109 @@
+# Technical Specifications — Issue #110: UI and UX improvements
+
+## Files Changed
+
+- `src/types/preferences.ts` — replaced `RemoteWritePreview`'s `{ beforeJson, afterJson }` text
+  shape with a field-level shape: new `StationFieldChange`, `StationChange` (discriminated union:
+  `edited`/`added`/`removed`), and `FuelTypeChange` types.
+- `src/composables/useRemotePreferencesWrite.ts` — added `pendingStationChanges` (module-level
+  state), `hasPendingChanges` (computed) and `markStationChange` to the composable's public
+  surface; `decodeAndValidateExistingFile` now returns the parsed `PreferencesFile` instead of
+  re-serialised JSON text; the write-confirm preview is now built from
+  `pendingStationChanges` + a fuel-type before/after comparison instead of raw JSON diffing.
+- `src/components/StationManagerTable.vue` — station add/edit/delete no longer call
+  `pushPreferences`; they call `markStationChange` with the specific field(s) that changed.
+  Removed the now-unused `useGitHubAuth`/`useRepoConfig`/`useDefaultFuelType`/
+  `buildPreferencesFile` imports.
+- `src/components/StationManager.vue` — added the "Enregistrer les modifications" button
+  (visible only while `hasPendingChanges` is true) and the composables/handler needed to trigger
+  the batched push.
+- `src/components/PreferencesDiffDialog.vue` — the GitHub write-confirm section's template now
+  renders `writeDiff.stationChanges`/`writeDiff.fuelTypeChange` as field-level rows instead of
+  `<pre>` JSON blocks; added `fieldLabel`/`stationChangeKey` helpers.
+- `src/components/GitHubSyncSettings.vue` — the save/connect button row is now
+  `flex-col` (stacked, full width) by default and `sm:flex-row` (side by side, auto width) from
+  the `sm` breakpoint up.
+
+## Non-trivial decisions
+
+1. **Pending station changes are tracked as discrete recorded events, not derived by diffing two
+   full station arrays.** A station's URL is its only identity, and comparing the GitHub-fetched
+   "before" array against the current local "after" array by URL breaks the moment a URL itself
+   is edited (it would show as a remove+add pair instead of a URL change) — and the business spec's
+   example explicitly shows a URL field change as one row. Recording `{ field, before, after }` at
+   the exact moment each edit is saved sidesteps the identity-matching problem entirely and is
+   also what makes bundling multiple edits into one dialog straightforward.
+
+2. **`pendingStationChanges` and `markStationChange` live in `useRemotePreferencesWrite`, not a
+   new composable.** That composable already owns "what's about to be / was just pushed"
+   (`writeDiff`, `pendingWrite`, `isWriting`); pending-but-not-yet-pushed changes are the same
+   kind of state one step earlier in the same lifecycle. Splitting it into a second composable
+   would force `StationManagerTable.vue` and `StationManager.vue` to each call two composables
+   for one concern, and `useRemotePreferencesWrite` to import the new composable — which the
+   composable-caller-responsibility convention forbids (composables never call other composables
+   internally).
+
+3. **`pushPreferences`'s public signature is unchanged** — it still reads
+   `pendingStationChanges` internally rather than taking it as a parameter. This keeps
+   `StationPricesContent.vue`'s existing fuel-type-only call site untouched: it naturally gets an
+   empty `stationChanges` list (no station edits happened) and only ever shows a
+   `fuelTypeChange`, satisfying the "default fuel type flow is unaffected" rule without an
+   `if (source === ...)` branch anywhere.
+
+4. **The pending-changes snapshot is taken synchronously at the top of `pushPreferences`, before
+   the `fetchExistingFile` GET, and only that snapshot is cleared on success** (via
+   `clearPendingStationChanges`'s reference-based filter, not a blind `= []`). Implements
+   security-guidelines.md rule 3: the GET is the only await between "button clicked" and "dialog
+   shown", so without freezing the snapshot first, an edit made during that window could appear
+   in the dialog but be silently dropped by a later full clear — or be pushed without ever having
+   been shown. Any edit made during the window stays pending afterwards for the next save.
+
+5. **`decodeAndValidateExistingFile` now returns the parsed `PreferencesFile` instead of
+   re-serialised JSON text.** The write-confirm dialog no longer needs the full remote text, only
+   the single `fuelTypeDefault` field for comparison — returning the already-validated object
+   avoids a pointless re-serialise/re-parse round trip and keeps `parseJsonFile`'s shape
+   validation (security-guidelines.md issue #64 rule 8) as the sole gate before the value is used.
+
+6. **`stationChangeKey` prefixes every generated key with `change.kind`** (`edited-<url>`,
+   `added-<url>`, `removed-<url>`) rather than the bare URL, so a `v-for` key collision can never
+   occur even if an edited and a removed/added entry happen to reference the same URL within one
+   batch.
+
+## Known limitation (documented, not fixed — out of test-cases.md scope)
+
+If the very same row is edited twice before "Enregistrer les modifications" is clicked (e.g. the
+name field is blurred, then blurred again with a further change), each save appends its own
+`edited` entry rather than merging into one before→final row — the dialog would show two rows for
+that station instead of one collapsed row. `test-cases.md` only requires that edits to
+*different* stations bundle correctly (covered), not that repeated edits to the *same* field
+collapse. Left as-is to avoid a stable-identity/coalescing mechanism the spec doesn't ask for.
+
+## Self-review: issues found and fixed
+
+1. **Fixed** — an earlier draft cleared `pendingStationChanges.value = []` unconditionally on
+   success. Since the snapshot is taken before an `await`, any edit made while that GET was in
+   flight would have been silently discarded (not pushed, not shown, and now not pending either).
+   Replaced with `clearPendingStationChanges`, which removes only the entries the completed push
+   actually covered.
+2. **Fixed** — `markStationChange` could be called with a zero-length `fieldChanges` array,
+   producing a blank "edited" row (a station heading with nothing under it) in the confirmation
+   dialog. `saveExistingRow` now only calls `markStationChange` when `buildFieldChanges` returns
+   at least one entry.
+3. **Fixed** — `stationChangeKey` initially used the bare station URL for every change kind. A
+   station removed and a *different* new station added with the same URL later in the same
+   session (or any coincidental URL reuse across change kinds within one batch) would have
+   produced duplicate `:key` values. Prefixed every generated key with the change's `kind`.
+
+## Test impact for the next phase
+
+`src/composables/useRemotePreferencesWrite.spec.ts` (written for issue #64) asserts
+`writeDiff.value?.beforeJson`/`afterJson` in two scenarios — D-1 (lines ~158-160) and D-2 (lines
+~181-182). Those two assertions no longer compile against the new `RemoteWritePreview` shape and
+must be rewritten to assert against `stationChanges`/`fuelTypeChange`. Because station changes are
+now caller-tracked rather than derived, D-1/D-2's setup will also need an explicit
+`markStationChange(...)` call before `pushPreferences(...)` to populate what the dialog should
+show — the composable alone can no longer infer "a station was added/renamed" from a before/after
+`PreferencesFile` pair. D-3 through D-9 assert PUT bodies, success flags, and error messages, none
+of which changed shape, and should be unaffected.
+
+status: ready

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/technical-specifications.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/technical-specifications.md
@@ -9,14 +9,20 @@
   state), `hasPendingChanges` (computed) and `markStationChange` to the composable's public
   surface; `decodeAndValidateExistingFile` now returns the parsed `PreferencesFile` instead of
   re-serialised JSON text; the write-confirm preview is now built from
-  `pendingStationChanges` + a fuel-type before/after comparison instead of raw JSON diffing.
+  `pendingStationChanges` + a fuel-type before/after comparison instead of raw JSON diffing;
+  `pushPreferences` takes a new `includeStationChanges: boolean` parameter so only the
+  `StationManager`-triggered call bundles/clears `pendingStationChanges` (review fix, see decision
+  #3).
 - `src/components/StationManagerTable.vue` — station add/edit/delete no longer call
   `pushPreferences`; they call `markStationChange` with the specific field(s) that changed.
   Removed the now-unused `useGitHubAuth`/`useRepoConfig`/`useDefaultFuelType`/
   `buildPreferencesFile` imports.
 - `src/components/StationManager.vue` — added the "Enregistrer les modifications" button
   (visible only while `hasPendingChanges` is true) and the composables/handler needed to trigger
-  the batched push.
+  the batched push; calls `pushPreferences(..., includeStationChanges: true, ...)`.
+- `src/components/StationPricesContent.vue` — `pushFuelTypeChange` now calls
+  `pushPreferences(..., includeStationChanges: false, ...)` so a station edit pending in
+  `StationManager` never leaks into a fuel-type-triggered push (review fix, see decision #3).
 - `src/components/PreferencesDiffDialog.vue` — the GitHub write-confirm section's template now
   renders `writeDiff.stationChanges`/`writeDiff.fuelTypeChange` as field-level rows instead of
   `<pre>` JSON blocks; added `fieldLabel`/`stationChangeKey` helpers.
@@ -43,12 +49,16 @@
    composable-caller-responsibility convention forbids (composables never call other composables
    internally).
 
-3. **`pushPreferences`'s public signature is unchanged** — it still reads
-   `pendingStationChanges` internally rather than taking it as a parameter. This keeps
-   `StationPricesContent.vue`'s existing fuel-type-only call site untouched: it naturally gets an
-   empty `stationChanges` list (no station edits happened) and only ever shows a
-   `fuelTypeChange`, satisfying the "default fuel type flow is unaffected" rule without an
-   `if (source === ...)` branch anywhere.
+3. **`pushPreferences` takes an explicit `includeStationChanges: boolean` parameter** (added in
+   review, replacing an earlier draft that read `pendingStationChanges` unconditionally). The
+   earlier draft assumed `StationPricesContent.vue`'s fuel-type-only call site would "naturally"
+   see an empty `stationChanges` list — that assumption breaks the moment a station edit is
+   pending in `StationManager` at the time the user saves a default fuel type: both components
+   render on the same page, so `pendingStationChanges` is genuinely non-empty at that call site
+   too. `StationManager.vue` passes `true` (it is the intended trigger for bundling and clearing
+   station edits); `StationPricesContent.vue` passes `false`, so a station edit still pending
+   review in `StationManager` is never bundled into, shown by, or cleared by a fuel-type push
+   (business-specifications.md: "the default fuel type save flow ... is unaffected").
 
 4. **The pending-changes snapshot is taken synchronously at the top of `pushPreferences`, before
    the `fetchExistingFile` GET, and only that snapshot is cleared on success** (via
@@ -69,14 +79,26 @@
    occur even if an edited and a removed/added entry happen to reference the same URL within one
    batch.
 
-## Known limitation (documented, not fixed — out of test-cases.md scope)
+## Known limitations (documented, not fixed — out of test-cases.md scope)
 
-If the very same row is edited twice before "Enregistrer les modifications" is clicked (e.g. the
-name field is blurred, then blurred again with a further change), each save appends its own
-`edited` entry rather than merging into one before→final row — the dialog would show two rows for
-that station instead of one collapsed row. `test-cases.md` only requires that edits to
-*different* stations bundle correctly (covered), not that repeated edits to the *same* field
-collapse. Left as-is to avoid a stable-identity/coalescing mechanism the spec doesn't ask for.
+1. If the very same row is edited twice before "Enregistrer les modifications" is clicked (e.g.
+   the name field is blurred, then blurred again with a further change), each save appends its
+   own `edited` entry rather than merging into one before→final row — the dialog would show two
+   rows for that station instead of one collapsed row. `test-cases.md` only requires that edits to
+   *different* stations bundle correctly (covered), not that repeated edits to the *same* field
+   collapse. Left as-is to avoid a stable-identity/coalescing mechanism the spec doesn't ask for.
+
+2. The fuel-type-triggered push (`includeStationChanges: false`) can no longer surface a real
+   station-list drift against the remote file that isn't currently sitting in
+   `pendingStationChanges` (e.g. a previous push failed and was cleared elsewhere, or the remote
+   was changed from another device) — decision #1 sources station diffs only from the tracked
+   `StationChange` event log, not from comparing the fetched remote array against the local one.
+   Pre-issue-110 behaviour could surface this via full JSON diffing; re-deriving it here would mean
+   reintroducing array-comparison diffing for one call site only, which test-cases.md does not ask
+   for and which decision #1 deliberately moved away from. The PUT content itself is unaffected —
+   it always sends the full, current, correct preferences file; only the write-confirm *preview*
+   would miss an unreviewed station-side drift on a fuel-type-only save. Flagged for a follow-up
+   issue if this turns out to matter in practice.
 
 ## Self-review: issues found and fixed
 
@@ -93,6 +115,12 @@ collapse. Left as-is to avoid a stable-identity/coalescing mechanism the spec do
    station removed and a *different* new station added with the same URL later in the same
    session (or any coincidental URL reuse across change kinds within one batch) would have
    produced duplicate `:key` values. Prefixed every generated key with the change's `kind`.
+4. **Fixed (review loop-back)** — `pushPreferences` read the shared `pendingStationChanges`
+   unconditionally, so a station edit still pending in `StationManager` leaked into a fuel-type
+   push from `StationPricesContent.vue`: it could be pushed with zero review (create-file path) or
+   shown/cleared from a dialog opened by the wrong button. Added the `includeStationChanges`
+   parameter (decision #3) so only the `StationManager`-triggered call bundles and clears
+   `pendingStationChanges`.
 
 ## Test impact for the next phase
 
@@ -105,5 +133,13 @@ now caller-tracked rather than derived, D-1/D-2's setup will also need an explic
 show — the composable alone can no longer infer "a station was added/renamed" from a before/after
 `PreferencesFile` pair. D-3 through D-9 assert PUT bodies, success flags, and error messages, none
 of which changed shape, and should be unaffected.
+
+`pushPreferences` also gained a new required `includeStationChanges: boolean` parameter (4th
+positional argument, before the existing optional `onUnauthorized` callback — review fix, decision
+#3). Every existing `pushPreferences(true, REPO_CONFIG, ...)` call in
+`useRemotePreferencesWrite.spec.ts` (D-1 through D-9) needs `true` inserted as the 4th argument to
+keep exercising the `StationManager`-equivalent path; a new test case should call it with `false`
+and assert a pending `markStationChange(...)` entry is neither bundled into the preview/PUT
+content nor cleared on success, covering the fuel-type-flow isolation this fix adds.
 
 status: ready

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/test-cases.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/test-cases.md
@@ -1,0 +1,69 @@
+# Test Cases — Issue #110: UI and UX improvements
+
+## Settings page mobile layout
+
+1. On a mobile-width viewport, while unauthenticated: the "Enregistrer les paramètres" button
+   and the "Se connecter avec GitHub" button are stacked one above the other, each spanning the
+   full width of the section.
+2. On a mobile-width viewport, while authenticated: the "Enregistrer la fréquence" button and
+   the "Se déconnecter" button are stacked one above the other, each full width.
+3. On a wider (tablet/desktop) viewport, in both the authenticated and unauthenticated states:
+   the two buttons remain side by side, as before this change.
+
+## "Enregistrer les modifications" button visibility
+
+4. On loading the station list with no local changes made yet: the "Enregistrer les
+   modifications" button is not shown.
+5. After editing an existing station's name and moving focus away: the button becomes visible.
+6. After editing an existing station's URL and moving focus away: the button becomes visible.
+7. After adding a new station (name and URL filled in and confirmed): the button becomes
+   visible.
+8. After deleting a station from the list: the button becomes visible.
+9. After editing two different stations one after another, without clicking the button in
+   between: the button is (and stays) visible after each edit — it does not disappear or
+   flicker between the two edits.
+10. Editing a station while GitHub sync is not configured or the user is not authenticated: the
+    button still becomes visible for the local change, consistent with the existing
+    unauthenticated no-op behaviour of the GitHub push itself.
+
+## Saving via the button (batching and outcomes)
+
+11. With two pending edits (e.g. one renamed station and one newly added station), clicking
+    "Enregistrer les modifications": a single confirmation dialog opens showing both changes
+    together — not two separate dialogs and not one push per edit.
+12. Confirming the dialog and the GitHub write succeeds: the confirmation dialog closes, the
+    "Enregistrer les modifications" button becomes hidden again, and a success indication is
+    shown.
+13. Cancelling the confirmation dialog instead of confirming: the pending changes are kept
+    locally, and the "Enregistrer les modifications" button remains visible so the user can
+    retry later.
+14. The GitHub write fails (e.g. network error or API failure) after confirming: an error
+    message is shown, the pending changes are kept, and the "Enregistrer les modifications"
+    button remains visible.
+15. No remote preferences file exists yet in the configured repository: clicking "Enregistrer
+    les modifications" creates the file directly with the pending changes (no confirmation
+    dialog, matching the existing create-on-first-write behaviour) and the button becomes
+    hidden again once it succeeds.
+16. After a successful save, editing another station afterwards: the "Enregistrer les
+    modifications" button becomes visible again for the new, separate pending change.
+
+## GitHub diff screen readability
+
+17. Only one field (e.g. a station's name) was changed since the last save: the confirmation
+    dialog shows just that field's old value and new value — it does not show the full station
+    list or raw file content.
+18. A station was added since the last save: the confirmation dialog lists it as an added
+    station, identified by name — not as raw JSON.
+19. A station was removed since the last save: the confirmation dialog lists it as a removed
+    station, identified by name.
+20. Several different kinds of changes happened in the same batch (one station added, one
+    renamed, one removed): the confirmation dialog lists each change as its own entry, all
+    together in one dialog.
+
+## Regression: unaffected flows
+
+21. Changing the default fuel type (from the price table page, not the station list) still
+    pushes to GitHub immediately on change, without needing or being affected by the
+    "Enregistrer les modifications" button.
+
+status: ready

--- a/docs/prompts/tasks/issue-110-ui-ux-improvements/test-results.md
+++ b/docs/prompts/tasks/issue-110-ui-ux-improvements/test-results.md
@@ -1,0 +1,22 @@
+# Test Results — Issue #110: UI and UX improvements
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.0) from the `feat-ui-ux-improvements`
+worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md).
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+379 test files, 452 tests total — all passed.
+
+- Duration: ~8 seconds
+
+status: passed

--- a/src/components/GitHubSyncSettings.spec.ts
+++ b/src/components/GitHubSyncSettings.spec.ts
@@ -21,6 +21,21 @@
  *   E-5 — owner/repo and file path fields disabled after login
  *   E-6 — owner/repo and file path fields re-enabled after logout
  *   E-7 — login button reflects the login-readiness check
+ *
+ * Scenarios covered (test-cases.md, issue #110 — settings page mobile layout):
+ *   TC-01 — save/connect buttons stack vertically, full width, while unauthenticated
+ *   TC-02 — save/disconnect buttons stack vertically, full width, while authenticated
+ *   TC-03 — both button rows carry the `sm:` classes that put them side by side
+ *           by side from the sm breakpoint up
+ *
+ * happy-dom does not evaluate CSS media queries, so "mobile" vs "wider
+ * viewport" cannot be asserted via actual layout. Tailwind is mobile-first
+ * here: unprefixed classes (`flex-col`, `w-full`) are the default/mobile
+ * layout, and `sm:`-prefixed classes (`sm:flex-row`, `sm:w-auto`) are the
+ * override that takes effect from the sm breakpoint up. TC-01/02 assert the
+ * unprefixed classes are present (mobile: stacked, full width); TC-03
+ * asserts the `sm:` classes are also present (wider viewports: side by side,
+ * auto width) in both auth states.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -109,6 +124,16 @@ function findButtonByText(wrapper: VueWrapper, text: string) {
 
 function inputElement(wrapper: VueWrapper, id: string): HTMLInputElement {
   return wrapper.find(`#${id}`).element as HTMLInputElement
+}
+
+/**
+ * The container `<div>` wrapping the save/connect (or save/disconnect)
+ * button pair — the element carrying the responsive stack/side-by-side
+ * classes (GitHubSyncSettings.vue's `<div class="flex flex-col gap-3
+ * sm:flex-row">`).
+ */
+function buttonRowContainer(wrapper: VueWrapper) {
+  return findButtonByText(wrapper, 'Enregistrer').element.parentElement as HTMLElement
 }
 
 beforeEach(() => {
@@ -266,5 +291,71 @@ describe('E-7: login button reflects the login-readiness check', () => {
     await wrapper.find('#revalidateCacheDays').setValue('7')
 
     expect(findButtonByText(wrapper, 'Se connecter avec GitHub').attributes('disabled')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-01 (issue #110): unauthenticated mobile layout — save/connect stacked, full width
+// ---------------------------------------------------------------------------
+
+describe('TC-01: save and connect buttons stack vertically and span full width on mobile (unauthenticated)', () => {
+  it('renders "Enregistrer les paramètres" and "Se connecter avec GitHub" as full-width buttons in a flex-col row', async () => {
+    mockIsAuthenticated.value = false
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const saveButton = findButtonByText(wrapper, 'Enregistrer les paramètres')
+    const connectButton = findButtonByText(wrapper, 'Se connecter avec GitHub')
+
+    expect(buttonRowContainer(wrapper).classList.contains('flex-col')).toBe(true)
+    expect(saveButton.classes()).toContain('w-full')
+    expect(connectButton.classes()).toContain('w-full')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-02 (issue #110): authenticated mobile layout — save/disconnect stacked, full width
+// ---------------------------------------------------------------------------
+
+describe('TC-02: save and disconnect buttons stack vertically and span full width on mobile (authenticated)', () => {
+  it('renders "Enregistrer la fréquence" and "Se déconnecter" as full-width buttons in a flex-col row', async () => {
+    mockIsAuthenticated.value = true
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const saveButton = findButtonByText(wrapper, 'Enregistrer la fréquence')
+    const disconnectButton = findButtonByText(wrapper, 'Se déconnecter')
+
+    expect(buttonRowContainer(wrapper).classList.contains('flex-col')).toBe(true)
+    expect(saveButton.classes()).toContain('w-full')
+    expect(disconnectButton.classes()).toContain('w-full')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-03 (issue #110): wider viewports keep the buttons side by side, in both auth states
+// ---------------------------------------------------------------------------
+
+describe('TC-03: the button row carries the sm: classes that keep buttons side by side on wider viewports', () => {
+  it('unauthenticated: the row is sm:flex-row and both buttons are sm:w-auto', async () => {
+    mockIsAuthenticated.value = false
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(buttonRowContainer(wrapper).classList.contains('sm:flex-row')).toBe(true)
+    expect(findButtonByText(wrapper, 'Enregistrer les paramètres').classes()).toContain('sm:w-auto')
+    expect(findButtonByText(wrapper, 'Se connecter avec GitHub').classes()).toContain('sm:w-auto')
+  })
+
+  it('authenticated: the row is sm:flex-row and both buttons are sm:w-auto', async () => {
+    mockIsAuthenticated.value = true
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(buttonRowContainer(wrapper).classList.contains('sm:flex-row')).toBe(true)
+    expect(findButtonByText(wrapper, 'Enregistrer la fréquence').classes()).toContain('sm:w-auto')
+    expect(findButtonByText(wrapper, 'Se déconnecter').classes()).toContain('sm:w-auto')
   })
 })

--- a/src/components/GitHubSyncSettings.vue
+++ b/src/components/GitHubSyncSettings.vue
@@ -151,14 +151,25 @@ async function onLogout(): Promise<void> {
       }}</span>
     </div>
 
-    <div class="flex gap-3">
-      <Button :disabled="cacheDaysError !== '' || isSaving" @click="onSave">
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <Button
+        class="w-full sm:w-auto"
+        :disabled="cacheDaysError !== '' || isSaving"
+        @click="onSave"
+      >
         {{ isAuthenticated ? 'Enregistrer la fréquence' : 'Enregistrer les paramètres' }}
       </Button>
-      <Button v-if="!isAuthenticated" :disabled="!loginReady || isSaving" @click="onLogin">
+      <Button
+        v-if="!isAuthenticated"
+        class="w-full sm:w-auto"
+        :disabled="!loginReady || isSaving"
+        @click="onLogin"
+      >
         Se connecter avec GitHub
       </Button>
-      <Button v-else variant="outline" @click="onLogout">Se déconnecter</Button>
+      <Button v-else class="w-full sm:w-auto" variant="outline" @click="onLogout">
+        Se déconnecter
+      </Button>
     </div>
   </section>
 </template>

--- a/src/components/PreferencesDiffDialog.spec.ts
+++ b/src/components/PreferencesDiffDialog.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for PreferencesDiffDialog.vue's write-confirm section — the GitHub
+ * diff screen readability rules added by issue #110.
+ *
+ * usePreferencesImport, useStationStorage, useDefaultFuelType, and
+ * useGitHubAuth are mocked with minimal stand-ins: this file only exercises
+ * the write-confirm half of the dialog (`writeDiff`/`isWriteDialogOpen`,
+ * driven by useRemotePreferencesWrite), not the import-diff half (already
+ * covered by the pre-existing import-flow component tests), so the other
+ * composables just need to not throw when called.
+ *
+ * useRemotePreferencesWrite is mocked with a controllable `writeDiff` ref so
+ * each test can feed the exact `RemoteWritePreview` shape it wants to assert
+ * the template against.
+ *
+ * Scenarios covered (test-cases.md, "GitHub diff screen readability"):
+ *   TC-17 — only one field changed: shows just that field's old/new value,
+ *           not the full station list or raw file content
+ *   TC-18 — a station was added: listed as added, identified by name, not
+ *           raw JSON
+ *   TC-19 — a station was removed: listed as removed, identified by name
+ *   TC-20 — several different kinds of changes in one batch: each is its
+ *           own entry, all together in one dialog
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import PreferencesDiffDialog from './PreferencesDiffDialog.vue'
+import type { RemoteWritePreview } from '@/types/preferences'
+
+// ---------------------------------------------------------------------------
+// Mock usePreferencesImport — the import-diff half of this dialog is out of
+// scope here; diff stays null so that section never renders.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/composables/usePreferencesImport', () => ({
+  usePreferencesImport: () => ({
+    diff: ref(null),
+    doOpenDialog: ref(false),
+    fuelTypeWarning: ref(null),
+    applyDiff: vi.fn().mockResolvedValue(undefined),
+    cancelImport: vi.fn(),
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock useRemotePreferencesWrite — the write-confirm half under test.
+// ---------------------------------------------------------------------------
+
+const mockWriteDiff: Ref<RemoteWritePreview | null> = ref(null)
+const mockIsWriteDialogOpen = ref(false)
+const mockIsWriting = ref(false)
+const mockConfirmWrite = vi.fn().mockResolvedValue(undefined)
+const mockCancelWrite = vi.fn()
+
+vi.mock('@/composables/useRemotePreferencesWrite', () => ({
+  useRemotePreferencesWrite: () => ({
+    writeDiff: mockWriteDiff,
+    isWriteDialogOpen: mockIsWriteDialogOpen,
+    isWriting: mockIsWriting,
+    confirmWrite: mockConfirmWrite,
+    cancelWrite: mockCancelWrite,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock useStationStorage, useDefaultFuelType, useGitHubAuth — required by
+// the component's setup() but only exercised by the import-diff half.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/composables/useStationStorage', () => ({
+  useStationStorage: () => ({
+    addStation: vi.fn().mockResolvedValue(undefined),
+    updateStation: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('@/composables/useDefaultFuelType', () => ({
+  useDefaultFuelType: () => ({
+    saveDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+    clearDefaultFuelType: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('@/composables/useGitHubAuth', () => ({
+  useGitHubAuth: () => ({
+    handleUnauthorized: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockWriteDiff.value = null
+  mockIsWriteDialogOpen.value = false
+  mockIsWriting.value = false
+  vi.clearAllMocks()
+})
+
+/**
+ * PreferencesDiffDialog.vue renders both dialogs via <Teleport to="body">.
+ * Stubbing teleport keeps the content inside the mounted wrapper's own DOM
+ * tree so `wrapper.find`/`wrapper.text()` see it directly, instead of having
+ * to reach into the real `document.body`.
+ */
+function mountDialog() {
+  return mount(PreferencesDiffDialog, { global: { stubs: { teleport: true } } })
+}
+
+// ---------------------------------------------------------------------------
+// TC-17: Only one field changed — shows just that field's old/new value
+// ---------------------------------------------------------------------------
+
+describe('TC-17: only one field changed shows just that field, not the full station list or raw content', () => {
+  it('shows the single name change as an old -> new comparison, with no raw JSON', async () => {
+    mockIsWriteDialogOpen.value = true
+    mockWriteDiff.value = {
+      stationChanges: [
+        {
+          kind: 'edited',
+          url: 'https://www.prix-carburants.gouv.fr/station/11111',
+          fieldChanges: [{ field: 'name', before: 'Ancien nom', after: 'Nouveau nom' }],
+        },
+      ],
+      fuelTypeChange: null,
+    }
+
+    const wrapper = mountDialog()
+
+    expect(wrapper.text()).toContain('Nom')
+    expect(wrapper.text()).toContain('Ancien nom')
+    expect(wrapper.text()).toContain('Nouveau nom')
+    expect(wrapper.find('pre').exists()).toBe(false)
+
+    const stationEntries = wrapper.findAll('li')
+    expect(stationEntries).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-18: A station was added — listed by name, not raw JSON
+// ---------------------------------------------------------------------------
+
+describe('TC-18: an added station is listed by name, not as raw JSON', () => {
+  it('shows "Ajoutée" with the station name', async () => {
+    mockIsWriteDialogOpen.value = true
+    mockWriteDiff.value = {
+      stationChanges: [
+        {
+          kind: 'added',
+          station: { name: 'Nouvelle station', url: 'https://www.prix-carburants.gouv.fr/station/22222' },
+        },
+      ],
+      fuelTypeChange: null,
+    }
+
+    const wrapper = mountDialog()
+
+    expect(wrapper.text()).toContain('Ajoutée')
+    expect(wrapper.text()).toContain('Nouvelle station')
+    expect(wrapper.find('pre').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('{')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-19: A station was removed — listed by name
+// ---------------------------------------------------------------------------
+
+describe('TC-19: a removed station is listed by name', () => {
+  it('shows "Supprimée" with the station name', async () => {
+    mockIsWriteDialogOpen.value = true
+    mockWriteDiff.value = {
+      stationChanges: [
+        {
+          kind: 'removed',
+          station: { name: 'Station retirée', url: 'https://www.prix-carburants.gouv.fr/station/33333' },
+        },
+      ],
+      fuelTypeChange: null,
+    }
+
+    const wrapper = mountDialog()
+
+    expect(wrapper.text()).toContain('Supprimée')
+    expect(wrapper.text()).toContain('Station retirée')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-20: Several different kinds of changes in one batch — each its own
+// entry, all together in one dialog
+// ---------------------------------------------------------------------------
+
+describe('TC-20: multiple kinds of changes in one batch each render as their own entry in a single dialog', () => {
+  it('lists the added, edited, and removed stations as three separate entries', async () => {
+    mockIsWriteDialogOpen.value = true
+    mockWriteDiff.value = {
+      stationChanges: [
+        {
+          kind: 'added',
+          station: { name: 'Station Ajoutée', url: 'https://www.prix-carburants.gouv.fr/station/44444' },
+        },
+        {
+          kind: 'edited',
+          url: 'https://www.prix-carburants.gouv.fr/station/55555',
+          fieldChanges: [{ field: 'url', before: 'https://old-url', after: 'https://new-url' }],
+        },
+        {
+          kind: 'removed',
+          station: { name: 'Station Supprimée', url: 'https://www.prix-carburants.gouv.fr/station/66666' },
+        },
+      ],
+      fuelTypeChange: null,
+    }
+
+    const wrapper = mountDialog()
+
+    // Exactly one dialog is open — not one per change.
+    expect(wrapper.findAll('[role="dialog"]')).toHaveLength(1)
+
+    const entries = wrapper.findAll('li')
+    expect(entries).toHaveLength(3)
+
+    expect(wrapper.text()).toContain('Ajoutée')
+    expect(wrapper.text()).toContain('Station Ajoutée')
+    expect(wrapper.text()).toContain('URL')
+    expect(wrapper.text()).toContain('https://old-url')
+    expect(wrapper.text()).toContain('https://new-url')
+    expect(wrapper.text()).toContain('Supprimée')
+    expect(wrapper.text()).toContain('Station Supprimée')
+  })
+
+  it('clicking "Confirmer l\'envoi" calls confirmWrite', async () => {
+    mockIsWriteDialogOpen.value = true
+    mockWriteDiff.value = {
+      stationChanges: [
+        {
+          kind: 'added',
+          station: { name: 'Station Ajoutée', url: 'https://www.prix-carburants.gouv.fr/station/44444' },
+        },
+      ],
+      fuelTypeChange: null,
+    }
+
+    const wrapper = mountDialog()
+    const confirmButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes("Confirmer l'envoi"))
+    await confirmButton!.trigger('click')
+
+    expect(mockConfirmWrite).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking "Annuler" calls cancelWrite', async () => {
+    mockIsWriteDialogOpen.value = true
+    mockWriteDiff.value = {
+      stationChanges: [
+        {
+          kind: 'added',
+          station: { name: 'Station Ajoutée', url: 'https://www.prix-carburants.gouv.fr/station/44444' },
+        },
+      ],
+      fuelTypeChange: null,
+    }
+
+    const wrapper = mountDialog()
+    const cancelButton = wrapper.findAll('button').find((button) => button.text() === 'Annuler')
+    await cancelButton!.trigger('click')
+
+    expect(mockCancelWrite).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/PreferencesDiffDialog.vue
+++ b/src/components/PreferencesDiffDialog.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import type { StationDiffRow, FuelTypeDiff } from '@/types/preferences'
+import type {
+  StationDiffRow,
+  FuelTypeDiff,
+  StationChange,
+  StationFieldChange,
+} from '@/types/preferences'
 import { usePreferencesImport } from '@/composables/usePreferencesImport'
 import { useRemotePreferencesWrite } from '@/composables/useRemotePreferencesWrite'
 import { useStationStorage } from '@/composables/useStationStorage'
@@ -60,6 +65,22 @@ const onChooseFuelType = (fuelTypeDiff: FuelTypeDiff, choice: 'file' | 'stored')
 
 const onConfirmWrite = async (): Promise<void> => {
   await confirmWrite(handleUnauthorized)
+}
+
+const FIELD_LABELS: Record<StationFieldChange['field'], string> = {
+  name: 'Nom',
+  url: 'URL',
+}
+
+function fieldLabel(field: StationFieldChange['field']): string {
+  return FIELD_LABELS[field]
+}
+
+// Prefixed with `kind` so an 'edited' and a 'removed'/'added' entry can never
+// collide even if they happen to share the same station URL within one batch.
+function stationChangeKey(change: StationChange): string {
+  if (change.kind === 'edited') return `edited-${change.url}`
+  return `${change.kind}-${change.station.url}`
 }
 </script>
 
@@ -182,12 +203,13 @@ const onConfirmWrite = async (): Promise<void> => {
     </div>
   </Teleport>
 
-  <!-- Write-confirm mode (Sub-Issue D, issue #64): before/after preview of the
-       remote file, a single confirm/cancel — the local state already written
-       to IndexedDB is already the value being pushed, so there is nothing to
-       merge (business-specifications.md Sub-Issue D rule 2). Every value below
-       renders through Vue's default text interpolation, never v-html
-       (security-guidelines.md rule 8). -->
+  <!-- Write-confirm mode (Sub-Issue D, issue #64): a field-level preview of
+       what changed (issue #110), a single confirm/cancel — the local state
+       already written to IndexedDB is already the value being pushed, so
+       there is nothing to merge (business-specifications.md Sub-Issue D rule
+       2). Every value below renders through Vue's default text
+       interpolation, never v-html (security-guidelines.md rule 8; issue
+       #110 rule 2). -->
   <Teleport to="body">
     <div
       v-if="isWriteDialogOpen && writeDiff"
@@ -203,15 +225,37 @@ const onConfirmWrite = async (): Promise<void> => {
           Aperçu des changements à enregistrer sur GitHub
         </h2>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <h3 class="text-sm font-medium mb-2">Actuel (GitHub)</h3>
-            <pre class="text-xs bg-gray-50 rounded p-3 overflow-x-auto">{{ writeDiff.beforeJson }}</pre>
-          </div>
-          <div>
-            <h3 class="text-sm font-medium mb-2">Nouveau</h3>
-            <pre class="text-xs bg-gray-50 rounded p-3 overflow-x-auto">{{ writeDiff.afterJson }}</pre>
-          </div>
+        <div v-if="writeDiff.stationChanges.length > 0">
+          <h3 class="text-sm font-medium mb-2">Stations</h3>
+          <ul class="flex flex-col gap-2 text-sm">
+            <li
+              v-for="change in writeDiff.stationChanges"
+              :key="stationChangeKey(change)"
+              class="border rounded p-2"
+            >
+              <template v-if="change.kind === 'added'">
+                <span class="text-green-600 font-medium">Ajoutée :</span> {{ change.station.name }}
+              </template>
+              <template v-else-if="change.kind === 'removed'">
+                <span class="text-red-600 font-medium">Supprimée :</span> {{ change.station.name }}
+              </template>
+              <template v-else>
+                <p class="font-medium break-all">{{ change.url }}</p>
+                <p v-for="fieldChange in change.fieldChanges" :key="fieldChange.field">
+                  {{ fieldLabel(fieldChange.field) }} :
+                  {{ fieldChange.before }} → {{ fieldChange.after }}
+                </p>
+              </template>
+            </li>
+          </ul>
+        </div>
+
+        <div v-if="writeDiff.fuelTypeChange">
+          <h3 class="text-sm font-medium mb-2">Carburant par défaut</h3>
+          <p class="text-sm">
+            {{ writeDiff.fuelTypeChange.before ?? 'aucun' }} →
+            {{ writeDiff.fuelTypeChange.after ?? 'aucun' }}
+          </p>
         </div>
 
         <div class="flex justify-end gap-3 pt-2">

--- a/src/components/StationManager.spec.ts
+++ b/src/components/StationManager.spec.ts
@@ -3,12 +3,28 @@
  *
  * useStationStorage is mocked so tests control the reactive station list
  * and assert which storage operations are called.
+ *
+ * Since issue #110, StationManager.vue also calls useRemotePreferencesWrite,
+ * useDefaultFuelType, useGitHubAuth, and useRepoConfig at the top level of
+ * its setup(). useDefaultFuelType/useGitHubAuth/useRepoConfig are mocked with
+ * plain refs (StationManager only reads their current value when the new
+ * "Enregistrer les modifications" button is clicked, it never awaits their
+ * load functions itself). useRemotePreferencesWrite is mocked with a small
+ * reactive implementation of markStationChange/hasPendingChanges — not a
+ * bare vi.fn() — because StationManagerTable.vue (mounted for real here,
+ * unstubbed, same as before issue #110) calls the *same* mocked
+ * markStationChange when a row is edited/added/deleted, and this file's new
+ * button-visibility tests (TC-04 through TC-10) rely on that call flowing
+ * through to hasPendingChanges the way the real composable does.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, ref } from 'vue'
+import { computed, defineComponent, ref } from 'vue'
+import type { Ref } from 'vue'
 import StationManager from './StationManager.vue'
+import type { RepoConfigDraft } from '@/types/repo-config'
+import type { StationChange } from '@/types/preferences'
 
 // ---------------------------------------------------------------------------
 // Mock useStationStorage
@@ -35,6 +51,58 @@ vi.mock('@/composables/useStationStorage', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Mock useRemotePreferencesWrite (issue #110) — a small reactive stand-in,
+// not a bare vi.fn(), so markStationChange calls from the real
+// (unstubbed) StationManagerTable actually drive hasPendingChanges here.
+// ---------------------------------------------------------------------------
+
+const mockPendingStationChanges: Ref<StationChange[]> = ref([])
+const mockHasPendingChanges = computed(() => mockPendingStationChanges.value.length > 0)
+const mockMarkStationChange = vi.fn((change: StationChange) => {
+  mockPendingStationChanges.value = [...mockPendingStationChanges.value, change]
+})
+const mockIsWriting = ref(false)
+const mockPushPreferences = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/composables/useRemotePreferencesWrite', () => ({
+  useRemotePreferencesWrite: () => ({
+    hasPendingChanges: mockHasPendingChanges,
+    markStationChange: mockMarkStationChange,
+    isWriting: mockIsWriting,
+    pushPreferences: mockPushPreferences,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock useDefaultFuelType, useGitHubAuth, useRepoConfig (issue #110) — read
+// by StationManager.vue's onSaveChanges handler when the new button is
+// clicked.
+// ---------------------------------------------------------------------------
+
+const mockDefaultFuelType: Ref<string | null> = ref(null)
+vi.mock('@/composables/useDefaultFuelType', () => ({
+  useDefaultFuelType: () => ({ defaultFuelType: mockDefaultFuelType }),
+}))
+
+const mockIsAuthenticated: Ref<boolean> = ref(false)
+const mockHandleUnauthorized = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/composables/useGitHubAuth', () => ({
+  useGitHubAuth: () => ({
+    isAuthenticated: mockIsAuthenticated,
+    handleUnauthorized: mockHandleUnauthorized,
+  }),
+}))
+
+const mockRepoConfig: Ref<RepoConfigDraft> = ref({
+  ownerRepo: '',
+  filePath: '',
+  revalidateCacheDays: null,
+})
+vi.mock('@/composables/useRepoConfig', () => ({
+  useRepoConfig: () => ({ repoConfig: mockRepoConfig }),
+}))
+
+// ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
@@ -47,6 +115,13 @@ beforeEach(() => {
   mockAddStation.mockResolvedValue(undefined)
   mockRemoveStation.mockResolvedValue(undefined)
   mockUpdateStation.mockResolvedValue(undefined)
+  mockPendingStationChanges.value = []
+  mockIsWriting.value = false
+  mockPushPreferences.mockResolvedValue(undefined)
+  mockDefaultFuelType.value = null
+  mockIsAuthenticated.value = false
+  mockHandleUnauthorized.mockResolvedValue(undefined)
+  mockRepoConfig.value = { ownerRepo: '', filePath: '', revalidateCacheDays: null }
   vi.clearAllMocks()
 })
 
@@ -717,5 +792,195 @@ describe('TC-31: Success message is per-row and does not appear on other rows', 
 
     expect(firstDataRow.text()).toContain('Saved')
     expect(secondDataRow.text()).not.toContain('Saved')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// "Enregistrer les modifications" button visibility (issue #110, test-cases.md)
+//
+// StationManagerTable is mounted for real (not stubbed) inside StationManager
+// here, so editing a row through it exercises the same markStationChange
+// call the real app makes — driving this file's mocked hasPendingChanges the
+// way the real composable would.
+// ---------------------------------------------------------------------------
+
+function findSaveChangesButton(wrapper: ReturnType<typeof mountComponent>) {
+  return wrapper.findAll('button').find((button) => button.text().includes('Enregistrer les modifications'))
+}
+
+// ---------------------------------------------------------------------------
+// TC-04: No local changes yet — the button is not shown
+// ---------------------------------------------------------------------------
+
+describe('TC-04: "Enregistrer les modifications" is not shown when no station-list change is pending', () => {
+  it('does not render the button on initial load', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-05: Editing an existing station's name shows the button
+// ---------------------------------------------------------------------------
+
+describe('TC-05: editing an existing station name makes the button visible', () => {
+  it('renders "Enregistrer les modifications" after a name is edited and blurred', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const firstRowNameInput = wrapper.findAll('input')[2]
+    await firstRowNameInput.setValue('Station A Updated')
+    await firstRowNameInput.trigger('blur')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-06: Editing an existing station's URL shows the button
+// ---------------------------------------------------------------------------
+
+describe('TC-06: editing an existing station URL makes the button visible', () => {
+  it('renders "Enregistrer les modifications" after a URL is edited and blurred', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const firstRowUrlInput = wrapper.findAll('input')[3]
+    await firstRowUrlInput.setValue('https://www.prix-carburants.gouv.fr/station/99999')
+    await firstRowUrlInput.trigger('blur')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-07: Adding a new station shows the button
+// ---------------------------------------------------------------------------
+
+describe('TC-07: adding a new station makes the button visible', () => {
+  it('renders "Enregistrer les modifications" after a new station is saved', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const rows = wrapper.findAll('tr')
+    const newRow = rows[1]
+    const [nameInput, urlInput] = newRow.findAll('input')
+
+    await nameInput.setValue('New Station')
+    await urlInput.setValue('https://www.prix-carburants.gouv.fr/station/77777')
+    await urlInput.trigger('blur')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-08: Deleting a station shows the button
+// ---------------------------------------------------------------------------
+
+describe('TC-08: deleting a station makes the button visible', () => {
+  it('renders "Enregistrer les modifications" after a station is deleted', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const deleteButtons = wrapper.findAll('button.delete-button')
+    await deleteButtons[0].trigger('click')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-09: Editing two different stations keeps the button visible throughout
+// ---------------------------------------------------------------------------
+
+describe('TC-09: editing two different stations in a row keeps the button visible, with no flicker', () => {
+  it('stays visible after the first edit and after the second edit', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const firstRowNameInput = wrapper.findAll('input')[2]
+    await firstRowNameInput.setValue('Station A Updated')
+    await firstRowNameInput.trigger('blur')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+
+    const secondRowNameInput = wrapper.findAll('input')[4]
+    await secondRowNameInput.setValue('Station B Updated')
+    await secondRowNameInput.trigger('blur')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+    expect(mockMarkStationChange).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-10: The button becomes visible for a local edit even without GitHub sync configured
+// ---------------------------------------------------------------------------
+
+describe('TC-10: editing a station makes the button visible even while GitHub sync is not configured', () => {
+  it('renders the button after an edit while unauthenticated with no repo config', async () => {
+    mockIsAuthenticated.value = false
+    mockRepoConfig.value = { ownerRepo: '', filePath: '', revalidateCacheDays: null }
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const firstRowNameInput = wrapper.findAll('input')[2]
+    await firstRowNameInput.setValue('Station A Updated')
+    await firstRowNameInput.trigger('blur')
+    await flushPromises()
+
+    expect(findSaveChangesButton(wrapper)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-11 (dispatch half): clicking the button triggers a single bundled push
+// ---------------------------------------------------------------------------
+
+describe('TC-11: clicking "Enregistrer les modifications" triggers one bundled push', () => {
+  it('calls pushPreferences once with includeStationChanges: true and the current preferences snapshot', async () => {
+    mockIsAuthenticated.value = true
+    mockRepoConfig.value = { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 }
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const firstRowNameInput = wrapper.findAll('input')[2]
+    await firstRowNameInput.setValue('Station A Updated')
+    await firstRowNameInput.trigger('blur')
+    await flushPromises()
+
+    const secondRowUrlInput = wrapper.findAll('input')[5]
+    await secondRowUrlInput.setValue('https://www.prix-carburants.gouv.fr/station/88888')
+    await secondRowUrlInput.trigger('blur')
+    await flushPromises()
+
+    expect(mockMarkStationChange).toHaveBeenCalledTimes(2)
+
+    const saveChangesButton = findSaveChangesButton(wrapper)
+    await saveChangesButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockPushPreferences).toHaveBeenCalledTimes(1)
+    expect(mockPushPreferences).toHaveBeenCalledWith(
+      true,
+      { ownerRepo: 'alice/repo', filePath: 'stations.json', revalidateCacheDays: 7 },
+      expect.objectContaining({
+        fuelTypeDefault: null,
+        favoriteStations: expect.any(Array),
+      }),
+      true,
+      mockHandleUnauthorized,
+    )
   })
 })

--- a/src/components/StationManager.vue
+++ b/src/components/StationManager.vue
@@ -1,7 +1,31 @@
 <script setup lang="ts">
+/**
+ * Object Calisthenics exception: six composables are called at the top level
+ * of setup() (beyond the two-instance-variable guideline) because this
+ * component now owns the "Enregistrer les modifications" trigger (issue
+ * #110) and, per the composable-caller-responsibility convention, must call
+ * every composable whose data or actions it needs itself — the same
+ * documented framework exception as GitHubSyncSettings.vue.
+ */
 import { usePreferencesImport } from '@/composables/usePreferencesImport'
+import { useRemotePreferencesWrite } from '@/composables/useRemotePreferencesWrite'
+import { useStationStorage } from '@/composables/useStationStorage'
+import { useDefaultFuelType } from '@/composables/useDefaultFuelType'
+import { useGitHubAuth } from '@/composables/useGitHubAuth'
+import { useRepoConfig } from '@/composables/useRepoConfig'
+import { buildPreferencesFile } from '@/utils/preferencesExport'
 
 const { fuelTypeWarning, doOpenDialog } = usePreferencesImport()
+const { hasPendingChanges, isWriting, pushPreferences } = useRemotePreferencesWrite()
+const { stations } = useStationStorage()
+const { defaultFuelType } = useDefaultFuelType()
+const { isAuthenticated, handleUnauthorized } = useGitHubAuth()
+const { repoConfig } = useRepoConfig()
+
+async function onSaveChanges(): Promise<void> {
+  const preferences = buildPreferencesFile(stations.value, defaultFuelType.value)
+  await pushPreferences(isAuthenticated.value, repoConfig.value, preferences, handleUnauthorized)
+}
 </script>
 
 <template>
@@ -13,9 +37,12 @@ const { fuelTypeWarning, doOpenDialog } = usePreferencesImport()
         >https://www.prix-carburants.gouv.fr/</AppLink
       >
     </p>
-    <div class="flex gap-3 mb-4">
+    <div class="flex gap-3 mb-4 flex-wrap">
       <PreferencesExport />
       <PreferencesImport />
+      <Button v-if="hasPendingChanges" :disabled="isWriting" @click="onSaveChanges">
+        {{ isWriting ? 'Enregistrement…' : 'Enregistrer les modifications' }}
+      </Button>
     </div>
     <!-- fuelTypeWarning is shown here so it appears below both export/import buttons,
          outside the PreferencesImport component's own layout. -->

--- a/src/components/StationManager.vue
+++ b/src/components/StationManager.vue
@@ -24,7 +24,13 @@ const { repoConfig } = useRepoConfig()
 
 async function onSaveChanges(): Promise<void> {
   const preferences = buildPreferencesFile(stations.value, defaultFuelType.value)
-  await pushPreferences(isAuthenticated.value, repoConfig.value, preferences, handleUnauthorized)
+  await pushPreferences(
+    isAuthenticated.value,
+    repoConfig.value,
+    preferences,
+    true,
+    handleUnauthorized,
+  )
 }
 </script>
 

--- a/src/components/StationManagerTable.vue
+++ b/src/components/StationManagerTable.vue
@@ -79,12 +79,9 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useStationStorage } from '@/composables/useStationStorage'
-import { useDefaultFuelType } from '@/composables/useDefaultFuelType'
-import { useGitHubAuth } from '@/composables/useGitHubAuth'
-import { useRepoConfig } from '@/composables/useRepoConfig'
 import { useRemotePreferencesWrite } from '@/composables/useRemotePreferencesWrite'
-import { buildPreferencesFile } from '@/utils/preferencesExport'
 import type { Station } from '@/types/station'
+import type { StationFieldChange } from '@/types/preferences'
 
 const SUCCESS_DISMISS_DELAY_MS = 2000
 const ALLOWED_ORIGIN = 'https://www.prix-carburants.gouv.fr'
@@ -103,22 +100,23 @@ interface RowDraft {
 // component mounts (Sub-Issue C rule 8, issue #64) — this component only
 // reads the shared singleton state (ADR-002), it does not load it itself.
 const { stations, addStation, removeStation, updateStation } = useStationStorage()
-const { defaultFuelType } = useDefaultFuelType()
-const { isAuthenticated, handleUnauthorized } = useGitHubAuth()
-const { repoConfig } = useRepoConfig()
-const { pushPreferences } = useRemotePreferencesWrite()
+const { markStationChange } = useRemotePreferencesWrite()
 
 const rowDrafts: Ref<RowDraft[]> = ref([])
 
-// Sub-Issue D, issue #64: pushes the just-saved station list to the user's
-// GitHub repo, reusing the same PreferencesFile shape the export/import
-// feature (issue #63) already builds. pushPreferences itself no-ops when the
-// user isn't authenticated or repo config is incomplete, and never throws
-// (business-specifications.md Sub-Issue D rule 4: write failures are
-// non-blocking), so callers can await it unconditionally.
-async function pushStationChange(): Promise<void> {
-  const preferences = buildPreferencesFile(stations.value, defaultFuelType.value)
-  await pushPreferences(isAuthenticated.value, repoConfig.value, preferences, handleUnauthorized)
+// Issue #110: station edits still save to IndexedDB immediately, but no
+// longer push to GitHub on every change — they only record what changed so
+// "Enregistrer les modifications" (StationManager.vue) can bundle every
+// pending edit into a single push once the user clicks it.
+function buildFieldChanges(original: Station, name: string, url: string): StationFieldChange[] {
+  const fieldChanges: StationFieldChange[] = []
+  if (original.name !== name) {
+    fieldChanges.push({ field: 'name', before: original.name, after: name })
+  }
+  if (original.url !== url) {
+    fieldChanges.push({ field: 'url', before: original.url, after: url })
+  }
+  return fieldChanges
 }
 
 /**
@@ -237,11 +235,15 @@ function scheduleSuccessDismiss(savedUrl: string): void {
 async function saveExistingRow(index: number, name: string, url: string): Promise<void> {
   const draft = rowDrafts.value[index]
   const originalUrl = draft.originalUrl
+  const original = stations.value.find((station) => station.url === originalUrl)
   try {
     await updateStation(originalUrl, { name, url })
     rowSuccessMap[originalUrl] = true
     scheduleSuccessDismiss(originalUrl)
-    await pushStationChange()
+    const fieldChanges = original ? buildFieldChanges(original, name, url) : []
+    if (fieldChanges.length > 0) {
+      markStationChange({ kind: 'edited', url: originalUrl, fieldChanges })
+    }
   } catch {
     draft.rowError = 'Could not save changes. Please try again.'
   }
@@ -249,9 +251,10 @@ async function saveExistingRow(index: number, name: string, url: string): Promis
 
 async function onDelete(originalUrl: string): Promise<void> {
   const draft = rowDrafts.value.find((row) => row.originalUrl === originalUrl)
+  const original = stations.value.find((station) => station.url === originalUrl)
   try {
     await removeStation(originalUrl)
-    await pushStationChange()
+    if (original) markStationChange({ kind: 'removed', station: original })
   } catch {
     if (draft) draft.rowError = 'Could not delete station. Please try again.'
   }
@@ -300,7 +303,7 @@ async function onNewRowBlur(): Promise<void> {
     newUrl.value = ''
     newNameError.value = ''
     newUrlError.value = ''
-    await pushStationChange()
+    markStationChange({ kind: 'added', station: { name: trimmedName, url: trimmedUrl } })
   } catch {
     newUrlError.value = 'Could not save station. Please try again.'
   }

--- a/src/components/StationPricesContent.spec.ts
+++ b/src/components/StationPricesContent.spec.ts
@@ -120,6 +120,21 @@ vi.mock('@/composables/useRemotePreferencesSync', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Mock useRemotePreferencesWrite (issue #110, TC-21 regression) — a bare
+// vi.fn() is enough here: this file only asserts pushFuelTypeChange's call
+// arguments, it does not need the reactive pending-changes behaviour
+// StationManager.spec.ts's mock provides.
+// ---------------------------------------------------------------------------
+
+const mockPushPreferences = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/composables/useRemotePreferencesWrite', () => ({
+  useRemotePreferencesWrite: () => ({
+    pushPreferences: mockPushPreferences,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -195,6 +210,8 @@ beforeEach(() => {
   mockClearDefaultFuelType.mockImplementation(async () => {
     mockDefaultFuelType.value = null
   })
+  mockPushPreferences.mockReset()
+  mockPushPreferences.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
@@ -1218,5 +1235,85 @@ describe('Issue-28 TC-39: "Effacer le défaut" is a plain <button> element for k
     expect(clearButton).toBeDefined()
     expect(clearButton!.element.tagName).toBe('BUTTON')
     expect(clearButton!.attributes('type')).toBe('button')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-21 (issue #110, regression): the default-fuel-type push flow is
+// unaffected by the "Enregistrer les modifications" button — it still
+// pushes to GitHub immediately on change, passing includeStationChanges:
+// false so it never needs (and is never blocked by) that button.
+// ---------------------------------------------------------------------------
+
+describe('TC-21: changing the default fuel type still pushes to GitHub immediately, isolated from station-list changes', () => {
+  it('calls pushPreferences with includeStationChanges: false when "Définir par défaut" is clicked', async () => {
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const saveButton = activeWrapper
+      .findAll('.default-fuel-button')
+      .find((b) => b.text() === 'Définir par défaut')
+    await saveButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockPushPreferences).toHaveBeenCalledTimes(1)
+    expect(mockPushPreferences).toHaveBeenCalledWith(
+      false,
+      { ownerRepo: '', filePath: '', revalidateCacheDays: null },
+      expect.objectContaining({ fuelTypeDefault: 'SP95' }),
+      false,
+      expect.any(Function),
+    )
+  })
+
+  it('calls pushPreferences with includeStationChanges: false when "Mettre à jour le défaut" is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      {
+        stationName: 'Station A',
+        url: 'https://example.com/station/a',
+        fuels: [
+          { type: 'SP95', price: 1.89 },
+          { type: 'Gasoil', price: 1.75 },
+        ],
+      },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const fuelButtons = activeWrapper.findAll('.fuel-type-selector button')
+    const gasoilButton = fuelButtons.find((b) => b.text() === 'Gasoil')
+    await gasoilButton!.trigger('click')
+    await nextTick()
+
+    const updateButton = activeWrapper
+      .findAll('.default-fuel-button')
+      .find((b) => b.text() === 'Mettre à jour le défaut')
+    await updateButton!.trigger('click')
+    await flushPromises()
+
+    const [, , , includeStationChanges] = mockPushPreferences.mock.calls[0]
+    expect(includeStationChanges).toBe(false)
+  })
+
+  it('calls pushPreferences with includeStationChanges: false when "Effacer le défaut" is clicked', async () => {
+    mockDefaultFuelType.value = 'SP95'
+    mockResults.value = [
+      { stationName: 'Station A', url: 'https://example.com/station/a', fuels: [{ type: 'SP95', price: 1.89 }] },
+    ]
+
+    activeWrapper = await mountAndSeedSelection(mockResults.value)
+
+    const clearButton = activeWrapper
+      .findAll('.default-fuel-button')
+      .find((b) => b.text() === 'Effacer le défaut')
+    await clearButton!.trigger('click')
+    await flushPromises()
+
+    const [, , , includeStationChanges] = mockPushPreferences.mock.calls[0]
+    expect(includeStationChanges).toBe(false)
   })
 })

--- a/src/components/StationPricesContent.vue
+++ b/src/components/StationPricesContent.vue
@@ -198,7 +198,13 @@ watch(derivedFuelTypes, (fuelTypes: string[]) => {
 // failures are non-blocking), so callers can await it unconditionally.
 async function pushFuelTypeChange(): Promise<void> {
   const preferences = buildPreferencesFile(stations.value, defaultFuelType.value)
-  await pushPreferences(isAuthenticated.value, repoConfig.value, preferences, handleUnauthorized)
+  await pushPreferences(
+    isAuthenticated.value,
+    repoConfig.value,
+    preferences,
+    false,
+    handleUnauthorized,
+  )
 }
 
 async function onSaveDefault(): Promise<void> {

--- a/src/composables/useRemotePreferencesWrite.spec.ts
+++ b/src/composables/useRemotePreferencesWrite.spec.ts
@@ -1,12 +1,13 @@
 /**
- * Tests for useRemotePreferencesWrite composable — Sub-Issue D, issue #64.
+ * Tests for useRemotePreferencesWrite composable — Sub-Issue D, issue #64;
+ * field-level diff + pending-station-change batching added by issue #110.
  *
  * useRemotePreferencesWrite is a singleton composable (ADR-002): writeDiff,
- * isWriteDialogOpen, writeError, writeSuccess, divergedNotice, and isWriting
- * are module-level refs shared across every consumer. vi.resetModules() +
- * dynamic import() gets a fresh module instance (and therefore fresh
- * reactive state) for each test, following the pattern established in
- * useRepoConfig.spec.ts and useRemotePreferencesSync.spec.ts.
+ * isWriteDialogOpen, writeError, writeSuccess, divergedNotice, isWriting, and
+ * pendingStationChanges are module-level refs shared across every consumer.
+ * vi.resetModules() + dynamic import() gets a fresh module instance (and
+ * therefore fresh reactive state) for each test, following the pattern
+ * established in useRepoConfig.spec.ts and useRemotePreferencesSync.spec.ts.
  *
  * `fetch` is mocked with a single implementation that branches on
  * `options?.method === 'PUT'`: the composable's GET (existing-file read) and
@@ -21,9 +22,15 @@
  * part of the public API) mirrored here verbatim from
  * useRemotePreferencesWrite.ts — keep in sync if they change.
  *
- * Scenarios covered (test-cases.md, Sub-Issue D):
- *   D-1 — diff dialog shown before write, add station
- *   D-2 — diff dialog shown before write, edit station
+ * Since issue #110, `pushPreferences` takes a 4th required
+ * `includeStationChanges: boolean` argument (before the optional
+ * `onUnauthorized` callback) — every call below passes `true` unless the test
+ * is specifically exercising the fuel-type-flow isolation (TC-21), which
+ * passes `false`.
+ *
+ * Scenarios covered (test-cases.md, Sub-Issue D + issue #110):
+ *   D-1 — diff dialog shown before write, add station (field-level shape)
+ *   D-2 — diff dialog shown before write, edit station (field-level shape)
  *   D-3 — confirmed write updates the remote file, add station
  *   D-4 — confirmed write updates the remote file, edit station
  *   D-5 — cancelled write leaves the remote file unchanged, shows divergence notice
@@ -31,11 +38,21 @@
  *   D-7 — stale sha (409 conflict) shows a conflict error
  *   D-8 — remote write failure (401) shows a non-blocking error
  *   D-9 — written JSON never includes repo configuration
+ *   TC-04 — no pending changes: hasPendingChanges is false
+ *   TC-05/06/07/08 — markStationChange makes hasPendingChanges true
+ *   TC-09 — two edits recorded before a push both stay pending, no flicker
+ *   TC-11 — two pending edits bundle into a single writeDiff.stationChanges
+ *   TC-12 — confirmed write clears pendingStationChanges and hides the button
+ *   TC-13 — cancelling keeps pendingStationChanges and hasPendingChanges true
+ *   TC-14 — a failed write keeps pendingStationChanges and hasPendingChanges true
+ *   TC-15 — no remote file: creates directly, no dialog, clears pending on success
+ *   TC-16 — after a successful push, a new markStationChange makes hasPendingChanges true again
+ *   TC-21 — includeStationChanges: false never bundles or clears pendingStationChanges
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RepoConfigDraft } from '@/types/repo-config'
-import type { PreferencesFile } from '@/types/preferences'
+import type { PreferencesFile, StationChange } from '@/types/preferences'
 
 // ---------------------------------------------------------------------------
 // Constants mirrored from useRemotePreferencesWrite.ts (module-private, not exported)
@@ -77,6 +94,17 @@ const UPDATED_PREFERENCES_EDIT: PreferencesFile = {
   favoriteStations: [
     { name: 'Station A Renamed', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
   ],
+}
+
+const ADDED_STATION_CHANGE: StationChange = {
+  kind: 'added',
+  station: { name: 'Station B', url: 'https://www.prix-carburants.gouv.fr/station/22222222' },
+}
+
+const EDITED_STATION_CHANGE: StationChange = {
+  kind: 'edited',
+  url: 'https://www.prix-carburants.gouv.fr/station/11111111',
+  fieldChanges: [{ field: 'name', before: 'Station A', after: 'Station A Renamed' }],
 }
 
 interface FetchOptions {
@@ -144,20 +172,21 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('D-1: diff dialog shown before write — add station', () => {
-  it('opens the write-confirm dialog with before/after JSON and sends no PUT yet', async () => {
+  it('opens the write-confirm dialog with the added station and sends no PUT yet', async () => {
     const fetchMock = buildFetchMock(
       githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
       githubWriteResponse(),
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { writeDiff, isWriteDialogOpen, pushPreferences } = await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    const { writeDiff, isWriteDialogOpen, markStationChange, pushPreferences } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
 
     expect(isWriteDialogOpen.value).toBe(true)
-    expect(writeDiff.value?.beforeJson).toContain('Station A')
-    expect(writeDiff.value?.beforeJson).not.toContain('Station B')
-    expect(writeDiff.value?.afterJson).toContain('Station B')
+    expect(writeDiff.value?.stationChanges).toEqual([ADDED_STATION_CHANGE])
+    expect(writeDiff.value?.fuelTypeChange).toBeNull()
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
@@ -167,19 +196,20 @@ describe('D-1: diff dialog shown before write — add station', () => {
 // ---------------------------------------------------------------------------
 
 describe('D-2: diff dialog shown before write — edit station', () => {
-  it('opens the write-confirm dialog reflecting the edited station name', async () => {
+  it('opens the write-confirm dialog reflecting the edited station field', async () => {
     const fetchMock = buildFetchMock(
       githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
       githubWriteResponse(),
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { writeDiff, isWriteDialogOpen, pushPreferences } = await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_EDIT)
+    const { writeDiff, isWriteDialogOpen, markStationChange, pushPreferences } =
+      await freshComposable()
+    markStationChange(EDITED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_EDIT, true)
 
     expect(isWriteDialogOpen.value).toBe(true)
-    expect(writeDiff.value?.beforeJson).toContain('"Station A"')
-    expect(writeDiff.value?.afterJson).toContain('Station A Renamed')
+    expect(writeDiff.value?.stationChanges).toEqual([EDITED_STATION_CHANGE])
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
@@ -196,9 +226,10 @@ describe('D-3: confirmed write updates the remote file — add station', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { writeSuccess, isWriteDialogOpen, pushPreferences, confirmWrite } =
+    const { writeSuccess, isWriteDialogOpen, markStationChange, pushPreferences, confirmWrite } =
       await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
     await confirmWrite()
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -220,9 +251,10 @@ describe('D-4: confirmed write updates the remote file — edit station', () => 
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { writeSuccess, isWriteDialogOpen, pushPreferences, confirmWrite } =
+    const { writeSuccess, isWriteDialogOpen, markStationChange, pushPreferences, confirmWrite } =
       await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_EDIT)
+    markStationChange(EDITED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_EDIT, true)
     await confirmWrite()
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -246,9 +278,10 @@ describe('D-5: cancelled write leaves the remote file unchanged, shows divergenc
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { divergedNotice, isWriteDialogOpen, pushPreferences, cancelWrite } =
+    const { divergedNotice, isWriteDialogOpen, markStationChange, pushPreferences, cancelWrite } =
       await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
     cancelWrite()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -266,9 +299,10 @@ describe('D-6: first-time write creates the remote file directly, no diff dialog
     const fetchMock = buildFetchMock(githubNotFoundResponse(), githubWriteResponse())
     vi.stubGlobal('fetch', fetchMock)
 
-    const { writeSuccess, isWriteDialogOpen, writeDiff, pushPreferences } =
+    const { writeSuccess, isWriteDialogOpen, writeDiff, markStationChange, pushPreferences } =
       await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
 
     expect(isWriteDialogOpen.value).toBe(false)
     expect(writeDiff.value).toBeNull()
@@ -284,14 +318,16 @@ describe('D-6: first-time write creates the remote file directly, no diff dialog
 
 describe('D-7: stale sha (409 conflict) shows a conflict error', () => {
   it('sets the conflict message and does not report success', async () => {
-    const fetchMock = buildFetchMock(
-      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
-      { status: 409, json: () => Promise.resolve({}) },
-    )
+    const fetchMock = buildFetchMock(githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA), {
+      status: 409,
+      json: () => Promise.resolve({}),
+    })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { writeError, writeSuccess, pushPreferences, confirmWrite } = await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    const { writeError, writeSuccess, markStationChange, pushPreferences, confirmWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
     await confirmWrite()
 
     expect(writeError.value).toBe(CONFLICT_MESSAGE)
@@ -305,15 +341,17 @@ describe('D-7: stale sha (409 conflict) shows a conflict error', () => {
 
 describe('D-8: remote write failure shows a non-blocking error', () => {
   it('notifies onUnauthorized and sets the session-expired message on a 401 PUT', async () => {
-    const fetchMock = buildFetchMock(
-      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
-      { status: 401, json: () => Promise.resolve({}) },
-    )
+    const fetchMock = buildFetchMock(githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA), {
+      status: 401,
+      json: () => Promise.resolve({}),
+    })
     vi.stubGlobal('fetch', fetchMock)
     const onUnauthorized = vi.fn()
 
-    const { writeError, writeSuccess, pushPreferences, confirmWrite } = await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    const { writeError, writeSuccess, markStationChange, pushPreferences, confirmWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
     await confirmWrite(onUnauthorized)
 
     expect(onUnauthorized).toHaveBeenCalledTimes(1)
@@ -334,8 +372,9 @@ describe('D-9: written JSON never includes repo configuration', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { pushPreferences, confirmWrite } = await freshComposable()
-    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD)
+    const { markStationChange, pushPreferences, confirmWrite } = await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
     await confirmWrite()
 
     const putBody = putBodyOf(fetchMock, 1)
@@ -345,5 +384,256 @@ describe('D-9: written JSON never includes repo configuration', () => {
     expect(writtenContent).not.toHaveProperty('owner')
     expect(writtenContent).not.toHaveProperty('repo')
     expect(writtenContent).not.toHaveProperty('revalidateCacheDays')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-04: No pending changes on load — hasPendingChanges is false
+// ---------------------------------------------------------------------------
+
+describe('TC-04: no pending changes on load', () => {
+  it('hasPendingChanges is false before any markStationChange call', async () => {
+    const { hasPendingChanges } = await freshComposable()
+
+    expect(hasPendingChanges.value).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-05/06/07/08: markStationChange makes hasPendingChanges true
+// ---------------------------------------------------------------------------
+
+describe('TC-05/06/07/08: recording a station change makes hasPendingChanges true', () => {
+  it('becomes true after an edited-station change is recorded', async () => {
+    const { hasPendingChanges, markStationChange } = await freshComposable()
+    markStationChange(EDITED_STATION_CHANGE)
+
+    expect(hasPendingChanges.value).toBe(true)
+  })
+
+  it('becomes true after an added-station change is recorded', async () => {
+    const { hasPendingChanges, markStationChange } = await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+
+    expect(hasPendingChanges.value).toBe(true)
+  })
+
+  it('becomes true after a removed-station change is recorded', async () => {
+    const { hasPendingChanges, markStationChange } = await freshComposable()
+    markStationChange({
+      kind: 'removed',
+      station: { name: 'Station A', url: 'https://www.prix-carburants.gouv.fr/station/11111111' },
+    })
+
+    expect(hasPendingChanges.value).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-09: Two edits recorded before a push both stay pending — no flicker
+// ---------------------------------------------------------------------------
+
+describe('TC-09: recording edits to two different stations keeps hasPendingChanges true throughout', () => {
+  it('stays true after the first edit, and stays true (not flickering) after the second', async () => {
+    const { hasPendingChanges, markStationChange } = await freshComposable()
+
+    markStationChange(EDITED_STATION_CHANGE)
+    expect(hasPendingChanges.value).toBe(true)
+
+    markStationChange(ADDED_STATION_CHANGE)
+    expect(hasPendingChanges.value).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-11: Two pending edits bundle into a single writeDiff.stationChanges
+// ---------------------------------------------------------------------------
+
+describe('TC-11: two pending edits bundle into one writeDiff on a single push', () => {
+  it('writeDiff.stationChanges contains both the renamed and the added station', async () => {
+    const fetchMock = buildFetchMock(
+      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
+      githubWriteResponse(),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { writeDiff, isWriteDialogOpen, markStationChange, pushPreferences } =
+      await freshComposable()
+    markStationChange(EDITED_STATION_CHANGE)
+    markStationChange(ADDED_STATION_CHANGE)
+
+    const bundledPreferences: PreferencesFile = {
+      fuelTypeDefault: 'SP95',
+      favoriteStations: [
+        ...UPDATED_PREFERENCES_EDIT.favoriteStations,
+        ...UPDATED_PREFERENCES_ADD.favoriteStations.slice(1),
+      ],
+    }
+    await pushPreferences(true, REPO_CONFIG, bundledPreferences, true)
+
+    expect(isWriteDialogOpen.value).toBe(true)
+    expect(writeDiff.value?.stationChanges).toEqual([EDITED_STATION_CHANGE, ADDED_STATION_CHANGE])
+    // A single GET only — one dialog, not one push per edit.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-12: Confirmed write clears pendingStationChanges and hides the button
+// ---------------------------------------------------------------------------
+
+describe('TC-12: a confirmed, successful write clears pendingStationChanges', () => {
+  it('hasPendingChanges becomes false and writeSuccess becomes true after confirmWrite', async () => {
+    const fetchMock = buildFetchMock(
+      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
+      githubWriteResponse(),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, writeSuccess, markStationChange, pushPreferences, confirmWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    await confirmWrite()
+
+    expect(writeSuccess.value).toBe(true)
+    expect(hasPendingChanges.value).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-13: Cancelling keeps pendingStationChanges and hasPendingChanges true
+// ---------------------------------------------------------------------------
+
+describe('TC-13: cancelling the confirmation dialog keeps the pending change', () => {
+  it('hasPendingChanges stays true after cancelWrite', async () => {
+    const fetchMock = buildFetchMock(
+      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
+      githubWriteResponse(),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, markStationChange, pushPreferences, cancelWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    cancelWrite()
+
+    expect(hasPendingChanges.value).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-14: A failed write keeps pendingStationChanges and hasPendingChanges true
+// ---------------------------------------------------------------------------
+
+describe('TC-14: a write that fails after confirmation keeps the pending change', () => {
+  it('hasPendingChanges stays true and writeError is set after a failed confirmWrite', async () => {
+    const fetchMock = buildFetchMock(githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA), {
+      status: 500,
+      ok: false,
+      json: () => Promise.resolve({}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, writeError, markStationChange, pushPreferences, confirmWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    await confirmWrite()
+
+    expect(writeError.value).not.toBeNull()
+    expect(hasPendingChanges.value).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-15: No remote file — creates directly, no dialog, clears pending on success
+// ---------------------------------------------------------------------------
+
+describe('TC-15: no remote preferences file yet — direct create clears the pending change', () => {
+  it('opens no dialog, PUTs directly, and hasPendingChanges becomes false on success', async () => {
+    const fetchMock = buildFetchMock(githubNotFoundResponse(), githubWriteResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, isWriteDialogOpen, writeSuccess, markStationChange, pushPreferences } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+
+    expect(isWriteDialogOpen.value).toBe(false)
+    expect(writeSuccess.value).toBe(true)
+    expect(hasPendingChanges.value).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-16: After a successful push, a new edit makes hasPendingChanges true again
+// ---------------------------------------------------------------------------
+
+describe('TC-16: editing another station after a successful save makes hasPendingChanges true again', () => {
+  it('hasPendingChanges is true for the new, separate pending change', async () => {
+    const fetchMock = buildFetchMock(
+      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
+      githubWriteResponse(),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, markStationChange, pushPreferences, confirmWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    await confirmWrite()
+    expect(hasPendingChanges.value).toBe(false)
+
+    markStationChange(EDITED_STATION_CHANGE)
+
+    expect(hasPendingChanges.value).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TC-21: includeStationChanges: false never bundles or clears pendingStationChanges
+// ---------------------------------------------------------------------------
+
+describe('TC-21: a fuel-type-only push (includeStationChanges: false) is unaffected by pending station changes', () => {
+  it('does not include the pending station change in writeDiff and does not clear it', async () => {
+    const fetchMock = buildFetchMock(
+      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
+      githubWriteResponse(),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, writeDiff, markStationChange, pushPreferences } =
+      await freshComposable()
+    markStationChange(EDITED_STATION_CHANGE)
+
+    const fuelTypeOnlyPreferences: PreferencesFile = {
+      fuelTypeDefault: 'Gasoil',
+      favoriteStations: EXISTING_PREFERENCES.favoriteStations,
+    }
+    await pushPreferences(true, REPO_CONFIG, fuelTypeOnlyPreferences, false)
+
+    expect(writeDiff.value?.stationChanges).toEqual([])
+    expect(writeDiff.value?.fuelTypeChange).toEqual({ before: 'SP95', after: 'Gasoil' })
+    // The station edit pending in StationManager is neither shown nor cleared.
+    expect(hasPendingChanges.value).toBe(true)
+  })
+
+  it('does not create the remote file with the pending station change when none exists yet', async () => {
+    const fetchMock = buildFetchMock(githubNotFoundResponse(), githubWriteResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { hasPendingChanges, markStationChange, pushPreferences } = await freshComposable()
+    markStationChange(EDITED_STATION_CHANGE)
+
+    const fuelTypeOnlyPreferences: PreferencesFile = {
+      fuelTypeDefault: 'Gasoil',
+      favoriteStations: [],
+    }
+    await pushPreferences(true, REPO_CONFIG, fuelTypeOnlyPreferences, false)
+
+    // The station edit was never bundled into this push, so it is still pending.
+    expect(hasPendingChanges.value).toBe(true)
   })
 })

--- a/src/composables/useRemotePreferencesWrite.ts
+++ b/src/composables/useRemotePreferencesWrite.ts
@@ -1,11 +1,18 @@
 /**
  * Singleton composable for pushing local preference changes to the user's
- * GitHub repo (Sub-Issue D, issue #64): whenever a station or default-fuel
- * change is saved to IndexedDB, the caller invokes `pushPreferences` with the
- * full up-to-date `{ fuelTypeDefault, favoriteStations }` snapshot. If a
- * remote file already exists, a before/after preview opens for the user to
- * confirm; if none exists yet, the file is created directly
+ * GitHub repo (Sub-Issue D, issue #64): the caller invokes `pushPreferences`
+ * with the full up-to-date `{ fuelTypeDefault, favoriteStations }` snapshot.
+ * If a remote file already exists, a field-level preview opens for the user
+ * to confirm; if none exists yet, the file is created directly
  * (business-specifications.md Sub-Issue D rule 2).
+ *
+ * Since issue #110, station-list edits (`StationManagerTable.vue`) no longer
+ * call `pushPreferences` on every change — they call `markStationChange` to
+ * record the edit, and the caller only pushes when the user clicks
+ * "Enregistrer les modifications" (see the addendum in
+ * `docs/decisions/ADR-012-github-repo-as-sync-backend.md`). The
+ * default-fuel-type flow (`StationPricesContent.vue`) is
+ * unaffected and still calls `pushPreferences` immediately on change.
  *
  * The before/after preview and the per-row import merge (issue #63) share one
  * dialog component (`PreferencesDiffDialog.vue`, Sub-Issue D rule 2) — this
@@ -30,10 +37,15 @@
  * exception (see useGitHubAuth.ts, useRepoConfig.ts, useRemotePreferencesSync.ts).
  */
 
-import { ref } from 'vue'
-import type { Ref } from 'vue'
+import { computed, ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import type { RepoConfigDraft } from '@/types/repo-config'
-import type { PreferencesFile, RemoteWritePreview } from '@/types/preferences'
+import type {
+  FuelTypeChange,
+  PreferencesFile,
+  RemoteWritePreview,
+  StationChange,
+} from '@/types/preferences'
 import { parseJsonFile } from '@/utils/preferencesImport'
 
 const PROXY_PATH = '/.netlify/functions/github-api-proxy'
@@ -61,6 +73,8 @@ interface PendingWrite {
   path: string
   sha: string | undefined
   content: string
+  /** The station-change snapshot this write covers — cleared on success, not the live list. */
+  stationChanges: StationChange[]
 }
 
 interface ExistingFile {
@@ -79,6 +93,11 @@ const writeError: Ref<string | null> = ref(null)
 const writeSuccess: Ref<boolean> = ref(false)
 const divergedNotice: Ref<string | null> = ref(null)
 const isWriting: Ref<boolean> = ref(false)
+// Station-list changes recorded since the last successful push (issue #110)
+// — appended by `markStationChange` as each edit is saved locally, read by
+// `hasPendingChanges` to show/hide "Enregistrer les modifications", and
+// bundled into the next push's preview/content.
+const pendingStationChanges: Ref<StationChange[]> = ref([])
 
 // Object Calisthenics exception: a seventh module-level variable, beyond the
 // six reactive refs above. It holds the write awaiting confirmation and is
@@ -154,8 +173,9 @@ async function fetchExistingFile(
 
 // Re-parses the existing remote file through the same shape validation
 // Sub-Issue C's read path enforces (security-guidelines.md rule 8) before its
-// content is ever placed in the write-confirm diff preview.
-function decodeAndValidateExistingFile(existingFile: ExistingFile): string {
+// content is ever compared against the local state for the write-confirm
+// diff preview (security-guidelines.md issue #110 rule 1).
+function decodeAndValidateExistingFile(existingFile: ExistingFile): PreferencesFile {
   let text: string
   try {
     text = decodeBase64Utf8(existingFile.content)
@@ -164,7 +184,33 @@ function decodeAndValidateExistingFile(existingFile: ExistingFile): string {
   }
   const parsed = parseJsonFile(text)
   if (parsed === null) throw new RemoteWriteContentInvalidError()
-  return toPreferencesJson(parsed)
+  return parsed
+}
+
+function buildFuelTypeChange(
+  before: PreferencesFile,
+  after: PreferencesFile,
+): FuelTypeChange | null {
+  if (before.fuelTypeDefault === after.fuelTypeDefault) return null
+  return { before: before.fuelTypeDefault, after: after.fuelTypeDefault }
+}
+
+function buildWritePreview(
+  before: PreferencesFile,
+  after: PreferencesFile,
+  stationChanges: StationChange[],
+): RemoteWritePreview {
+  return { stationChanges, fuelTypeChange: buildFuelTypeChange(before, after) }
+}
+
+// Removes only the change entries this push actually covered, by reference —
+// any edit recorded after the snapshot was taken (while the write was still
+// in flight) is left pending rather than silently dropped
+// (security-guidelines.md issue #110 rule 3).
+function clearPendingStationChanges(pushed: StationChange[]): void {
+  pendingStationChanges.value = pendingStationChanges.value.filter(
+    (change) => !pushed.includes(change),
+  )
 }
 
 async function handlePutResponse(response: Response): Promise<void> {
@@ -194,8 +240,8 @@ async function putRemoteFile(
   await handlePutResponse(response)
 }
 
-function openWriteDialog(beforeJson: string, afterJson: string): void {
-  writeDiff.value = { beforeJson, afterJson }
+function openWriteDialog(preview: RemoteWritePreview): void {
+  writeDiff.value = preview
   isWriteDialogOpen.value = true
 }
 
@@ -238,28 +284,44 @@ async function handleWriteFailure(
   writeError.value = WRITE_FAILED_MESSAGE
 }
 
-async function createRemoteFile(ownerRepo: OwnerRepo, path: string, content: string): Promise<void> {
+async function createRemoteFile(
+  ownerRepo: OwnerRepo,
+  path: string,
+  content: string,
+  stationChanges: StationChange[],
+): Promise<void> {
   await putRemoteFile(ownerRepo, path, content, undefined)
   divergedNotice.value = null
   writeSuccess.value = true
+  clearPendingStationChanges(stationChanges)
 }
 
 async function resolvePendingWrite(
   ownerRepo: OwnerRepo,
   path: string,
-  afterJson: string,
+  preferences: PreferencesFile,
+  stationChanges: StationChange[],
 ): Promise<void> {
+  const afterJson = toPreferencesJson(preferences)
   const existingFile = await fetchExistingFile(ownerRepo, path)
   if (existingFile === null) {
-    await createRemoteFile(ownerRepo, path, afterJson)
+    await createRemoteFile(ownerRepo, path, afterJson, stationChanges)
     return
   }
-  const beforeJson = decodeAndValidateExistingFile(existingFile)
-  pendingWrite = { ownerRepo, path, sha: existingFile.sha, content: afterJson }
-  openWriteDialog(beforeJson, afterJson)
+  const beforePreferences = decodeAndValidateExistingFile(existingFile)
+  pendingWrite = { ownerRepo, path, sha: existingFile.sha, content: afterJson, stationChanges }
+  openWriteDialog(buildWritePreview(beforePreferences, preferences, stationChanges))
 }
 
 export function useRemotePreferencesWrite() {
+  const hasPendingChanges: ComputedRef<boolean> = computed(
+    () => pendingStationChanges.value.length > 0,
+  )
+
+  const markStationChange = (change: StationChange): void => {
+    pendingStationChanges.value = [...pendingStationChanges.value, change]
+  }
+
   const pushPreferences = async (
     isAuthenticated: boolean,
     repoConfig: RepoConfigDraft,
@@ -273,21 +335,32 @@ export function useRemotePreferencesWrite() {
       writeError.value = INVALID_CONFIG_MESSAGE
       return
     }
-    // Guards against duplicate in-flight requests (e.g. two blur events firing
-    // in quick succession): without it, two calls could race on the initial
-    // GET and both resolve into a create/diff step for the same target file.
-    // The change that loses the race is not dropped silently — it is already
-    // in IndexedDB (the caller awaits its own storage write first), so the
-    // same persistent notice cancelWrite uses tells the user it hasn't
-    // reached GitHub yet (review-results.md, sub-issue-86).
+    // Guards against duplicate in-flight requests (e.g. a double click on
+    // "Enregistrer les modifications"): without it, two calls could race on
+    // the initial GET and both resolve into a create/diff step for the same
+    // target file. The change that loses the race is not dropped silently —
+    // it is already in IndexedDB (the caller awaits its own storage write
+    // first) and still recorded in pendingStationChanges, so the same
+    // persistent notice cancelWrite uses tells the user it hasn't reached
+    // GitHub yet (review-results.md, sub-issue-86).
     if (isWriting.value) {
       divergedNotice.value = DIVERGED_MESSAGE
       return
     }
     isWriting.value = true
     resetWriteFeedback()
+    // Snapshot before the async GET below, not after: any station edit made
+    // while the request is in flight must stay pending rather than being
+    // silently included-but-unreviewed or dropped by a later blind clear
+    // (security-guidelines.md issue #110 rule 3).
+    const stationChangesSnapshot = pendingStationChanges.value
     try {
-      await resolvePendingWrite(ownerRepo, repoConfig.filePath.trim(), toPreferencesJson(preferences))
+      await resolvePendingWrite(
+        ownerRepo,
+        repoConfig.filePath.trim(),
+        preferences,
+        stationChangesSnapshot,
+      )
     } catch (error) {
       await handleWriteFailure(error, onUnauthorized)
     } finally {
@@ -301,13 +374,14 @@ export function useRemotePreferencesWrite() {
     // for the same sha — the template also disables the button while
     // isWriting is true, this is the belt-and-braces check.
     if (isWriting.value) return
-    const { ownerRepo, path, sha, content } = pendingWrite
+    const { ownerRepo, path, sha, content, stationChanges } = pendingWrite
     isWriting.value = true
     resetWriteFeedback()
     try {
       await putRemoteFile(ownerRepo, path, content, sha)
       divergedNotice.value = null
       writeSuccess.value = true
+      clearPendingStationChanges(stationChanges)
     } catch (error) {
       await handleWriteFailure(error, onUnauthorized)
     } finally {
@@ -323,6 +397,8 @@ export function useRemotePreferencesWrite() {
   }
 
   return {
+    hasPendingChanges,
+    markStationChange,
     writeDiff,
     isWriteDialogOpen,
     writeError,

--- a/src/composables/useRemotePreferencesWrite.ts
+++ b/src/composables/useRemotePreferencesWrite.ts
@@ -12,7 +12,10 @@
  * "Enregistrer les modifications" (see the addendum in
  * `docs/decisions/ADR-012-github-repo-as-sync-backend.md`). The
  * default-fuel-type flow (`StationPricesContent.vue`) is
- * unaffected and still calls `pushPreferences` immediately on change.
+ * unaffected and still calls `pushPreferences` immediately on change — it
+ * passes `includeStationChanges: false` so a station edit still pending in
+ * `StationManager` never leaks into (and is never cleared by) a fuel-type
+ * push it wasn't reviewed from.
  *
  * The before/after preview and the per-row import merge (issue #63) share one
  * dialog component (`PreferencesDiffDialog.vue`, Sub-Issue D rule 2) — this
@@ -326,6 +329,7 @@ export function useRemotePreferencesWrite() {
     isAuthenticated: boolean,
     repoConfig: RepoConfigDraft,
     preferences: PreferencesFile,
+    includeStationChanges: boolean,
     onUnauthorized?: () => void | Promise<void>,
   ): Promise<void> => {
     if (!isAuthenticated) return
@@ -352,8 +356,12 @@ export function useRemotePreferencesWrite() {
     // Snapshot before the async GET below, not after: any station edit made
     // while the request is in flight must stay pending rather than being
     // silently included-but-unreviewed or dropped by a later blind clear
-    // (security-guidelines.md issue #110 rule 3).
-    const stationChangesSnapshot = pendingStationChanges.value
+    // (security-guidelines.md issue #110 rule 3). Callers that aren't the
+    // StationManager "Enregistrer les modifications" trigger (e.g. the
+    // default-fuel-type flow) pass includeStationChanges: false so this push
+    // never bundles or clears station edits it never showed for review
+    // (business-specifications.md: the fuel-type flow is unaffected).
+    const stationChangesSnapshot = includeStationChanges ? pendingStationChanges.value : []
     try {
       await resolvePendingWrite(
         ownerRepo,

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -54,12 +54,46 @@ export interface PreferencesDiff {
 }
 
 /**
- * Before/after JSON text preview for a pending write to the remote GitHub
- * repo (Sub-Issue D, issue #64) — a single confirm/cancel, not a per-row
- * merge, since the local state already written to IndexedDB is already the
- * value being pushed; there is nothing to merge.
+ * A single before/after value for one field of one station, part of a
+ * pending GitHub write's field-level diff (issue #110).
+ */
+export interface StationFieldChange {
+  field: 'name' | 'url'
+  before: string
+  after: string
+}
+
+/**
+ * The three kinds of station-list change tracked between GitHub pushes
+ * (issue #110): a station's name and/or URL was edited, a station was
+ * added, or a station was removed. Recorded as discrete events at the
+ * moment each edit is saved locally, rather than derived by diffing two
+ * full station arrays afterwards — the remote (pre-push) array and the
+ * local array have no shared identity to match on once a station's URL
+ * itself can change.
+ */
+export type StationChange =
+  | { kind: 'edited'; url: string; fieldChanges: StationFieldChange[] }
+  | { kind: 'added'; station: Station }
+  | { kind: 'removed'; station: Station }
+
+/**
+ * Before/after value for the default fuel type, only present when the
+ * remote file's value differs from the local value being pushed.
+ */
+export interface FuelTypeChange {
+  before: string | null
+  after: string | null
+}
+
+/**
+ * Field-level preview for a pending write to the remote GitHub repo
+ * (Sub-Issue D, issue #64; field-level shape added by issue #110) — a
+ * single confirm/cancel, not a per-row merge, since the local state
+ * already written to IndexedDB is already the value being pushed; there
+ * is nothing to merge.
  */
 export interface RemoteWritePreview {
-  beforeJson: string
-  afterJson: string
+  stationChanges: StationChange[]
+  fuelTypeChange: FuelTypeChange | null
 }


### PR DESCRIPTION
## Summary

- Stack the settings-page "Enregistrer" and connect/disconnect GitHub buttons vertically
  (full width) on mobile viewports; they stay side by side from the `sm` breakpoint up.
- Replace the per-field GitHub push in `StationManager` with an explicit
  "Enregistrer les modifications" button: station add/edit/delete now save to IndexedDB
  immediately but only push to GitHub, batched, when the button is clicked.
- Replace the write-confirm dialog's raw before/after JSON with a field-level old → new
  diff (added/removed stations by name, edited fields as "Nom : ancien → nouveau").
- The default-fuel-type push flow (`StationPricesContent.vue`) is unaffected — it still
  pushes immediately on change, isolated from any station-list edit pending review in
  `StationManager` (`pushPreferences`'s new `includeStationChanges` parameter).
- Addendum to `ADR-012-github-repo-as-sync-backend.md` documenting the batched write flow
  for station-list changes.

## Test plan

- [x] `npx vitest run` — 379 test files, 452 tests, all passing
- [x] `vue-tsc --noEmit` — clean
- [x] `eslint` on touched files — clean
- [x] Settings page: save/connect (and save/disconnect) buttons stack full-width on mobile,
      sit side by side from `sm` up, in both auth states
- [x] "Enregistrer les modifications" button: hidden with no pending changes, appears after
      name/URL edit, add, or delete, stays visible across multiple edits without flicker
- [x] Batched save: multiple pending edits bundle into a single confirmation dialog and a
      single GitHub push; cancel or failure keeps the pending changes and the button visible
- [x] Diff dialog shows only what changed (field-level, added/removed by name), not raw JSON
- [x] Default fuel type save still pushes immediately, unaffected by pending station changes

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
