### PR TITLE
fix: handle GitHub org OAuth 403 restriction

### DIFF
--- a/.env.proton-pass-example
+++ b/.env.proton-pass-example
@@ -12,7 +12,7 @@ GITHUB_CLIENT_SECRET=pass://[share-id-of-target-vault]/[item-id-in-target-vault]
 # read/write permission (see ADR-014's "PAT Setup Guide" for how to create
 # it); the other three mirror whatever owner/repo/path you configured in the
 # app's Settings UI.
-HISTORY_GITHUB_PAT=pass://[share-id-of-target-vault]/[item-id-in-target-vault]/Fine-grained PAT
+HISTORY_GITHUB_PAT=[github-fined-grained-pat]
 HISTORY_GITHUB_OWNER=[github-owner-of-target-repo]
 HISTORY_GITHUB_REPO=[target-repo-name]
 HISTORY_PREFS_FILE_PATH=[same-path-as-settings-ui-filepath]

--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -125,6 +125,9 @@ declare global {
   export type { FuelPrice } from './src/types/fuel-price'
   import('./src/types/fuel-price')
   // @ts-ignore
+  export type { OrgRestrictionNotice } from './src/types/org-restriction-notice'
+  import('./src/types/org-restriction-notice')
+  // @ts-ignore
   export type { PreferencesFile, DiffRowKind, StationDiffRow, FuelTypeDiff, PreferencesDiff, StationFieldChange, StationChange, FuelTypeChange, RemoteWritePreview } from './src/types/preferences'
   import('./src/types/preferences')
   // @ts-ignore

--- a/components.d.ts
+++ b/components.d.ts
@@ -46,6 +46,7 @@ declare module 'vue' {
     LogOut: typeof import('./src/components/ui/icon/LogOut.vue')['default']
     Menu: typeof import('./src/components/ui/icon/Menu.vue')['default']
     Moon: typeof import('./src/components/ui/icon/Moon.vue')['default']
+    OrgRestrictionNotice: typeof import('./src/components/OrgRestrictionNotice.vue')['default']
     PaintBrush: typeof import('./src/components/ui/icon/PaintBrush.vue')['default']
     PencilLine: typeof import('./src/components/ui/icon/PencilLine.vue')['default']
     PreferencesDiffDialog: typeof import('./src/components/PreferencesDiffDialog.vue')['default']

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/README.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/README.md
@@ -1,0 +1,29 @@
+Worktree: E:/Git/GitHub/french-gas-stations-scraper_fix-github-oauth-403-handling
+
+# Issue #108: Handle GitHub org OAuth restriction (403) with actionable message
+
+## Problem
+
+A user whose GitHub organization has "OAuth App access restrictions" enabled gets an HTTP 403 from the GitHub Contents API, with a distinct message and `documentation_url` — not a 401/404/409. None of our GitHub-proxy call sites recognize this case today; it falls into a generic "unreachable"/"failed" message instead of telling the user what's actually wrong and how to fix it.
+
+Real response body observed for a specific user (org name redacted as `Puzzlout`):
+
+```json
+{
+  "message": "Although you appear to have the correct authorization credentials, the `Puzzlout` organization has enabled OAuth App access restrictions, meaning that data access to third-parties is limited. For more information on these restrictions, including how to enable this app, visit https://docs.github.com/articles/restricting-access-to-your-organization-s-data/",
+  "documentation_url": "https://docs.github.com/rest/repos/contents#create-or-update-file-contents",
+  "status": "403"
+}
+```
+
+## Scope
+
+- `src/composables/useRepoConfig.ts` (`classifyProxyResponse`/`checkProxyReachable`) — repo/file-path reachability check during Settings save.
+- `src/composables/useRemotePreferencesSync.ts` (`requestRemoteFile`) — read on app load (Sub-Issue C).
+- `src/composables/useRemotePreferencesWrite.ts` (`fetchExistingFile`/`handlePutResponse`) — write on update (Sub-Issue D).
+
+Add a distinct branch for HTTP 403 in each composable's response handling, surfacing a message that tells the user their GitHub organization restricts OAuth Apps and links to GitHub's restriction docs (https://docs.github.com/articles/restricting-access-to-your-organization-s-data/).
+
+## Out of scope
+
+- `netlify/functions/github-api-proxy.ts` needs no change — it already forwards GitHub's status/body verbatim for non-401 responses; this is a client-side message-mapping gap only.

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/business-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/business-specifications.md
@@ -5,8 +5,8 @@
 When a user's GitHub organization has "OAuth App access restrictions" enabled, every
 call site that talks to the `github-api-proxy` function must recognize the resulting
 HTTP 403 and tell the user specifically what is wrong (the organization blocks
-third-party OAuth Apps) and how to fix it (a link to GitHub's restriction docs),
-instead of falling into a generic "unreachable"/"failed" message.
+third-party OAuth Apps) and how to fix it (a link to that organization's own OAuth App
+access settings page), instead of falling into a generic "unreachable"/"failed" message.
 
 ## Scope
 
@@ -29,31 +29,32 @@ it already forwards GitHub's status/body verbatim):
    other forbidden causes) or whose body can't be parsed falls back to that call
    site's existing generic failure message — unchanged from today.
 
-2. **Message content.** When the org-restriction case is detected, the user-visible
-   message must state that the organization restricts data access for third-party
-   OAuth Apps, include GitHub's own explanatory text from the response body (so the
-   organization name is visible to the user, since it's embedded in that text), and
-   link to `https://docs.github.com/articles/restricting-access-to-your-organization-s-data/`.
-   The GitHub-supplied text is shown as plain text, never interpreted as HTML.
+2. **Message content is fixed and identical at all three call sites.** GitHub's own
+   403 explanatory text is used only to detect the case (rule 1) and is never shown
+   to the user — no part of the response body reaches the displayed message. The
+   message shown is exactly:
 
-3. **Message tone stays call-site-specific.** Each of the three composables keeps
-   composing this message in its own existing style (language, and — for the write
-   path — the "your local data is kept" reassurance already used for its other
-   failure messages), the same way each composable already phrases 401/404/409
-   differently today. Only the underlying GitHub-restriction information (rule 2) is
-   shared.
+   > Le dépôt choisi se trouve sous une organisation n'autorisant pas
+   > l'authentification avec votre compte et le dépôt choisi. Veuillez visiter ce
+   > lien pour autoriser l'accès.
 
-4. **No change to unrelated statuses.** 401 (re-authentication), 404 (not found),
+   "lien" is a clickable link that opens, in a new browser tab (without navigating
+   away from the app), the settings page where an admin of that organization manages
+   OAuth App access restrictions. The link target is built only from the repo owner
+   the user has already configured in this app's own Settings — never from any field
+   in the GitHub response body (e.g. its `documentation_url`).
+
+3. **No change to unrelated statuses.** 401 (re-authentication), 404 (not found),
    409 (conflict), 200 (success), and other/unexpected statuses keep their current
    behavior exactly as-is; 403 is a new, additional branch alongside them.
 
-5. **`useRepoConfig.ts` short-circuits like a 401.** Today, a file-path check that
+4. **`useRepoConfig.ts` short-circuits like a 401.** Today, a file-path check that
    isn't 200/401/404 falls through to also check whether the repo itself is
    reachable. An org-OAuth-restriction 403 skips that fallback (it would 403 again
    for the same organization-wide reason) and resolves directly to the message from
    rule 2 — mirroring how a 401 already short-circuits.
 
-6. **Read and write paths surface it as a distinct, non-retryable failure.** In
+5. **Read and write paths surface it as a distinct, non-retryable failure.** In
    `useRemotePreferencesSync.ts` and `useRemotePreferencesWrite.ts`, the
    org-restriction 403 is surfaced as its own error state (not the generic
    fetch-failed / write-failed message, and not the re-authentication message —
@@ -64,6 +65,8 @@ it already forwards GitHub's status/body verbatim):
 - `netlify/functions/github-api-proxy.ts` — already forwards GitHub's status/body
   verbatim for non-401 responses.
 - Any UI affordance to let the user request org-admin approval from within the app —
-  the message only informs and links to GitHub's own docs.
+  the link only takes the user to GitHub's own settings page for that purpose.
+- Per-call-site wording variation for this message (unlike the app's other failure
+  messages, which do vary by call site) — rule 2's text is shown verbatim everywhere.
 
 status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/business-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/business-specifications.md
@@ -1,0 +1,69 @@
+# Business Specifications: Handle GitHub org OAuth restriction (403)
+
+## Goal
+
+When a user's GitHub organization has "OAuth App access restrictions" enabled, every
+call site that talks to the `github-api-proxy` function must recognize the resulting
+HTTP 403 and tell the user specifically what is wrong (the organization blocks
+third-party OAuth Apps) and how to fix it (a link to GitHub's restriction docs),
+instead of falling into a generic "unreachable"/"failed" message.
+
+## Scope
+
+Files to modify (no new files; `netlify/functions/github-api-proxy.ts` is unchanged —
+it already forwards GitHub's status/body verbatim):
+
+- `src/composables/useRepoConfig.ts` — repo/file-path reachability check run during
+  Settings save (`classifyProxyResponse`/`checkProxyReachable`).
+- `src/composables/useRemotePreferencesSync.ts` — remote-file read on app load
+  (`requestRemoteFile`).
+- `src/composables/useRemotePreferencesWrite.ts` — remote-file read/write during a
+  preferences push (`fetchExistingFile`/`handlePutResponse`).
+
+## Rules
+
+1. **Detecting the org-restriction case.** A 403 response is only treated as the
+   org-OAuth-restriction case when its JSON body's `message` field indicates GitHub
+   blocked the request for that reason (per GitHub's own wording, e.g. "OAuth App
+   access restrictions"). A 403 whose body doesn't indicate this (rate limiting,
+   other forbidden causes) or whose body can't be parsed falls back to that call
+   site's existing generic failure message — unchanged from today.
+
+2. **Message content.** When the org-restriction case is detected, the user-visible
+   message must state that the organization restricts data access for third-party
+   OAuth Apps, include GitHub's own explanatory text from the response body (so the
+   organization name is visible to the user, since it's embedded in that text), and
+   link to `https://docs.github.com/articles/restricting-access-to-your-organization-s-data/`.
+   The GitHub-supplied text is shown as plain text, never interpreted as HTML.
+
+3. **Message tone stays call-site-specific.** Each of the three composables keeps
+   composing this message in its own existing style (language, and — for the write
+   path — the "your local data is kept" reassurance already used for its other
+   failure messages), the same way each composable already phrases 401/404/409
+   differently today. Only the underlying GitHub-restriction information (rule 2) is
+   shared.
+
+4. **No change to unrelated statuses.** 401 (re-authentication), 404 (not found),
+   409 (conflict), 200 (success), and other/unexpected statuses keep their current
+   behavior exactly as-is; 403 is a new, additional branch alongside them.
+
+5. **`useRepoConfig.ts` short-circuits like a 401.** Today, a file-path check that
+   isn't 200/401/404 falls through to also check whether the repo itself is
+   reachable. An org-OAuth-restriction 403 skips that fallback (it would 403 again
+   for the same organization-wide reason) and resolves directly to the message from
+   rule 2 — mirroring how a 401 already short-circuits.
+
+6. **Read and write paths surface it as a distinct, non-retryable failure.** In
+   `useRemotePreferencesSync.ts` and `useRemotePreferencesWrite.ts`, the
+   org-restriction 403 is surfaced as its own error state (not the generic
+   fetch-failed / write-failed message, and not the re-authentication message —
+   re-authenticating does not fix an org-level restriction).
+
+## Out of scope
+
+- `netlify/functions/github-api-proxy.ts` — already forwards GitHub's status/body
+  verbatim for non-401 responses.
+- Any UI affordance to let the user request org-admin approval from within the app —
+  the message only informs and links to GitHub's own docs.
+
+status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
@@ -7,31 +7,44 @@ type-check: clean
 
 ## Checklist
 
-- **security-guidelines.md rule 4 not satisfied**: `src/components/OrgRestrictionNotice.vue:4`
-  renders the link via the existing `AppLink` component, which sets `rel="noopener"` only
-  (`src/components/AppLink.vue:7`, confirmed unmodified by this branch via
-  `git diff develop...HEAD -- src/components/AppLink.vue`). Rule 4's "What" explicitly requires
-  `rel="noopener noreferrer"` alongside `target="_blank"`. `technical-specifications.md`'s
-  "Non-trivial decisions" section argues `noopener` alone already closes the `window.opener`
-  vector the rule's "Why" describes, and that's true — but the security doc as currently written
-  is a specific, literal requirement (`noopener noreferrer`), not just "prevent
-  reverse-tabnabbing," so the code doesn't verifiably satisfy the rule as stated. Two ways to
-  close this: add `noreferrer` (e.g. to `AppLink.vue`, which would also tighten the app's other
-  external links) or amend security-guidelines.md rule 4 to explicitly accept `noopener` alone
-  and note why. Either is a legitimate call — not this review's decision to make silently.
+- **`src/components/layout/AppFooter.test.ts:90-96` will fail against the changed
+  `AppLink.vue`.** The existing test `it('all links have rel="noopener"', ...)` asserts
+  `link.attributes('rel')).toBe('noopener')` for every `AppLink`-rendered anchor in
+  `AppFooter.vue`. `AppLink.vue:7` was changed by this branch from `rel="noopener"` to
+  `rel="noopener noreferrer"` (the rule-4 fix from the prior review round), so every footer
+  link now renders `rel="noopener noreferrer"` and this assertion no longer matches. Update
+  the expectation to `'noopener noreferrer'` — `src/pages/mentions-legales.spec.ts` (TC-05)
+  already asserts the same value elsewhere, so this brings the two in line.
+- **`src/components/OrgRestrictionNotice.vue:13` has a stale comment.** It still reads
+  "Reuses `AppLink`, which already opens external links in a new tab with `rel="noopener"`"
+  — but `AppLink.vue:7` now sets `rel="noopener noreferrer"`. Leaving the comment as-is
+  re-states the exact claim the prior review round rejected (that `noopener` alone satisfies
+  security-guidelines.md rule 4); update it to say `noopener noreferrer` so it doesn't mislead
+  a future reader into thinking the weaker value is still in place.
+- **`technical-specifications.md`'s claim that the `AppLink` fix "tightens every other
+  external link already using `AppLink` (`AppFooter.vue`, `StationManager.vue`)" is not true
+  for `StationManager.vue`.** `StationManager.vue:42` passes its own `rel="noopener"`
+  attribute directly on its `<AppLink>` usage. Since `rel` isn't a declared prop of `AppLink`,
+  Vue 3's fallthrough-attribute merge applies it to the component's root element *after* the
+  template's own `rel="noopener noreferrer"` binding — for non-class/style attributes the
+  fallthrough value wins, so this specific link is still rendered with `rel="noopener"` only,
+  unchanged by this branch. `StationManager.vue` isn't in this task's file list so it's not
+  this review's call to fix it, but the tech-spec claim should either be corrected or (if the
+  team wants the tightening to actually apply there) the redundant `rel="noopener"` should be
+  dropped from that call site so `AppLink`'s own binding takes effect.
 
 All other checklist items ✓ — verified against `technical-specifications.md`,
 `business-specifications.md`, and `test-cases.md`: org-restriction detection is a boolean-only
-check (no response text ever reaches a ref or the DOM — rule 2 confirmed via `grep` for the
-removed sanitization/message-carrying code, none remains); the settings-page link is built only
-from the app's own configured owner and percent-encoded (rule 3); the fixed sentence is
-centralized in one component (`OrgRestrictionNotice.vue`) reused at all three call sites,
-satisfying test case 22's byte-identical requirement by construction; `useRepoConfig.ts`'s
+check (no response text ever reaches a ref or the DOM — rule 2 confirmed); the settings-page
+link is built only from the app's own configured owner and percent-encoded (rule 3); the fixed
+sentence is centralized in one component (`OrgRestrictionNotice.vue`) reused at all three call
+sites, satisfying test case 22's byte-identical requirement by construction; `useRepoConfig.ts`'s
 short-circuit and the two remote-preferences composables' distinct non-retryable failure
 (including the read-before-write GET and the final PUT) all match business-specifications.md
-rules 1 and 3–5; no `v-html` anywhere; props are used via `props.owner` inside a `computed`
-rather than destructured (no reactivity-loss pitfall); explicit return types and no unguarded
-`any`/`unknown` in the new/changed exported functions; no dead code or unused imports from the
-removed sanitization logic.
+rules 1 and 3–5; the 403-body read is wrapped in try/catch in all three composables, falling
+back to the existing generic-failure branch on parse failure or a non-matching body (rule 1);
+no `v-html` anywhere; props are used via `props.owner` inside a `computed` rather than
+destructured (no reactivity-loss pitfall); explicit return types and no unguarded `any`/`unknown`
+in the new/changed exported functions; no dead code or unused imports.
 
 status: changes requested

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
@@ -1,34 +1,37 @@
 # Review Results: Handle GitHub org OAuth restriction (403)
 
 lint: clean (9 pre-existing errors remain in `usePreferencesExport.spec.ts` /
-`usePreferencesImport.spec.ts` — confirmed via `git diff develop...HEAD --stat`, neither file
-is touched by this branch; unrelated to this task's changed files)
+`usePreferencesImport.spec.ts` — confirmed via `git diff develop...HEAD`, neither file is
+touched by this branch; unrelated to this task's changed files)
 type-check: clean
 
 ## Checklist
 
-All checklist items ✓ — verified against `technical-specifications.md`, `security-guidelines.md`,
-`business-specifications.md`, and `test-cases.md`:
+- **security-guidelines.md rule 4 not satisfied**: `src/components/OrgRestrictionNotice.vue:4`
+  renders the link via the existing `AppLink` component, which sets `rel="noopener"` only
+  (`src/components/AppLink.vue:7`, confirmed unmodified by this branch via
+  `git diff develop...HEAD -- src/components/AppLink.vue`). Rule 4's "What" explicitly requires
+  `rel="noopener noreferrer"` alongside `target="_blank"`. `technical-specifications.md`'s
+  "Non-trivial decisions" section argues `noopener` alone already closes the `window.opener`
+  vector the rule's "Why" describes, and that's true — but the security doc as currently written
+  is a specific, literal requirement (`noopener noreferrer`), not just "prevent
+  reverse-tabnabbing," so the code doesn't verifiably satisfy the rule as stated. Two ways to
+  close this: add `noreferrer` (e.g. to `AppLink.vue`, which would also tighten the app's other
+  external links) or amend security-guidelines.md rule 4 to explicitly accept `noopener` alone
+  and note why. Either is a legitimate call — not this review's decision to make silently.
 
-- Security guidelines: rule 1 (try/catch around `response.json()`/body-shape read, falls to
-  `null` → generic message) confirmed in all three `extractOrgRestrictionMessage` functions;
-  rule 2 (hardcoded `ORG_RESTRICTION_DOCS_URL`, never read from the response body) confirmed;
-  rule 3 (control/bidi-char stripping via `CONTROL_CHAR_CODE_RANGES` + `sanitizeGitHubText`,
-  covering ranges 0x200b–0x200f, 0x202a–0x202e, 0x2060–0x2069, 0xfeff) confirmed, plus all three
-  refs (`validationError`, `syncError`, `writeError`) are rendered with `{{ }}` text
-  interpolation only — no `v-html` anywhere in the codebase.
-- Business spec rules 1–6 traced line-by-line against test cases 1–21: detection
-  (`.includes('OAuth App access restrictions')`), message content/tone per call site, the
-  401-style short-circuit in `useRepoConfig.ts` skipping the repo-level fallback, and the
-  distinct non-retryable failure surfaced in both the read and write composables (including the
-  read-before-write GET and the final PUT in `useRemotePreferencesWrite.ts`) all match.
-- No response body is read twice on any path (checked each `response.json()` call site against
-  the branches that precede/follow it).
-- No dead code, unused imports, `any`/unguarded `unknown`, or missing return types introduced.
-- Object Calisthenics exceptions (guard-clause chains, >2 module-level state vars) are all
-  pre-existing, documented in the file's own comments, and untouched by this diff (confirmed via
-  `git diff develop...HEAD -- src/composables/useRepoConfig.ts`).
+All other checklist items ✓ — verified against `technical-specifications.md`,
+`business-specifications.md`, and `test-cases.md`: org-restriction detection is a boolean-only
+check (no response text ever reaches a ref or the DOM — rule 2 confirmed via `grep` for the
+removed sanitization/message-carrying code, none remains); the settings-page link is built only
+from the app's own configured owner and percent-encoded (rule 3); the fixed sentence is
+centralized in one component (`OrgRestrictionNotice.vue`) reused at all three call sites,
+satisfying test case 22's byte-identical requirement by construction; `useRepoConfig.ts`'s
+short-circuit and the two remote-preferences composables' distinct non-retryable failure
+(including the read-before-write GET and the final PUT) all match business-specifications.md
+rules 1 and 3–5; no `v-html` anywhere; props are used via `props.owner` inside a `computed`
+rather than destructured (no reactivity-loss pitfall); explicit return types and no unguarded
+`any`/`unknown` in the new/changed exported functions; no dead code or unused imports from the
+removed sanitization logic.
 
-All other checklist items ✓.
-
-status: approved
+status: changes requested

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
@@ -7,31 +7,23 @@ type-check: clean
 
 ## Checklist
 
-- **`src/components/layout/AppFooter.test.ts:90-96` will fail against the changed
-  `AppLink.vue`.** The existing test `it('all links have rel="noopener"', ...)` asserts
-  `link.attributes('rel')).toBe('noopener')` for every `AppLink`-rendered anchor in
-  `AppFooter.vue`. `AppLink.vue:7` was changed by this branch from `rel="noopener"` to
-  `rel="noopener noreferrer"` (the rule-4 fix from the prior review round), so every footer
-  link now renders `rel="noopener noreferrer"` and this assertion no longer matches. Update
-  the expectation to `'noopener noreferrer'` — `src/pages/mentions-legales.spec.ts` (TC-05)
-  already asserts the same value elsewhere, so this brings the two in line.
-- **`src/components/OrgRestrictionNotice.vue:13` has a stale comment.** It still reads
-  "Reuses `AppLink`, which already opens external links in a new tab with `rel="noopener"`"
-  — but `AppLink.vue:7` now sets `rel="noopener noreferrer"`. Leaving the comment as-is
-  re-states the exact claim the prior review round rejected (that `noopener` alone satisfies
-  security-guidelines.md rule 4); update it to say `noopener noreferrer` so it doesn't mislead
-  a future reader into thinking the weaker value is still in place.
-- **`technical-specifications.md`'s claim that the `AppLink` fix "tightens every other
-  external link already using `AppLink` (`AppFooter.vue`, `StationManager.vue`)" is not true
-  for `StationManager.vue`.** `StationManager.vue:42` passes its own `rel="noopener"`
-  attribute directly on its `<AppLink>` usage. Since `rel` isn't a declared prop of `AppLink`,
-  Vue 3's fallthrough-attribute merge applies it to the component's root element *after* the
-  template's own `rel="noopener noreferrer"` binding — for non-class/style attributes the
-  fallthrough value wins, so this specific link is still rendered with `rel="noopener"` only,
-  unchanged by this branch. `StationManager.vue` isn't in this task's file list so it's not
-  this review's call to fix it, but the tech-spec claim should either be corrected or (if the
-  team wants the tightening to actually apply there) the redundant `rel="noopener"` should be
-  dropped from that call site so `AppLink`'s own binding takes effect.
+All three prior-round findings are resolved and verified:
+
+- `src/components/OrgRestrictionNotice.vue:13`'s comment now correctly says
+  `rel="noopener noreferrer"`, matching `AppLink.vue:7`.
+- `src/components/StationManager.vue:42`'s `AppLink` usage now passes `to="..."` instead of
+  `href`/`target`/`rel`. Confirmed this takes `AppLink`'s external-link branch (`to` starts
+  with `http`), so the link now genuinely renders `target="_blank" rel="noopener noreferrer"`
+  with no per-call-site `rel` able to shadow it — `technical-specifications.md`'s "tightens
+  every other external link" claim now holds for this call site.
+- `src/components/StationManager.spec.ts:177` stubs `AppLink` as `{ template: '<a><slot /></a>' }`,
+  so the prop-name change (`href`→`to`) does not break that test — confirmed by reading the stub.
+
+The remaining known item — `src/components/layout/AppFooter.test.ts:90-96` still asserting
+`rel="noopener"` — is not a new finding: it's a pre-existing test that predates this branch's
+`AppLink.vue` change, is explicitly out of this task's `test-cases.md`, and is documented in
+`technical-specifications.md`'s "Known follow-up" section as deferred to `/jli-writes-tests`
+per prior user direction. Not blocking this review.
 
 All other checklist items ✓ — verified against `technical-specifications.md`,
 `business-specifications.md`, and `test-cases.md`: org-restriction detection is a boolean-only
@@ -47,4 +39,4 @@ no `v-html` anywhere; props are used via `props.owner` inside a `computed` rathe
 destructured (no reactivity-loss pitfall); explicit return types and no unguarded `any`/`unknown`
 in the new/changed exported functions; no dead code or unused imports.
 
-status: changes requested
+status: approved

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/review-results.md
@@ -1,0 +1,34 @@
+# Review Results: Handle GitHub org OAuth restriction (403)
+
+lint: clean (9 pre-existing errors remain in `usePreferencesExport.spec.ts` /
+`usePreferencesImport.spec.ts` — confirmed via `git diff develop...HEAD --stat`, neither file
+is touched by this branch; unrelated to this task's changed files)
+type-check: clean
+
+## Checklist
+
+All checklist items ✓ — verified against `technical-specifications.md`, `security-guidelines.md`,
+`business-specifications.md`, and `test-cases.md`:
+
+- Security guidelines: rule 1 (try/catch around `response.json()`/body-shape read, falls to
+  `null` → generic message) confirmed in all three `extractOrgRestrictionMessage` functions;
+  rule 2 (hardcoded `ORG_RESTRICTION_DOCS_URL`, never read from the response body) confirmed;
+  rule 3 (control/bidi-char stripping via `CONTROL_CHAR_CODE_RANGES` + `sanitizeGitHubText`,
+  covering ranges 0x200b–0x200f, 0x202a–0x202e, 0x2060–0x2069, 0xfeff) confirmed, plus all three
+  refs (`validationError`, `syncError`, `writeError`) are rendered with `{{ }}` text
+  interpolation only — no `v-html` anywhere in the codebase.
+- Business spec rules 1–6 traced line-by-line against test cases 1–21: detection
+  (`.includes('OAuth App access restrictions')`), message content/tone per call site, the
+  401-style short-circuit in `useRepoConfig.ts` skipping the repo-level fallback, and the
+  distinct non-retryable failure surfaced in both the read and write composables (including the
+  read-before-write GET and the final PUT in `useRemotePreferencesWrite.ts`) all match.
+- No response body is read twice on any path (checked each `response.json()` call site against
+  the branches that precede/follow it).
+- No dead code, unused imports, `any`/unguarded `unknown`, or missing return types introduced.
+- Object Calisthenics exceptions (guard-clause chains, >2 module-level state vars) are all
+  pre-existing, documented in the file's own comments, and untouched by this diff (confirmed via
+  `git diff develop...HEAD -- src/composables/useRepoConfig.ts`).
+
+All other checklist items ✓.
+
+status: approved

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/security-guidelines.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/security-guidelines.md
@@ -1,34 +1,42 @@
 # Security Guidelines: Handle GitHub org OAuth restriction (403)
 
 1. **Fail closed on unparseable/unexpected 403 bodies.** What: wrap the 403 body read
-   (parsing JSON, reading `message`) in a try/catch (or `.catch()`), the same
-   defensive pattern already used for other proxy-response parsing in these files;
-   any parse failure or unexpected shape must fall through to the call site's
-   existing generic-failure message, never throw uncaught. Where:
-   `useRepoConfig.ts`, `useRemotePreferencesSync.ts`,
-   `useRemotePreferencesWrite.ts` — wherever the org-restriction detection (rule 1
-   of business-specifications.md) reads the response body. Why: the 403 body's
-   exact shape is GitHub's, not a contract this project controls; a future GitHub
-   change or a proxy hiccup must degrade to the existing message, not crash the
-   flow.
+   (parsing JSON, reading `message`) in a try/catch (or `.catch()`), the same defensive
+   pattern already used for other proxy-response parsing in these files; any parse
+   failure or unexpected shape must fall through to the call site's existing
+   generic-failure message, never throw uncaught. Where: `useRepoConfig.ts`,
+   `useRemotePreferencesSync.ts`, `useRemotePreferencesWrite.ts` — wherever the
+   org-restriction detection (rule 1 of business-specifications.md) reads the response
+   body. Why: the 403 body's exact shape is GitHub's, not a contract this project
+   controls; a future GitHub change or a proxy hiccup must degrade to the existing
+   message, not crash the flow.
 
-2. **The restriction-docs link is a hardcoded literal, never response-derived.**
-   What: the `https://docs.github.com/articles/restricting-access-to-your-organization-s-data/`
-   link shown to the user must be a fixed string in the code — never built from, or
-   substituted by, any URL found in the response body (e.g. its own
-   `documentation_url` field). Where: the three composables' 403 message
-   construction. Why: treating server response data as a link target risks
-   pointing the user at an attacker-controlled URL if the proxy or the upstream
-   response is ever tampered with (open-redirect / phishing vector).
+2. **Never render any GitHub response content in the org-restriction message.** What:
+   the only permitted use of the 403 body's `message` field is a boolean check for the
+   org-restriction indicator string; no field from the response body (the message text,
+   `documentation_url`, or anything else) may reach the DOM. Where: the three
+   composables' message-building step, and whichever component renders it (must never
+   use `v-html`). Why: since the displayed message is now a fixed string
+   (business-specifications.md rule 2), there is no legitimate reason for GitHub-supplied
+   text to reach the page at all — letting any of it back in reopens the
+   injection/spoofing surface this fixed-message design exists to close.
 
-3. **Neutralize invisible/bidi control characters in the echoed GitHub text.**
-   What: before assigning GitHub's `message` text to the ref shown in the UI, strip
-   Unicode bidirectional-override and other non-printing control characters. This
-   is in addition to relying on Vue's default text-interpolation escaping (never
-   `v-html`) which business-specifications.md rule 2 already requires. Where: the
-   point in each composable where the extracted message text is stored for
-   display. Why: verbatim external text can visually reorder or hide what the user
-   reads (a "Trojan Source"-style spoofing attack) even when script injection is
-   already blocked by escaping.
+3. **Build the settings-page link only from the app's own already-validated repo-owner
+   value, percent-encoded.** What: the organization segment of the link must come from
+   the owner the user configured in this app's Settings (already validated as
+   non-empty and slash-free) — never from any response field — and must be
+   percent-encoded before insertion into the URL. Where: the link-construction step in
+   each of the three composables. Why: building a URL from unencoded external-ish input
+   is a bug that only shows itself the day that owner value contains a character it
+   doesn't today; deriving it from the response body instead would risk pointing the
+   user at an attacker-controlled URL if the proxy or upstream response is ever
+   tampered with.
+
+4. **The new-tab link must not create a reverse-tabnabbing vector.** What: the anchor
+   that opens the settings page in a new browser tab must include
+   `rel="noopener noreferrer"` alongside `target="_blank"`. Where: the link element
+   rendering the org-restriction message. Why: without it, the newly opened GitHub tab
+   retains a `window.opener` handle back to this app, letting a compromised or
+   malicious destination page redirect or manipulate the tab the user came from.
 
 status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/security-guidelines.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/security-guidelines.md
@@ -1,0 +1,34 @@
+# Security Guidelines: Handle GitHub org OAuth restriction (403)
+
+1. **Fail closed on unparseable/unexpected 403 bodies.** What: wrap the 403 body read
+   (parsing JSON, reading `message`) in a try/catch (or `.catch()`), the same
+   defensive pattern already used for other proxy-response parsing in these files;
+   any parse failure or unexpected shape must fall through to the call site's
+   existing generic-failure message, never throw uncaught. Where:
+   `useRepoConfig.ts`, `useRemotePreferencesSync.ts`,
+   `useRemotePreferencesWrite.ts` — wherever the org-restriction detection (rule 1
+   of business-specifications.md) reads the response body. Why: the 403 body's
+   exact shape is GitHub's, not a contract this project controls; a future GitHub
+   change or a proxy hiccup must degrade to the existing message, not crash the
+   flow.
+
+2. **The restriction-docs link is a hardcoded literal, never response-derived.**
+   What: the `https://docs.github.com/articles/restricting-access-to-your-organization-s-data/`
+   link shown to the user must be a fixed string in the code — never built from, or
+   substituted by, any URL found in the response body (e.g. its own
+   `documentation_url` field). Where: the three composables' 403 message
+   construction. Why: treating server response data as a link target risks
+   pointing the user at an attacker-controlled URL if the proxy or the upstream
+   response is ever tampered with (open-redirect / phishing vector).
+
+3. **Neutralize invisible/bidi control characters in the echoed GitHub text.**
+   What: before assigning GitHub's `message` text to the ref shown in the UI, strip
+   Unicode bidirectional-override and other non-printing control characters. This
+   is in addition to relying on Vue's default text-interpolation escaping (never
+   `v-html`) which business-specifications.md rule 2 already requires. Where: the
+   point in each composable where the extracted message text is stored for
+   display. Why: verbatim external text can visually reorder or hide what the user
+   reads (a "Trojan Source"-style spoofing attack) even when script injection is
+   already blocked by escaping.
+
+status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
@@ -140,6 +140,56 @@ the `mentions-legales.spec.ts` TC-05 precedent).
 was already failing against this branch's `AppLink.vue` change before this pass and is
 unaffected by today's fixes — it is not part of this task's `test-cases.md` and this command
 does not touch test files, so it is called out here rather than silently left for
-`/jli-runs-tests` to discover cold.
+`/jli-runs-tests` to discover cold. (Resolved by `/jli-writes-tests` in a later pass, which
+updated the assertion to `'noopener noreferrer'`.)
+
+## Loop-back fix: `test-results.md` Scenario 17 failure
+
+### Files changed
+
+- `src/components/OrgRestrictionNotice.vue` — the `ce`/`<AppLink>lien</AppLink>`/`pour` text
+  and link, previously each on their own template line, are joined onto one line
+  (`ce <AppLink ...>lien</AppLink> pour`).
+
+### Root cause
+
+Vue's compiler (default `whitespace: 'condense'`) fully removes a text node's boundary
+whitespace when that whitespace run contains a newline and sits directly against an element
+tag — it does not condense it to a single space the way it does for whitespace runs that
+stay within plain text. With `ce` and `pour` each on their own line around `<AppLink>`, the
+newline-adjacent-to-tag boundaries on both sides were stripped entirely, rendering
+`...visiter celienpour autoriser...` with no separating spaces — the bug
+`OrgRestrictionNotice.spec.ts`'s Scenario 17 (test-results.md) caught, since it asserts the
+exact fixed sentence from business-specifications.md rule 2.
+
+### Fix and why it's correct
+
+Putting `ce <AppLink ...>lien</AppLink> pour` on a single line means the whitespace on each
+side of the tag is a single space with no newline in it — condense mode preserves that as-is
+(only newline-containing boundary whitespace is dropped; a same-line space next to a tag is
+kept). The surrounding prose (`avec votre\n  compte`, `pour\n  autoriser`) is left wrapped
+across lines exactly as before, since interior newlines *within* a text run (not touching a
+tag boundary) already condensed correctly to a single space — that part of the rendering was
+never broken, and test-results.md's diff confirms the sentence up to `ce` and after `pour`
+was already correct.
+
+### Self-code review
+
+1. **Checked for a resulting double space.** `AppLink.vue` renders its slot content
+   (`<slot></slot>`) with no surrounding whitespace of its own, so joining `ce <AppLink>` and
+   `</AppLink> pour` on one line contributes exactly one space on each side of the link text
+   — not two. No change needed.
+2. **Checked the fix doesn't reintroduce the newline-adjacent-to-tag bug elsewhere in the
+   same file.** The template now has exactly one inline element (`AppLink`); both of its
+   surrounding boundaries were moved onto its own line, and no other tag boundary exists to
+   re-check.
+3. **Checked whether this fix could regress the "no GitHub response text" and "no `v-html`"
+   security guarantees (security-guidelines.md rule 2).** The change is purely whitespace
+   placement in static template text — no interpolation, binding, or `v-html` was touched. No
+   change needed.
+
+Same-pattern multi-line-around-inline-element templates elsewhere in the codebase (if any)
+are out of this task's scope (business-specifications.md lists no other files) and are not
+touched here.
 
 status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
@@ -10,8 +10,12 @@
   (security-guidelines.md rule 3).
 - `src/components/OrgRestrictionNotice.vue` (new) — renders the fixed French sentence
   (business-specifications.md rule 2) with the "lien" word as a real link, reusing the existing
-  `AppLink` component for the `target="_blank" rel="noopener"` new-tab behavior
+  `AppLink` component for the `target="_blank" rel="noopener noreferrer"` new-tab behavior
   (security-guidelines.md rule 4) instead of a one-off anchor.
+- `src/components/AppLink.vue` — `rel="noopener"` changed to `rel="noopener noreferrer"` on its
+  external-link branch (review-results.md finding), to literally satisfy security-guidelines.md
+  rule 4's stated requirement; this also tightens every other external link already using
+  `AppLink` (`AppFooter.vue`, `StationManager.vue`).
 - `src/composables/useRepoConfig.ts` — `classifyProxyResponse`/`checkProxyReachable` detect the
   org-restriction 403 as a boolean (`isOrgRestrictedResponse`, replacing the old
   message-extracting/sanitizing `extractOrgRestrictionMessage`); `resolveValidationError`
@@ -54,15 +58,15 @@
   by construction instead of by discipline. This follows the same small,
   single-purpose-message-component precedent already in the codebase (`EmptyStationsMessage.vue`).
 
-- **The link is rendered via the existing `AppLink` component, not a new one-off `<a>`.**
-  `AppLink` already implements exactly the required external-link behavior
-  (`target="_blank" rel="noopener"`, used elsewhere in `AppFooter.vue`/`StationManager.vue`), so
-  reusing it satisfies security-guidelines.md rule 4 by construction and avoids a second,
-  slightly different implementation of the same security-sensitive attribute pair. `AppLink`
-  uses `rel="noopener"` (not `noopener noreferrer`); `noopener` alone already fully closes the
-  `window.opener` reverse-tabnabbing vector security-guidelines.md rule 4 is about, so matching
-  this project's one established convention was chosen over introducing a second, inconsistent
-  external-link pattern for `noreferrer`'s purely-cosmetic (referrer-header) difference.
+- **The link is rendered via the existing `AppLink` component, not a new one-off `<a>`, and
+  `AppLink` itself was updated to add `noreferrer`.** review-results.md's first pass flagged
+  that `AppLink` only set `rel="noopener"`, while security-guidelines.md rule 4 explicitly
+  requires `rel="noopener noreferrer"` — `noopener` alone does close the `window.opener`
+  reverse-tabnabbing vector the rule's "Why" describes, but the rule's "What" is a literal,
+  specific requirement, not just "prevent reverse-tabnabbing by some means." Fixing `AppLink`
+  itself (rather than adding a one-off anchor just for this feature) satisfies the rule and
+  tightens every other external link already using it, instead of leaving the codebase with two
+  different external-link `rel` conventions.
 
 - **Each composable's error ref stays `string | OrgRestrictionNotice | null`, split into two
   typed computed refs inside the consuming component rather than in the composable.** This
@@ -98,5 +102,11 @@ Three issues were found and fixed while reviewing the new code:
    the established convention in this codebase (`splitOwnerRepo`, `buildProxyUrl`,
    `hasCompleteRepoConfig`) is already to duplicate such small per-file helpers rather than
    share them across these three composables — consistent, not a new pattern.
+
+Additionally, after the review's `rel` finding, checked whether `AppLink.vue`'s change to
+`noopener noreferrer` could regress anything: no `.spec.ts` file exists for `AppLink.vue`
+itself, and `src/pages/mentions-legales.spec.ts` (TC-05) already asserts external links
+elsewhere in this app carry `rel="noopener noreferrer"` — confirming `AppLink`'s prior
+`noopener`-only was the inconsistent outlier, not an established convention this change breaks.
 
 status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
@@ -1,99 +1,102 @@
 # Technical Specifications: Handle GitHub org OAuth restriction (403)
 
-## Why this file stops at "review specs" instead of code
+## Files changed
 
-Mid-implementation, the user redirected the message design (see conversation): instead of
-echoing GitHub's own 403 message text with a fixed generic docs link, the app should show one
-fixed French sentence with a link built from the user's own configured repo owner, opening in a
-new tab. This contradicts several rules already written into `business-specifications.md` and
-`security-guidelines.md`, and several scenarios in `test-cases.md` no longer describe the
-intended behavior. Rather than have `/jli-codes` silently rewrite those three files (owned by
-`/jli-writes-spec`, `/jli-verifies-security`, `/jli-writes-tests-spec`), this file records the
-fully-resolved design below so the spec-revision commands can transcribe it directly without
-re-asking the user anything.
+- `src/types/org-restriction-notice.ts` (new) — `OrgRestrictionNotice { owner: string }`, the
+  shape carried by `validationError`/`syncError`/`writeError` when the org-restriction case is
+  detected.
+- `src/utils/orgRestrictionNotice.ts` (new) — `buildOrgRestrictionSettingsUrl(owner)`, the pure
+  function that builds the percent-encoded per-organization settings-page URL
+  (security-guidelines.md rule 3).
+- `src/components/OrgRestrictionNotice.vue` (new) — renders the fixed French sentence
+  (business-specifications.md rule 2) with the "lien" word as a real link, reusing the existing
+  `AppLink` component for the `target="_blank" rel="noopener"` new-tab behavior
+  (security-guidelines.md rule 4) instead of a one-off anchor.
+- `src/composables/useRepoConfig.ts` — `classifyProxyResponse`/`checkProxyReachable` detect the
+  org-restriction 403 as a boolean (`isOrgRestrictedResponse`, replacing the old
+  message-extracting/sanitizing `extractOrgRestrictionMessage`); `resolveValidationError`
+  resolves it to `{ owner }` and skips the repo-level fallback, mirroring the 401 short-circuit.
+- `src/composables/useRemotePreferencesSync.ts` — `requestRemoteFile` throws
+  `RemoteOrgRestrictedError` (now carrying the owner, not GitHub's text) on an org-restricted
+  403; `handleFetchFailure` maps it to `{ owner }`.
+- `src/composables/useRemotePreferencesWrite.ts` — `fetchExistingFile` and `handlePutResponse`
+  (now taking `owner` as a parameter) both throw `RemoteWriteOrgRestrictedError` carrying the
+  owner; `handleWriteFailure` maps it to `{ owner }`.
+- `src/components/GitHubSyncSettings.vue`, `src/components/HomePageContent.vue` — each error ref
+  (`validationError`, `syncError`, `writeError`) is split into two local computed refs (plain
+  text vs. `OrgRestrictionNotice`) so the template renders either the existing `{{ }}`
+  interpolation or `<OrgRestrictionNotice :owner="..." />`, never a raw object.
 
-## Resolved design (confirmed with the user)
+## Non-trivial decisions
 
-1. **Message text is fixed and identical at all three call sites** (no more per-composable tone
-   variation, no more "your local data is kept" reassurance tied to this message):
+- **`ProxyCheckResult` reverts from a discriminated union back to a plain string union.** The
+  first pass (superseded) needed to carry GitHub's message text alongside the "orgRestricted"
+  outcome, which required a `{ kind: '...' }` shape. The redesign no longer displays any
+  response text — detection is now a pure boolean — so the payload-carrying reason for the
+  union no longer exists; the simpler `'ok' | 'notFound' | 'unauthorized' | 'orgRestricted' |
+  'error'` union is restored.
 
-   > Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec
-   > votre compte et le dépôt choisi. Veuillez visiter ce **lien** pour autoriser l'accès.
+- **The owner is threaded through as a plain function/error-constructor argument, not
+  re-derived from the response.** `useRepoConfig.ts`'s `resolveValidationError` already has
+  `ownerRepo` in scope at both the file-check and repo-check call sites, so building
+  `{ owner: ownerRepo.owner }` there needs no new plumbing. In the two remote-preferences
+  composables, `RemoteOrgRestrictedError`/`RemoteWriteOrgRestrictedError` carry the owner via
+  the standard `Error.message` property (mirroring the existing
+  `RemoteUnauthorizedError`/`RemoteWriteConflictError` pattern in both files) instead of a
+  custom field — `handlePutResponse` gained an `owner: string` parameter since it previously had
+  no access to `ownerRepo` (it only received the fetch `Response`).
 
-   (Typo fixed from the user's literal wording: "choisit" → "choisi" — the earlier occurrence
-   is the past participle modifying "dépôt", matching the second, already-correct occurrence in
-   the same sentence. Flagging this fix explicitly rather than silently carrying a typo into
-   product copy; revert in `/jli-writes-spec` if the exact literal string is wanted instead.)
+- **A new component (`OrgRestrictionNotice.vue`) owns both the fixed sentence and the link,
+  reused at all three render sites, rather than duplicating the sentence in each of the two
+  view components.** business-specifications.md rule 2 now requires the text to be identical
+  everywhere (unlike the old per-call-site tone), so centralizing it removes the risk of the
+  three copies drifting apart and satisfies test-cases.md scenario 22 (byte-identical output)
+  by construction instead of by discipline. This follows the same small,
+  single-purpose-message-component precedent already in the codebase (`EmptyStationsMessage.vue`).
 
-2. **GitHub's own 403 `message` body text is no longer displayed anywhere.** It is still read,
-   but only to *detect* the org-restriction case (does it contain `"OAuth App access
-   restrictions"`) — the extracted text itself is discarded, never interpolated into the
-   user-visible message. Consequence: the bidi/control-character stripping
-   (`sanitizeGitHubText`, `CONTROL_CHAR_CODE_RANGES`) built for the previous design has no
-   remaining purpose (there is no longer any GitHub-supplied text reaching the DOM) and should
-   be removed, not carried forward — dead code otherwise. The `ProxyCheckResult`-style
-   discriminated union (`{ kind: 'orgRestricted'; message: string }`) also reverts to needing no
-   payload: detection becomes a plain boolean check, so `useRepoConfig.ts`'s `ProxyCheckResult`
-   can revert to a plain string union (`'ok' | 'notFound' | 'unauthorized' | 'orgRestricted' |
-   'error'`) rather than the discriminated union added in the first pass — simpler, and the
-   original one-off need for a payload (carrying the message) no longer exists.
+- **The link is rendered via the existing `AppLink` component, not a new one-off `<a>`.**
+  `AppLink` already implements exactly the required external-link behavior
+  (`target="_blank" rel="noopener"`, used elsewhere in `AppFooter.vue`/`StationManager.vue`), so
+  reusing it satisfies security-guidelines.md rule 4 by construction and avoids a second,
+  slightly different implementation of the same security-sensitive attribute pair. `AppLink`
+  uses `rel="noopener"` (not `noopener noreferrer`); `noopener` alone already fully closes the
+  `window.opener` reverse-tabnabbing vector security-guidelines.md rule 4 is about, so matching
+  this project's one established convention was chosen over introducing a second, inconsistent
+  external-link pattern for `noreferrer`'s purely-cosmetic (referrer-header) difference.
 
-3. **The link is built from the user's own configured repo owner, never from the response
-   body**, as:
+- **Each composable's error ref stays `string | OrgRestrictionNotice | null`, split into two
+  typed computed refs inside the consuming component rather than in the composable.** This
+  keeps every composable's public return shape a single ref per error state (no API change
+  beyond the value type), and keeps the `typeof`-based narrowing (`'object'` vs `'string'`) a
+  template-adjacent concern local to each `.vue` file, since only one component consumes each
+  ref today.
 
-   ```
-   https://github.com/organizations/${encodeURIComponent(owner)}/settings/oauth_application_policy
-   ```
+- **`buildOrgRestrictionSettingsUrl` percent-encodes the owner even though GitHub logins are
+  alphanumeric-and-hyphen only today** (security-guidelines.md rule 3) — defensive, not
+  currently reachable by any input this app accepts, but building a URL by concatenating
+  unencoded input is the kind of pattern that becomes a bug the day that assumption changes.
 
-   `owner` is the same value already extracted by each composable's existing `splitOwnerRepo`
-   (the user's own Settings input, already validated as non-empty and free of `/`) — not
-   anything read from GitHub's response. `encodeURIComponent` is applied defensively even though
-   GitHub org/user logins are alphanumeric-and-hyphen only, because building a URL by
-   concatenating any external-ish string without encoding is the kind of pattern that becomes a
-   bug the day that assumption changes.
+## Self-code review
 
-   This is a *narrower*, not weaker, version of the original security rule ("never
-   response-derived"): the org-restriction feature can only ever fire for the org the user
-   themselves is already configured against, so linking to that org's own OAuth policy page is
-   exactly the actionable page. It must still never read `documentation_url` or any other
-   response field.
+Three issues were found and fixed while reviewing the new code:
 
-4. **The link renders as a real `<a>` element**, `target="_blank" rel="noopener noreferrer"` —
-   not markdown brackets, and not plain interpolated text. `rel="noopener noreferrer"` is
-   required alongside `target="_blank"` to prevent the opened GitHub tab from getting a `window
-   .opener` reference back to this app (reverse-tabnabbing) — this becomes a new
-   security-guidelines.md rule, replacing the now-moot bidi-stripping rule.
+1. **`typeof x === 'object'` narrowing double-checked against `null`.** Since
+   `typeof null === 'object'` in JavaScript, `typeof validationError.value === 'object' ?
+   validationError.value : null` needed verifying it still resolves correctly when the ref is
+   `null` — it does, because the true-branch's value *is* `validationError.value`, which is
+   `null` in that case, so the computed still yields `null` either way. Confirmed correct, no
+   change needed, but left as a note here since it's non-obvious.
+2. **`handlePutResponse` was missing `ownerRepo` in scope.** Unlike `fetchExistingFile` (which
+   receives `ownerRepo` directly), `handlePutResponse` previously only received the `Response`.
+   Added an explicit `owner: string` parameter (passed as `ownerRepo.owner` from its one call
+   site in `putRemoteFile`) rather than threading the whole `OwnerRepo` object through, since
+   only the owner is ever needed here.
+3. **Redundant `ORG_RESTRICTION_INDICATOR`/`isOrgRestrictedResponse` duplication across all
+   three composables was reconsidered and kept as-is.** Extracting it to a shared util would
+   remove three small, identical functions, but business-specifications.md's Scope section
+   still lists only these three composables with "no new files" for that specific concern, and
+   the established convention in this codebase (`splitOwnerRepo`, `buildProxyUrl`,
+   `hasCompleteRepoConfig`) is already to duplicate such small per-file helpers rather than
+   share them across these three composables — consistent, not a new pattern.
 
-5. **New shared type + component needed** (type-first per CLAUDE.md): a `UserMessage` type
-   (`string | { textBefore: string; linkLabel: string; linkUrl: string; textAfter: string }`) in
-   `src/types/`, and a small presentational component (e.g. `MessageWithLink.vue`) that renders
-   either the plain string or the three-part text+link+text, so the link-rendering logic isn't
-   tripled across `GitHubSyncSettings.vue` (`validationError`) and `HomePageContent.vue`
-   (`syncError`, `writeError`). This is a new file, which the original business spec's "no new
-   files" scope note no longer holds against — that note was about the three composables, not
-   about needing zero new files ever; a shared render helper for a genuinely new UI need (a
-   real link, not plain text) is a reasonable, minimal addition rather than tripled duplication.
-
-## What needs to change in the other spec files (for `/jli-writes-spec` etc.)
-
-- `business-specifications.md` rule 2: replace "include GitHub's own explanatory text" with the
-  fixed sentence above; replace the generic docs URL with the per-owner
-  `oauth_application_policy` URL.
-- `business-specifications.md` rule 3: delete or rewrite — message is now identical at all three
-  call sites, so "each keeps its own style" no longer applies to this specific message.
-- `security-guidelines.md` rule 2: rewrite from "hardcoded literal" to "built only from the
-  user's own configured owner, `encodeURIComponent`-escaped, never from the response body."
-- `security-guidelines.md` rule 3: replace bidi/control-char stripping with the
-  `rel="noopener noreferrer"` requirement for the new `target="_blank"` link.
-- `test-cases.md` 17–21: rewrite to match — fixed sentence + owner-derived link (17), link never
-  derived from `documentation_url` even when present (18), real anchor with
-  `target="_blank" rel="noopener noreferrer"` (19), no GitHub response text of any kind reaches
-  the rendered output even if it contains HTML/bidi/control characters (20, strengthened from
-  "stripped" to "never included"), identical message byte-for-byte at all three call sites (21,
-  reversed from "distinct tone" to "consistency guard").
-
-### Specifications Need Review
-
-Please review current code and results.
-
-status: review specs
+status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
@@ -1,0 +1,83 @@
+# Technical Specifications: Handle GitHub org OAuth restriction (403)
+
+## Files changed
+
+- `src/composables/useRepoConfig.ts` — `classifyProxyResponse`/`checkProxyReachable` now read the
+  403 response body to detect GitHub's org-OAuth-restriction case; `resolveValidationError` resolves
+  it to a distinct message and skips the repo-level fallback, mirroring the existing 401 short-circuit.
+- `src/composables/useRemotePreferencesSync.ts` — `requestRemoteFile` throws a new
+  `RemoteOrgRestrictedError` on an org-restricted 403; `handleFetchFailure` maps it to a distinct
+  `syncError` message.
+- `src/composables/useRemotePreferencesWrite.ts` — `fetchExistingFile` and `handlePutResponse` both
+  throw a new `RemoteWriteOrgRestrictedError` on an org-restricted 403; `handleWriteFailure` maps it
+  to a distinct `writeError` message with the same "your local data is kept" reassurance this
+  composable's other failure messages already use.
+
+No new files were created and `netlify/functions/github-api-proxy.ts` is unchanged, per the task's
+scope.
+
+## Non-trivial decisions
+
+- **`ProxyCheckResult` becomes a discriminated union, not a string enum.** Detecting the
+  org-restriction case requires reading the 403 response body, so the org-restricted branch must
+  carry the extracted message alongside its outcome. A plain string union (`'orgRestricted'`) would
+  have nowhere to put that payload, so each variant became `{ kind: '...' }`, with `orgRestricted`
+  adding a `message` field. This changed `classifyProxyResponse` from a sync `(status: number)`
+  function into an async `(response: Response)` function, since detecting the reason now requires
+  awaiting `response.json()`.
+
+- **Detection, sanitization, and the docs-link constant are duplicated per composable, not
+  extracted to a shared util.** The task's scope explicitly lists these three files with "no new
+  files." The existing code in all three files already duplicates small helpers this way
+  (`splitOwnerRepo`, `buildProxyUrl`, `hasCompleteRepoConfig`), so this follows the file's own
+  established convention rather than introducing a new one.
+
+- **The org-restriction 403 body is read via a small `extractOrgRestrictionMessage(response)`
+  helper, wrapped in try/catch (security-guidelines.md rule 1).** Any parse failure or unexpected
+  shape resolves to `null`, which every call site treats as "not the org-restriction case" and
+  falls through to that call site's existing generic-failure message — never an uncaught throw.
+
+- **The restriction-docs link and indicator string are hardcoded string constants
+  (`ORG_RESTRICTION_DOCS_URL`, `ORG_RESTRICTION_INDICATOR`), never read from the response body's
+  own `documentation_url` field** (security-guidelines.md rule 2) — this is what test case 18
+  checks for.
+
+- **New error classes (`RemoteOrgRestrictedError`, `RemoteWriteOrgRestrictedError`) carry the
+  sanitized GitHub message via the standard `Error.message` property**, rather than a custom field.
+  This mirrors the existing `RemoteUnauthorizedError`/`RemoteWriteConflictError` pattern in both
+  files exactly, so `handleFetchFailure`/`handleWriteFailure` stay a flat `instanceof` chain instead
+  of introducing a second way to carry error payloads.
+
+- **Bidi/control-character stripping is built from numeric Unicode code points
+  (`CONTROL_CHAR_CODE_RANGES` + `String.fromCharCode`), not typed as literal characters or `\u`
+  escape sequences in the regex source.** This keeps the source file itself free of the exact
+  invisible/bidi characters security-guidelines.md rule 3 defends against, which is easier to audit
+  than a regex literal containing invisible bytes. The regex is built once at module load (not per
+  call), so there's no repeated-compilation cost per sanitize call.
+
+- **Each composable phrases its org-restriction message in its own style**
+  (business-specifications.md rule 3 / test case 21): `useRepoConfig.ts`'s Settings-save message has
+  no "local data" reassurance (saving always persists to IndexedDB regardless of auth, per that
+  file's own doc comment); `useRemotePreferencesSync.ts` says "vos données locales sont
+  utilisées" (matching its sibling `ACCESS_REVOKED_MESSAGE`); `useRemotePreferencesWrite.ts` says
+  "vos données locales sont conservées" (matching its sibling `WRITE_FAILED_MESSAGE`/
+  `INVALID_REMOTE_CONTENT_MESSAGE`). All three still independently satisfy test case 17's content
+  requirement (states the org-OAuth-restriction, includes GitHub's text, links to the fixed URL).
+
+## Self-code review
+
+Two issues were found and fixed while reviewing the new sanitization/detection code:
+
+1. **Missing BOM in the stripped character ranges.** U+FEFF (byte-order mark / zero-width
+   no-break space) is another invisible character usable in spoofing, not covered by the initial
+   range list. Added `[0xfeff, 0xfeff]` to `CONTROL_CHAR_CODE_RANGES` in all three files.
+2. **No trim after stripping control characters.** If GitHub's message had leading/trailing
+   invisible characters, stripping them could leave stray whitespace in the composed message.
+   `sanitizeGitHubText` now trims the result after stripping.
+
+One additional risk was checked and confirmed safe rather than changed: reusing a single
+module-level global (`/g`) `RegExp` object across repeated `sanitizeGitHubText` calls could in
+principle leak `lastIndex` state between calls — but `String.prototype.replace` resets `lastIndex`
+to 0 itself when the regex is global, so the shared compiled pattern is safe to reuse as written.
+
+status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
@@ -1,83 +1,99 @@
 # Technical Specifications: Handle GitHub org OAuth restriction (403)
 
-## Files changed
+## Why this file stops at "review specs" instead of code
 
-- `src/composables/useRepoConfig.ts` — `classifyProxyResponse`/`checkProxyReachable` now read the
-  403 response body to detect GitHub's org-OAuth-restriction case; `resolveValidationError` resolves
-  it to a distinct message and skips the repo-level fallback, mirroring the existing 401 short-circuit.
-- `src/composables/useRemotePreferencesSync.ts` — `requestRemoteFile` throws a new
-  `RemoteOrgRestrictedError` on an org-restricted 403; `handleFetchFailure` maps it to a distinct
-  `syncError` message.
-- `src/composables/useRemotePreferencesWrite.ts` — `fetchExistingFile` and `handlePutResponse` both
-  throw a new `RemoteWriteOrgRestrictedError` on an org-restricted 403; `handleWriteFailure` maps it
-  to a distinct `writeError` message with the same "your local data is kept" reassurance this
-  composable's other failure messages already use.
+Mid-implementation, the user redirected the message design (see conversation): instead of
+echoing GitHub's own 403 message text with a fixed generic docs link, the app should show one
+fixed French sentence with a link built from the user's own configured repo owner, opening in a
+new tab. This contradicts several rules already written into `business-specifications.md` and
+`security-guidelines.md`, and several scenarios in `test-cases.md` no longer describe the
+intended behavior. Rather than have `/jli-codes` silently rewrite those three files (owned by
+`/jli-writes-spec`, `/jli-verifies-security`, `/jli-writes-tests-spec`), this file records the
+fully-resolved design below so the spec-revision commands can transcribe it directly without
+re-asking the user anything.
 
-No new files were created and `netlify/functions/github-api-proxy.ts` is unchanged, per the task's
-scope.
+## Resolved design (confirmed with the user)
 
-## Non-trivial decisions
+1. **Message text is fixed and identical at all three call sites** (no more per-composable tone
+   variation, no more "your local data is kept" reassurance tied to this message):
 
-- **`ProxyCheckResult` becomes a discriminated union, not a string enum.** Detecting the
-  org-restriction case requires reading the 403 response body, so the org-restricted branch must
-  carry the extracted message alongside its outcome. A plain string union (`'orgRestricted'`) would
-  have nowhere to put that payload, so each variant became `{ kind: '...' }`, with `orgRestricted`
-  adding a `message` field. This changed `classifyProxyResponse` from a sync `(status: number)`
-  function into an async `(response: Response)` function, since detecting the reason now requires
-  awaiting `response.json()`.
+   > Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec
+   > votre compte et le dépôt choisi. Veuillez visiter ce **lien** pour autoriser l'accès.
 
-- **Detection, sanitization, and the docs-link constant are duplicated per composable, not
-  extracted to a shared util.** The task's scope explicitly lists these three files with "no new
-  files." The existing code in all three files already duplicates small helpers this way
-  (`splitOwnerRepo`, `buildProxyUrl`, `hasCompleteRepoConfig`), so this follows the file's own
-  established convention rather than introducing a new one.
+   (Typo fixed from the user's literal wording: "choisit" → "choisi" — the earlier occurrence
+   is the past participle modifying "dépôt", matching the second, already-correct occurrence in
+   the same sentence. Flagging this fix explicitly rather than silently carrying a typo into
+   product copy; revert in `/jli-writes-spec` if the exact literal string is wanted instead.)
 
-- **The org-restriction 403 body is read via a small `extractOrgRestrictionMessage(response)`
-  helper, wrapped in try/catch (security-guidelines.md rule 1).** Any parse failure or unexpected
-  shape resolves to `null`, which every call site treats as "not the org-restriction case" and
-  falls through to that call site's existing generic-failure message — never an uncaught throw.
+2. **GitHub's own 403 `message` body text is no longer displayed anywhere.** It is still read,
+   but only to *detect* the org-restriction case (does it contain `"OAuth App access
+   restrictions"`) — the extracted text itself is discarded, never interpolated into the
+   user-visible message. Consequence: the bidi/control-character stripping
+   (`sanitizeGitHubText`, `CONTROL_CHAR_CODE_RANGES`) built for the previous design has no
+   remaining purpose (there is no longer any GitHub-supplied text reaching the DOM) and should
+   be removed, not carried forward — dead code otherwise. The `ProxyCheckResult`-style
+   discriminated union (`{ kind: 'orgRestricted'; message: string }`) also reverts to needing no
+   payload: detection becomes a plain boolean check, so `useRepoConfig.ts`'s `ProxyCheckResult`
+   can revert to a plain string union (`'ok' | 'notFound' | 'unauthorized' | 'orgRestricted' |
+   'error'`) rather than the discriminated union added in the first pass — simpler, and the
+   original one-off need for a payload (carrying the message) no longer exists.
 
-- **The restriction-docs link and indicator string are hardcoded string constants
-  (`ORG_RESTRICTION_DOCS_URL`, `ORG_RESTRICTION_INDICATOR`), never read from the response body's
-  own `documentation_url` field** (security-guidelines.md rule 2) — this is what test case 18
-  checks for.
+3. **The link is built from the user's own configured repo owner, never from the response
+   body**, as:
 
-- **New error classes (`RemoteOrgRestrictedError`, `RemoteWriteOrgRestrictedError`) carry the
-  sanitized GitHub message via the standard `Error.message` property**, rather than a custom field.
-  This mirrors the existing `RemoteUnauthorizedError`/`RemoteWriteConflictError` pattern in both
-  files exactly, so `handleFetchFailure`/`handleWriteFailure` stay a flat `instanceof` chain instead
-  of introducing a second way to carry error payloads.
+   ```
+   https://github.com/organizations/${encodeURIComponent(owner)}/settings/oauth_application_policy
+   ```
 
-- **Bidi/control-character stripping is built from numeric Unicode code points
-  (`CONTROL_CHAR_CODE_RANGES` + `String.fromCharCode`), not typed as literal characters or `\u`
-  escape sequences in the regex source.** This keeps the source file itself free of the exact
-  invisible/bidi characters security-guidelines.md rule 3 defends against, which is easier to audit
-  than a regex literal containing invisible bytes. The regex is built once at module load (not per
-  call), so there's no repeated-compilation cost per sanitize call.
+   `owner` is the same value already extracted by each composable's existing `splitOwnerRepo`
+   (the user's own Settings input, already validated as non-empty and free of `/`) — not
+   anything read from GitHub's response. `encodeURIComponent` is applied defensively even though
+   GitHub org/user logins are alphanumeric-and-hyphen only, because building a URL by
+   concatenating any external-ish string without encoding is the kind of pattern that becomes a
+   bug the day that assumption changes.
 
-- **Each composable phrases its org-restriction message in its own style**
-  (business-specifications.md rule 3 / test case 21): `useRepoConfig.ts`'s Settings-save message has
-  no "local data" reassurance (saving always persists to IndexedDB regardless of auth, per that
-  file's own doc comment); `useRemotePreferencesSync.ts` says "vos données locales sont
-  utilisées" (matching its sibling `ACCESS_REVOKED_MESSAGE`); `useRemotePreferencesWrite.ts` says
-  "vos données locales sont conservées" (matching its sibling `WRITE_FAILED_MESSAGE`/
-  `INVALID_REMOTE_CONTENT_MESSAGE`). All three still independently satisfy test case 17's content
-  requirement (states the org-OAuth-restriction, includes GitHub's text, links to the fixed URL).
+   This is a *narrower*, not weaker, version of the original security rule ("never
+   response-derived"): the org-restriction feature can only ever fire for the org the user
+   themselves is already configured against, so linking to that org's own OAuth policy page is
+   exactly the actionable page. It must still never read `documentation_url` or any other
+   response field.
 
-## Self-code review
+4. **The link renders as a real `<a>` element**, `target="_blank" rel="noopener noreferrer"` —
+   not markdown brackets, and not plain interpolated text. `rel="noopener noreferrer"` is
+   required alongside `target="_blank"` to prevent the opened GitHub tab from getting a `window
+   .opener` reference back to this app (reverse-tabnabbing) — this becomes a new
+   security-guidelines.md rule, replacing the now-moot bidi-stripping rule.
 
-Two issues were found and fixed while reviewing the new sanitization/detection code:
+5. **New shared type + component needed** (type-first per CLAUDE.md): a `UserMessage` type
+   (`string | { textBefore: string; linkLabel: string; linkUrl: string; textAfter: string }`) in
+   `src/types/`, and a small presentational component (e.g. `MessageWithLink.vue`) that renders
+   either the plain string or the three-part text+link+text, so the link-rendering logic isn't
+   tripled across `GitHubSyncSettings.vue` (`validationError`) and `HomePageContent.vue`
+   (`syncError`, `writeError`). This is a new file, which the original business spec's "no new
+   files" scope note no longer holds against — that note was about the three composables, not
+   about needing zero new files ever; a shared render helper for a genuinely new UI need (a
+   real link, not plain text) is a reasonable, minimal addition rather than tripled duplication.
 
-1. **Missing BOM in the stripped character ranges.** U+FEFF (byte-order mark / zero-width
-   no-break space) is another invisible character usable in spoofing, not covered by the initial
-   range list. Added `[0xfeff, 0xfeff]` to `CONTROL_CHAR_CODE_RANGES` in all three files.
-2. **No trim after stripping control characters.** If GitHub's message had leading/trailing
-   invisible characters, stripping them could leave stray whitespace in the composed message.
-   `sanitizeGitHubText` now trims the result after stripping.
+## What needs to change in the other spec files (for `/jli-writes-spec` etc.)
 
-One additional risk was checked and confirmed safe rather than changed: reusing a single
-module-level global (`/g`) `RegExp` object across repeated `sanitizeGitHubText` calls could in
-principle leak `lastIndex` state between calls — but `String.prototype.replace` resets `lastIndex`
-to 0 itself when the regex is global, so the shared compiled pattern is safe to reuse as written.
+- `business-specifications.md` rule 2: replace "include GitHub's own explanatory text" with the
+  fixed sentence above; replace the generic docs URL with the per-owner
+  `oauth_application_policy` URL.
+- `business-specifications.md` rule 3: delete or rewrite — message is now identical at all three
+  call sites, so "each keeps its own style" no longer applies to this specific message.
+- `security-guidelines.md` rule 2: rewrite from "hardcoded literal" to "built only from the
+  user's own configured owner, `encodeURIComponent`-escaped, never from the response body."
+- `security-guidelines.md` rule 3: replace bidi/control-char stripping with the
+  `rel="noopener noreferrer"` requirement for the new `target="_blank"` link.
+- `test-cases.md` 17–21: rewrite to match — fixed sentence + owner-derived link (17), link never
+  derived from `documentation_url` even when present (18), real anchor with
+  `target="_blank" rel="noopener noreferrer"` (19), no GitHub response text of any kind reaches
+  the rendered output even if it contains HTML/bidi/control characters (20, strengthened from
+  "stripped" to "never included"), identical message byte-for-byte at all three call sites (21,
+  reversed from "distinct tone" to "consistency guard").
 
-status: ready
+### Specifications Need Review
+
+Please review current code and results.
+
+status: review specs

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/technical-specifications.md
@@ -16,6 +16,12 @@
   external-link branch (review-results.md finding), to literally satisfy security-guidelines.md
   rule 4's stated requirement; this also tightens every other external link already using
   `AppLink` (`AppFooter.vue`, `StationManager.vue`).
+- `src/components/StationManager.vue` — its `AppLink` usage changed from
+  `href="..." target="_blank" rel="noopener"` to `to="..."` (review-results.md second-pass
+  finding). See "Non-trivial decisions" below.
+- `src/components/OrgRestrictionNotice.vue` — doc comment corrected from `rel="noopener"` to
+  `rel="noopener noreferrer"` (review-results.md second-pass finding), matching the `AppLink.vue`
+  fix above so the comment doesn't restate the claim the first review round rejected.
 - `src/composables/useRepoConfig.ts` — `classifyProxyResponse`/`checkProxyReachable` detect the
   org-restriction 403 as a boolean (`isOrgRestrictedResponse`, replacing the old
   message-extracting/sanitizing `extractOrgRestrictionMessage`); `resolveValidationError`
@@ -80,6 +86,20 @@
   currently reachable by any input this app accepts, but building a URL by concatenating
   unencoded input is the kind of pattern that becomes a bug the day that assumption changes.
 
+- **`StationManager.vue`'s `AppLink` usage was switched from `href`/`target`/`rel` attributes to
+  the `to` prop, instead of just dropping the redundant `rel`.** review-results.md's second-pass
+  finding was that this call site's own `rel="noopener"` attribute overrides `AppLink`'s internal
+  `rel="noopener noreferrer"` via Vue's fallthrough-attribute merge, so the `AppLink.vue` fix
+  above wasn't actually reaching this link. Investigating why revealed a deeper pre-existing
+  issue: `AppLink`'s `isExternal` check (`typeof to === 'string' && to.startsWith('http')`) only
+  fires off the `to` prop, not `href` — this call site passed `href`, so it was never taking the
+  external-link branch at all, and was falling through to `AppLink`'s `router-link` branch (only
+  still working as an external link by accident, because Vue Router skips its click-interception
+  for anchors carrying `target="_blank"`). Passing `to` instead of `href`/`target`/`rel` fixes
+  both problems at once: it takes the intended external-link branch, which supplies
+  `target="_blank" rel="noopener noreferrer"` itself, so no per-call-site `rel` can shadow it
+  again.
+
 ## Self-code review
 
 Three issues were found and fixed while reviewing the new code:
@@ -108,5 +128,18 @@ Additionally, after the review's `rel` finding, checked whether `AppLink.vue`'s 
 itself, and `src/pages/mentions-legales.spec.ts` (TC-05) already asserts external links
 elsewhere in this app carry `rel="noopener noreferrer"` — confirming `AppLink`'s prior
 `noopener`-only was the inconsistent outlier, not an established convention this change breaks.
+That check missed `src/components/layout/AppFooter.test.ts:90-96`, which does assert the old
+`rel="noopener"` value for `AppFooter.vue`'s `AppLink`-rendered links and will now fail — this
+is a `.test.ts` file, so per this command's rules it is not edited here; per user direction it
+is left for `/jli-writes-tests` to update (expected new value: `'noopener noreferrer'`, matching
+the `mentions-legales.spec.ts` TC-05 precedent).
+
+### Known follow-up: pre-existing test needs updating
+
+`src/components/layout/AppFooter.test.ts:90-96` (`it('all links have rel="noopener"', ...)`)
+was already failing against this branch's `AppLink.vue` change before this pass and is
+unaffected by today's fixes — it is not part of this task's `test-cases.md` and this command
+does not touch test files, so it is called out here rather than silently left for
+`/jli-runs-tests` to discover cold.
 
 status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-cases.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-cases.md
@@ -46,10 +46,11 @@
 
 12. Given an authenticated push with a complete repo config, when the check for
     an existing remote file returns 403 with an org-restriction body, then the
-    write error shown is the distinct org-restriction message, phrased with the
-    same "your local data is kept" reassurance this composable's other write
-    failures already use — not the generic write-failed message and not the
-    re-authentication message.
+    write error shown is the fixed org-restriction message (scenario 17) —
+    not the generic write-failed message, not the re-authentication message,
+    and without the "your local data is kept" reassurance this composable's
+    other write failures use (this message does not vary by call site, per
+    business-specifications.md rule 2).
 13. Given the same setup, when the existing-file check returns 403 with a body
     that does not indicate an org restriction, then the write error is the
     existing generic write-failed message, unchanged from today.
@@ -65,25 +66,30 @@
 ## Shared message content and safety (all three call sites)
 
 17. Given a detected org-restriction 403, when the message is shown to the user,
-    then it states that the organization restricts data access for third-party
-    OAuth Apps, includes GitHub's own explanatory text from the response body,
-    and links to `https://docs.github.com/articles/restricting-access-to-your-organization-s-data/`.
-18. Given a 403 response whose body's own `documentation_url` field differs from
-    the restriction-docs URL, when the org-restriction message is shown, then
-    the link always points to the fixed restriction-docs URL — never to the
+    then it is exactly the fixed sentence "Le dépôt choisi se trouve sous une
+    organisation n'autorisant pas l'authentification avec votre compte et le
+    dépôt choisi. Veuillez visiter ce lien pour autoriser l'accès." with "lien"
+    rendered as a clickable link — none of GitHub's own response text appears.
+18. Given the repo owner configured in Settings is, for example, `acme-corp`,
+    when the org-restriction message's link is inspected, then it points to the
+    OAuth App access settings page for the `acme-corp` organization specifically
+    — not any other organization, and not a generic GitHub docs page.
+19. Given a 403 response whose body's own `documentation_url` field points to an
+    unrelated page, when the org-restriction message's link is shown, then it
+    still points to the configured owner's own settings page — never to the
     value from the response body.
-19. Given an org-restriction body whose message text contains characters that
-    would normally be interpreted as HTML (e.g. angle brackets), when it is
-    displayed, then those characters appear as literal text on the page and are
-    not rendered as markup.
-20. Given an org-restriction body whose message text contains invisible
-    Unicode bidirectional-override or other non-printing control characters,
-    when it is displayed, then those characters are absent from the rendered
-    text and the visible text reads in a stable, non-reordered order.
-21. Given the same org-restriction condition occurring at each of the three call
-    sites, when their messages are compared, then each is worded in that call
-    site's own existing style (matching how its other error messages already
-    differ from one another), while each still independently satisfies scenario
-    17's content requirement.
+20. Given an org-restriction body whose `message` field contains arbitrary text
+    (including characters that would normally be interpreted as HTML, or
+    invisible Unicode bidirectional-override/control characters), when the
+    message is displayed, then none of that response text appears anywhere in
+    the rendered message — only the fixed sentence and the owner's own link are
+    shown.
+21. Given the org-restriction message's link, when the user activates it, then
+    GitHub's settings page opens in a new browser tab and the app's own
+    page/state is left unchanged (the user is not navigated away from the app).
+22. Given the same org-restriction condition occurring at each of the three call
+    sites for the same configured owner, when their messages are compared, then
+    all three are identical (regression guard — unlike the app's other failure
+    messages, this one does not vary by call site).
 
 status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-cases.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-cases.md
@@ -1,0 +1,89 @@
+# Test Cases: Handle GitHub org OAuth restriction (403)
+
+## Settings save — repo/file-path reachability check (`useRepoConfig.ts`)
+
+1. Given a valid repo/file path, when the file-path check returns 403 with a body
+   indicating GitHub's OAuth App organization restriction, then the validation
+   error shown to the user is the distinct org-restriction message — and the
+   repo-level fallback check that normally runs after a non-ok, non-401, non-404
+   result is skipped (mirrors how a 401 already short-circuits).
+2. Given the same setup, when the file-path check returns 403 with a body that
+   does not indicate an org restriction (e.g. a rate-limit message), then the
+   validation error is the existing generic "impossible de vérifier" message,
+   unchanged from today.
+3. Given the same setup, when the file-path check returns 403 with a body that
+   isn't valid JSON (or has no readable `message`), then the validation error
+   falls back to the existing generic message and no unhandled error is thrown.
+4. Given a file-path check that returns 404 (falls through to the repo-level
+   check, as today), when that repo-level check then returns 403 with an
+   org-restriction body, then the validation error is the distinct
+   org-restriction message.
+5. Given a file-path check that returns 401, when validation runs, then the
+   result is unchanged: the existing session-expired message (regression guard —
+   this feature adds no new branch for 401).
+6. Given a file-path check that returns 404, when validation runs, then it still
+   falls through to the repo-level check exactly as before (regression guard).
+7. Given a file-path check that returns 200, when validation runs, then there is
+   no validation error (regression guard).
+
+## App-load read (`useRemotePreferencesSync.ts`)
+
+8. Given a stale local cache and a complete repo config, when the remote-file
+   fetch returns 403 with an org-restriction body, then the sync error shown is
+   the distinct org-restriction message — not the generic fetch-failed message
+   and not the re-authentication message — and the locally stored preferences
+   are left untouched.
+9. Given the same setup, when the remote-file fetch returns 403 with a body that
+   does not indicate an org restriction, then the sync error is the existing
+   generic fetch-failed message, unchanged from today.
+10. Given the same setup, when the remote-file fetch returns 401, then the sync
+    error is the existing access-revoked message (regression guard).
+11. Given the same setup, when the remote-file fetch returns 200 with a valid
+    file, then the remote preferences are applied normally with no sync error
+    (regression guard).
+
+## Preferences push — read-before-write and final write (`useRemotePreferencesWrite.ts`)
+
+12. Given an authenticated push with a complete repo config, when the check for
+    an existing remote file returns 403 with an org-restriction body, then the
+    write error shown is the distinct org-restriction message, phrased with the
+    same "your local data is kept" reassurance this composable's other write
+    failures already use — not the generic write-failed message and not the
+    re-authentication message.
+13. Given the same setup, when the existing-file check returns 403 with a body
+    that does not indicate an org restriction, then the write error is the
+    existing generic write-failed message, unchanged from today.
+14. Given the existing-file check succeeded and the user confirmed the write,
+    when the final PUT returns 403 with an org-restriction body, then the write
+    error shown is the same distinct org-restriction message.
+15. Given the same confirmed-write setup, when the final PUT returns 401, then
+    the write error is the existing re-authentication message (regression
+    guard).
+16. Given the same confirmed-write setup, when the final PUT returns 409, then
+    the write error is the existing conflict message (regression guard).
+
+## Shared message content and safety (all three call sites)
+
+17. Given a detected org-restriction 403, when the message is shown to the user,
+    then it states that the organization restricts data access for third-party
+    OAuth Apps, includes GitHub's own explanatory text from the response body,
+    and links to `https://docs.github.com/articles/restricting-access-to-your-organization-s-data/`.
+18. Given a 403 response whose body's own `documentation_url` field differs from
+    the restriction-docs URL, when the org-restriction message is shown, then
+    the link always points to the fixed restriction-docs URL — never to the
+    value from the response body.
+19. Given an org-restriction body whose message text contains characters that
+    would normally be interpreted as HTML (e.g. angle brackets), when it is
+    displayed, then those characters appear as literal text on the page and are
+    not rendered as markup.
+20. Given an org-restriction body whose message text contains invisible
+    Unicode bidirectional-override or other non-printing control characters,
+    when it is displayed, then those characters are absent from the rendered
+    text and the visible text reads in a stable, non-reordered order.
+21. Given the same org-restriction condition occurring at each of the three call
+    sites, when their messages are compared, then each is worded in that call
+    site's own existing style (matching how its other error messages already
+    differ from one another), while each still independently satisfies scenario
+    17's content requirement.
+
+status: ready

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-results.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-results.md
@@ -11,40 +11,12 @@ All those mentioned in [technical specs](technical-specifications.md).
 
 ## Results
 
-### Failures
-
-**File:** `src/components/OrgRestrictionNotice.spec.ts`
-**Test:** Scenario 17: the message is exactly the fixed sentence, "lien" rendered as a
-clickable link > renders the fixed sentence verbatim, with a real `<a>` link whose text is
-"lien"
-
-```
-AssertionError: expected 'Le dépôt choisi se trouve sous une or…' to be 'Le dépôt choisi se trouve sous une or…' // Object.is equality
-
-Expected: "Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre compte et le dépôt choisi. Veuillez visiter ce lien pour autoriser l'accès."
-Received: "Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre compte et le dépôt choisi. Veuillez visiter celienpour autoriser l'accès."
-
-    at src/components/OrgRestrictionNotice.spec.ts:40:56
-```
-
-**Root cause:** `OrgRestrictionNotice.vue`'s template places `ce`, `<AppLink>lien</AppLink>`,
-and `pour` on separate lines. Vue's default whitespace-condense compilation drops the
-whitespace-only text nodes between text and an adjacent inline element when that whitespace
-spans a newline, rather than collapsing them to a single space. The compiled render function
-therefore emits no space character at all around the link — this reproduces identically in a
-real browser, not just in this test's happy-dom environment. The rendered sentence reads
-`...Veuillez visiter celienpour autoriser l'accès.` at all three call sites that reuse this
-component (Settings validation error, sync error banner, write error banner), violating
-business-specifications.md rule 2's "exactly the fixed sentence" requirement.
+All tests passed. No failures.
 
 ### Test Summary
 
-409 test files, 484 tests total — 1 failed.
+409 test files, 484 tests total — all passed.
 
-- Test files: 407 passed, 1 failed (`numFailedTestSuites` reported 2, but only one file
-  (`OrgRestrictionNotice.spec.ts`) actually contains a failing assertion — the other count
-  appears to be a Vitest JSON-reporter aggregation artifact, not a second failure)
-- Tests: 483 passed, 1 failed
-- Duration: ~9 seconds
+- Duration: ~21 seconds
 
-status: failed
+status: passed

--- a/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-results.md
+++ b/docs/prompts/tasks/issue-108-github-oauth-403-handling/test-results.md
@@ -1,0 +1,50 @@
+# Test Results — Issue #108: Handle GitHub org OAuth restriction (403) with actionable message
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.0) from the
+`french-gas-stations-scraper_fix-github-oauth-403-handling` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md).
+
+## Results
+
+### Failures
+
+**File:** `src/components/OrgRestrictionNotice.spec.ts`
+**Test:** Scenario 17: the message is exactly the fixed sentence, "lien" rendered as a
+clickable link > renders the fixed sentence verbatim, with a real `<a>` link whose text is
+"lien"
+
+```
+AssertionError: expected 'Le dépôt choisi se trouve sous une or…' to be 'Le dépôt choisi se trouve sous une or…' // Object.is equality
+
+Expected: "Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre compte et le dépôt choisi. Veuillez visiter ce lien pour autoriser l'accès."
+Received: "Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre compte et le dépôt choisi. Veuillez visiter celienpour autoriser l'accès."
+
+    at src/components/OrgRestrictionNotice.spec.ts:40:56
+```
+
+**Root cause:** `OrgRestrictionNotice.vue`'s template places `ce`, `<AppLink>lien</AppLink>`,
+and `pour` on separate lines. Vue's default whitespace-condense compilation drops the
+whitespace-only text nodes between text and an adjacent inline element when that whitespace
+spans a newline, rather than collapsing them to a single space. The compiled render function
+therefore emits no space character at all around the link — this reproduces identically in a
+real browser, not just in this test's happy-dom environment. The rendered sentence reads
+`...Veuillez visiter celienpour autoriser l'accès.` at all three call sites that reuse this
+component (Settings validation error, sync error banner, write error banner), violating
+business-specifications.md rule 2's "exactly the fixed sentence" requirement.
+
+### Test Summary
+
+409 test files, 484 tests total — 1 failed.
+
+- Test files: 407 passed, 1 failed (`numFailedTestSuites` reported 2, but only one file
+  (`OrgRestrictionNotice.spec.ts`) actually contains a failing assertion — the other count
+  appears to be a Vitest JSON-reporter aggregation artifact, not a second failure)
+- Tests: 483 passed, 1 failed
+- Duration: ~9 seconds
+
+status: failed

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -4,7 +4,7 @@
     v-if="isExternal"
     :href="isExternal ? to.toString() : ''"
     target="_blank"
-    rel="noopener"
+    rel="noopener noreferrer"
     class="external-link link"
   >
     <slot></slot>

--- a/src/components/GitHubSyncSettings.spec.ts
+++ b/src/components/GitHubSyncSettings.spec.ts
@@ -22,6 +22,9 @@
  *   E-6 — owner/repo and file path fields re-enabled after logout
  *   E-7 — login button reflects the login-readiness check
  *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   1 (rendering) — an org-restriction validationError renders OrgRestrictionNotice, not raw text
+ *
  * Scenarios covered (test-cases.md, issue #110 — settings page mobile layout):
  *   TC-01 — save/connect buttons stack vertically, full width, while unauthenticated
  *   TC-02 — save/disconnect buttons stack vertically, full width, while authenticated
@@ -44,6 +47,7 @@ import { defineComponent, ref } from 'vue'
 import type { Ref } from 'vue'
 import GitHubSyncSettings from './GitHubSyncSettings.vue'
 import type { RepoConfigDraft } from '@/types/repo-config'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 
 // ---------------------------------------------------------------------------
 // Mock useGitHubAuth
@@ -86,7 +90,7 @@ const mockRepoConfig: Ref<RepoConfigDraft> = ref({
   filePath: '',
   revalidateCacheDays: 7,
 })
-const mockValidationError: Ref<string | null> = ref(null)
+const mockValidationError: Ref<string | OrgRestrictionNotice | null> = ref(null)
 const mockLoadRepoConfig = vi.fn().mockResolvedValue(undefined)
 const mockSaveRepoConfig = vi.fn().mockResolvedValue(undefined)
 
@@ -291,6 +295,26 @@ describe('E-7: login button reflects the login-readiness check', () => {
     await wrapper.find('#revalidateCacheDays').setValue('7')
 
     expect(findButtonByText(wrapper, 'Se connecter avec GitHub').attributes('disabled')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 1 (rendering): an org-restriction validationError renders OrgRestrictionNotice
+// ---------------------------------------------------------------------------
+
+describe('Scenario 1 (rendering): an org-restriction validationError renders OrgRestrictionNotice, not raw text', () => {
+  it('renders the fixed sentence with a link to the configured owner\'s settings page', async () => {
+    mockValidationError.value = { owner: 'acme-corp' }
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const alert = wrapper.find('[role="alert"]')
+    expect(alert.text()).toContain("Veuillez visiter ce")
+    expect(alert.text()).not.toContain('[object Object]')
+    const link = alert.find('a')
+    expect(link.attributes('href')).toBe(
+      'https://github.com/organizations/acme-corp/settings/oauth_application_policy',
+    )
   })
 })
 

--- a/src/components/GitHubSyncSettings.vue
+++ b/src/components/GitHubSyncSettings.vue
@@ -23,6 +23,7 @@ import { ref, computed } from 'vue'
 import { useGitHubAuth } from '@/composables/useGitHubAuth'
 import { useRepoConfig } from '@/composables/useRepoConfig'
 import type { RepoConfigDraft } from '@/types/repo-config'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 
 const CACHE_DAYS_ERROR_MESSAGE = 'Le nombre de jours doit être un entier positif.'
 
@@ -36,6 +37,16 @@ const {
   handleUnauthorized,
 } = useGitHubAuth()
 const { repoConfig, validationError, loadRepoConfig, saveRepoConfig } = useRepoConfig()
+
+// validationError carries either a plain string or an org-OAuth-restriction
+// notice (issue #108) — split into two typed computed refs here so the
+// template never needs to narrow the union itself.
+const validationErrorText = computed(() =>
+  typeof validationError.value === 'string' ? validationError.value : null,
+)
+const validationErrorOrgRestriction = computed<OrgRestrictionNotice | null>(() =>
+  typeof validationError.value === 'object' ? validationError.value : null,
+)
 
 // The auth flag and the repo config live under separate IndexedDB keys with
 // no data dependency between them, so loading them in parallel halves the
@@ -116,7 +127,12 @@ async function onLogout(): Promise<void> {
     <h2 class="text-xl font-semibold">Synchronisation GitHub</h2>
 
     <p v-if="authError" role="alert" class="text-sm text-red-600">{{ authError }}</p>
-    <p v-if="validationError" role="alert" class="text-sm text-red-600">{{ validationError }}</p>
+    <p v-if="validationErrorText" role="alert" class="text-sm text-red-600">
+      {{ validationErrorText }}
+    </p>
+    <p v-else-if="validationErrorOrgRestriction" role="alert" class="text-sm text-red-600">
+      <OrgRestrictionNotice :owner="validationErrorOrgRestriction.owner" />
+    </p>
 
     <div class="flex flex-col gap-1">
       <Label for="ownerRepo">Dépôt (owner/repo)</Label>

--- a/src/components/HomePageContent.spec.ts
+++ b/src/components/HomePageContent.spec.ts
@@ -20,12 +20,17 @@
  * Scenarios covered (test-cases.md, Sub-Issue C):
  *   C-17 — every view reflects the same station list once a sync completes
  *   C-18 — no view shows a stale list before the sync outcome is known
+ *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   8 (rendering)  — an org-restriction syncError renders OrgRestrictionNotice, not raw text
+ *   12 (rendering) — an org-restriction writeError renders OrgRestrictionNotice, not raw text
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, ref } from 'vue'
 import type { Station } from '@/types/station'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 import HomePageContent from './HomePageContent.vue'
 
 // ---------------------------------------------------------------------------
@@ -125,10 +130,28 @@ const mockSyncOnLoad = vi.fn((_isAuthenticated: boolean, _repoConfig: unknown, a
   })
 })
 
+const mockSyncError = ref<string | OrgRestrictionNotice | null>(null)
+
 vi.mock('@/composables/useRemotePreferencesSync', () => ({
   useRemotePreferencesSync: () => ({
-    syncError: ref(null),
+    syncError: mockSyncError,
     syncOnLoad: mockSyncOnLoad,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock useRemotePreferencesWrite — HomePageContent reads only writeError,
+// writeSuccess, and divergedNotice; pushPreferences/confirmWrite/etc. are not
+// called from this component, so the mock exposes only what it consumes.
+// ---------------------------------------------------------------------------
+
+const mockWriteError = ref<string | OrgRestrictionNotice | null>(null)
+
+vi.mock('@/composables/useRemotePreferencesWrite', () => ({
+  useRemotePreferencesWrite: () => ({
+    writeError: mockWriteError,
+    writeSuccess: ref(false),
+    divergedNotice: ref(null),
   }),
 }))
 
@@ -182,6 +205,8 @@ beforeEach(() => {
   mockClearDefaultFuelType.mockClear()
   mockSyncOnLoad.mockClear()
   resolveSync = null
+  mockSyncError.value = null
+  mockWriteError.value = null
 })
 
 // ---------------------------------------------------------------------------
@@ -231,5 +256,51 @@ describe('C-17: every view reflects the same station list once a sync completes'
     expect(mockReplaceStations).toHaveBeenCalledWith([
       { name: 'Remote Station', url: 'https://www.prix-carburants.gouv.fr/station/99999999' },
     ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 8 (rendering): an org-restriction syncError renders OrgRestrictionNotice
+// ---------------------------------------------------------------------------
+
+describe('Scenario 8 (rendering): an org-restriction syncError renders OrgRestrictionNotice, not raw text', () => {
+  it('renders the fixed sentence with a link to the configured owner\'s settings page', async () => {
+    const wrapper = mountHomePage()
+    await flushPromises()
+    resolveSync?.()
+    await flushPromises()
+
+    mockSyncError.value = { owner: 'acme-corp' }
+    await flushPromises()
+
+    const alert = wrapper.find('.text-amber-700[role="alert"]')
+    expect(alert.text()).not.toContain('[object Object]')
+    const link = alert.find('a')
+    expect(link.attributes('href')).toBe(
+      'https://github.com/organizations/acme-corp/settings/oauth_application_policy',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 12 (rendering): an org-restriction writeError renders OrgRestrictionNotice
+// ---------------------------------------------------------------------------
+
+describe('Scenario 12 (rendering): an org-restriction writeError renders OrgRestrictionNotice, not raw text', () => {
+  it('renders the fixed sentence with a link to the configured owner\'s settings page', async () => {
+    const wrapper = mountHomePage()
+    await flushPromises()
+    resolveSync?.()
+    await flushPromises()
+
+    mockWriteError.value = { owner: 'acme-corp' }
+    await flushPromises()
+
+    const alert = wrapper.find('.text-red-700[role="alert"]')
+    expect(alert.text()).not.toContain('[object Object]')
+    const link = alert.find('a')
+    expect(link.attributes('href')).toBe(
+      'https://github.com/organizations/acme-corp/settings/oauth_application_policy',
+    )
   })
 })

--- a/src/components/HomePageContent.vue
+++ b/src/components/HomePageContent.vue
@@ -1,6 +1,12 @@
 <template>
-  <p v-if="syncError" role="alert" class="text-sm text-amber-700 mb-2">{{ syncError }}</p>
-  <p v-if="writeError" role="alert" class="text-sm text-red-700 mb-2">{{ writeError }}</p>
+  <p v-if="syncErrorText" role="alert" class="text-sm text-amber-700 mb-2">{{ syncErrorText }}</p>
+  <p v-else-if="syncErrorOrgRestriction" role="alert" class="text-sm text-amber-700 mb-2">
+    <OrgRestrictionNotice :owner="syncErrorOrgRestriction.owner" />
+  </p>
+  <p v-if="writeErrorText" role="alert" class="text-sm text-red-700 mb-2">{{ writeErrorText }}</p>
+  <p v-else-if="writeErrorOrgRestriction" role="alert" class="text-sm text-red-700 mb-2">
+    <OrgRestrictionNotice :owner="writeErrorOrgRestriction.owner" />
+  </p>
   <p v-if="divergedNotice" role="status" class="text-sm text-amber-700 mb-2">
     {{ divergedNotice }}
   </p>
@@ -37,6 +43,7 @@
 // (HomePageContent.spec.ts, C-17) showed renders the genuine StationPrices
 // subtree (with its own network-calling children) instead of the intended
 // component. StationManager does not exhibit this and is left auto-imported.
+import { computed } from 'vue'
 import StationPrices from './StationPrices.vue'
 import { useStationStorage } from '@/composables/useStationStorage'
 import { useDefaultFuelType } from '@/composables/useDefaultFuelType'
@@ -47,6 +54,7 @@ import { useRemotePreferencesWrite } from '@/composables/useRemotePreferencesWri
 import { getPreferencesSyncedAt, restorePreferencesSyncedAt } from '@/utils/preferencesSyncTimestamp'
 import type { PreferencesFile } from '@/types/preferences'
 import type { Station } from '@/types/station'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 
 const { stations, loadStations, replaceStations } = useStationStorage()
 const { loadDefaultFuelType, saveDefaultFuelType, clearDefaultFuelType } = useDefaultFuelType()
@@ -58,6 +66,20 @@ const { syncError, syncOnLoad } = useRemotePreferencesSync()
 // ancestor of both StationPrices and StationManager — the two subtrees whose
 // mutations trigger a remote write (Sub-Issue D rule 1).
 const { writeError, writeSuccess, divergedNotice } = useRemotePreferencesWrite()
+
+// syncError/writeError each carry either a plain string or an org-OAuth-
+// restriction notice (issue #108) — split into typed computed refs here so
+// the template never needs to narrow the union itself.
+const syncErrorText = computed(() => (typeof syncError.value === 'string' ? syncError.value : null))
+const syncErrorOrgRestriction = computed<OrgRestrictionNotice | null>(() =>
+  typeof syncError.value === 'object' ? syncError.value : null,
+)
+const writeErrorText = computed(() =>
+  typeof writeError.value === 'string' ? writeError.value : null,
+)
+const writeErrorOrgRestriction = computed<OrgRestrictionNotice | null>(() =>
+  typeof writeError.value === 'object' ? writeError.value : null,
+)
 
 // Applies a merged remote read (Sub-Issue C, issue #64) through
 // useStationStorage/useDefaultFuelType's own setters, per the

--- a/src/components/OrgRestrictionNotice.spec.ts
+++ b/src/components/OrgRestrictionNotice.spec.ts
@@ -5,6 +5,17 @@
  * rel/target behavior) rather than stubbing it, so the rendered `<a>` seen
  * here is the real external-link markup AppLink produces.
  *
+ * OrgRestrictionNotice.vue's template has no wrapping element — it compiles
+ * to a Fragment with three root nodes (text, <AppLink>, text). Mounted
+ * directly, @vue/test-utils' wrapper.text() computes
+ * getRootNodes().map(el => el.textContent.trim()).join('') — it trims each
+ * root node individually before joining with no separator, which strips the
+ * real spaces around the link regardless of what the template contains. The
+ * fixture below wraps the component in a single-root <p>, matching how it is
+ * always mounted in production (GitHubSyncSettings.vue/HomePageContent.vue
+ * each render it inside one <p role="alert">), so wrapper.text() only trims
+ * the outer edges and the interior spacing is read correctly.
+ *
  * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
  *   17 — the message is exactly the fixed sentence, "lien" rendered as a clickable link
  *   18 — the link points to the configured owner's own settings page
@@ -15,6 +26,7 @@
 import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { defineComponent } from 'vue'
 import OrgRestrictionNotice from './OrgRestrictionNotice.vue'
 import AppLink from './AppLink.vue'
 
@@ -26,8 +38,14 @@ const router = createRouter({
   routes: [{ path: '/', component: { template: '<div />' } }],
 })
 
+const SingleRootHost = defineComponent({
+  components: { OrgRestrictionNotice },
+  props: { owner: { type: String, required: true } },
+  template: '<p role="alert"><OrgRestrictionNotice :owner="owner" /></p>',
+})
+
 function mountNotice(owner: string) {
-  return mount(OrgRestrictionNotice, {
+  return mount(SingleRootHost, {
     props: { owner },
     global: { plugins: [router], components: { AppLink } },
   })

--- a/src/components/OrgRestrictionNotice.spec.ts
+++ b/src/components/OrgRestrictionNotice.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for OrgRestrictionNotice.vue — issue #108.
+ *
+ * Reuses AppLink (already covered by AppFooter.test.ts for its own
+ * rel/target behavior) rather than stubbing it, so the rendered `<a>` seen
+ * here is the real external-link markup AppLink produces.
+ *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   17 — the message is exactly the fixed sentence, "lien" rendered as a clickable link
+ *   18 — the link points to the configured owner's own settings page
+ *   21 — the link opens in a new tab without navigating the app away
+ *   22 — the same owner always renders byte-identical output (no call-site variation)
+ */
+
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import OrgRestrictionNotice from './OrgRestrictionNotice.vue'
+import AppLink from './AppLink.vue'
+
+const FIXED_SENTENCE =
+  "Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre compte et le dépôt choisi. Veuillez visiter ce lien pour autoriser l'accès."
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+})
+
+function mountNotice(owner: string) {
+  return mount(OrgRestrictionNotice, {
+    props: { owner },
+    global: { plugins: [router], components: { AppLink } },
+  })
+}
+
+describe('Scenario 17: the message is exactly the fixed sentence, "lien" rendered as a clickable link', () => {
+  it('renders the fixed sentence verbatim, with a real <a> link whose text is "lien"', () => {
+    const wrapper = mountNotice('acme-corp')
+
+    expect(wrapper.text().replace(/\s+/g, ' ').trim()).toBe(FIXED_SENTENCE)
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toBe('lien')
+  })
+})
+
+describe('Scenario 18: the link points to the configured owner\'s own OAuth App access settings page', () => {
+  it('builds the href from the acme-corp owner', () => {
+    const wrapper = mountNotice('acme-corp')
+
+    expect(wrapper.find('a').attributes('href')).toBe(
+      'https://github.com/organizations/acme-corp/settings/oauth_application_policy',
+    )
+  })
+
+  it('builds a different href for a different owner', () => {
+    const wrapper = mountNotice('other-org')
+
+    expect(wrapper.find('a').attributes('href')).toBe(
+      'https://github.com/organizations/other-org/settings/oauth_application_policy',
+    )
+  })
+})
+
+describe('Scenario 21: the link opens in a new tab without navigating the app away', () => {
+  it('carries target="_blank" and rel="noopener noreferrer"', () => {
+    const wrapper = mountNotice('acme-corp')
+    const link = wrapper.find('a')
+
+    expect(link.attributes('target')).toBe('_blank')
+    expect(link.attributes('rel')).toBe('noopener noreferrer')
+  })
+})
+
+describe('Scenario 22: the same owner always renders byte-identical output', () => {
+  it('produces the same markup across independent mounts for the same owner', () => {
+    const first = mountNotice('acme-corp')
+    const second = mountNotice('acme-corp')
+
+    expect(first.html()).toBe(second.html())
+  })
+})

--- a/src/components/OrgRestrictionNotice.vue
+++ b/src/components/OrgRestrictionNotice.vue
@@ -1,0 +1,25 @@
+<template>
+  Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre
+  compte et le dépôt choisi. Veuillez visiter ce
+  <AppLink :to="settingsUrl">lien</AppLink>
+  pour autoriser l'accès.
+</template>
+
+<script setup lang="ts">
+/**
+ * Renders the fixed org-OAuth-restriction message (business-specifications.md
+ * rule 2, issue #108) with a real, clickable link to the configured
+ * organization's own OAuth App access settings page. Reuses `AppLink`, which
+ * already opens external links in a new tab with `rel="noopener"`
+ * (security-guidelines.md rule 4), instead of a one-off anchor element.
+ *
+ * The caller supplies only `owner` — the message text itself is fixed and
+ * identical everywhere it is shown (business-specifications.md rule 2's
+ * "Out of scope" note), so it is not a prop.
+ */
+import { computed } from 'vue'
+import { buildOrgRestrictionSettingsUrl } from '@/utils/orgRestrictionNotice'
+
+const props = defineProps<{ owner: string }>()
+const settingsUrl = computed(() => buildOrgRestrictionSettingsUrl(props.owner))
+</script>

--- a/src/components/OrgRestrictionNotice.vue
+++ b/src/components/OrgRestrictionNotice.vue
@@ -1,7 +1,5 @@
 <template>
-  Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre
-  compte et le dépôt choisi. Veuillez visiter ce <AppLink :to="settingsUrl">lien</AppLink> pour
-  autoriser l'accès.
+  Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre compte et le dépôt choisi. Veuillez visiter ce <AppLink :to="settingsUrl">lien</AppLink> pour autoriser l'accès.
 </template>
 
 <script setup lang="ts">

--- a/src/components/OrgRestrictionNotice.vue
+++ b/src/components/OrgRestrictionNotice.vue
@@ -10,7 +10,7 @@
  * Renders the fixed org-OAuth-restriction message (business-specifications.md
  * rule 2, issue #108) with a real, clickable link to the configured
  * organization's own OAuth App access settings page. Reuses `AppLink`, which
- * already opens external links in a new tab with `rel="noopener"`
+ * already opens external links in a new tab with `rel="noopener noreferrer"`
  * (security-guidelines.md rule 4), instead of a one-off anchor element.
  *
  * The caller supplies only `owner` — the message text itself is fixed and

--- a/src/components/OrgRestrictionNotice.vue
+++ b/src/components/OrgRestrictionNotice.vue
@@ -1,8 +1,7 @@
 <template>
   Le dépôt choisi se trouve sous une organisation n'autorisant pas l'authentification avec votre
-  compte et le dépôt choisi. Veuillez visiter ce
-  <AppLink :to="settingsUrl">lien</AppLink>
-  pour autoriser l'accès.
+  compte et le dépôt choisi. Veuillez visiter ce <AppLink :to="settingsUrl">lien</AppLink> pour
+  autoriser l'accès.
 </template>
 
 <script setup lang="ts">

--- a/src/components/StationManager.vue
+++ b/src/components/StationManager.vue
@@ -39,7 +39,7 @@ async function onSaveChanges(): Promise<void> {
     <h2 class="text-xl font-semibold mb-1">Gérer mes stations</h2>
     <p class="mb-4">
       Gérez votre liste de stations en renseignant un nom et le lien depuis
-      <AppLink href="https://www.prix-carburants.gouv.fr/" target="_blank" rel="noopener"
+      <AppLink to="https://www.prix-carburants.gouv.fr/"
         >https://www.prix-carburants.gouv.fr/</AppLink
       >
     </p>

--- a/src/components/layout/AppFooter.test.ts
+++ b/src/components/layout/AppFooter.test.ts
@@ -87,11 +87,14 @@ describe('AppFooter', () => {
     })
   })
 
-  it('all links have rel="noopener"', () => {
+  // AppLink.vue now sets rel="noopener noreferrer" (issue #108,
+  // security-guidelines.md rule 4) — matches mentions-legales.spec.ts TC-05's
+  // existing external-link convention.
+  it('all links have rel="noopener noreferrer"', () => {
     const wrapper = mount(AppFooter, globalConfig)
     const links = wrapper.findAll('a.external-link')
     links.forEach((link) => {
-      expect(link.attributes('rel')).toBe('noopener')
+      expect(link.attributes('rel')).toBe('noopener noreferrer')
     })
   })
 

--- a/src/composables/useRemotePreferencesSync.spec.ts
+++ b/src/composables/useRemotePreferencesSync.spec.ts
@@ -44,6 +44,12 @@
  * C-16 through C-18 (empty-state rendering, cross-view consistency) are
  * component-level scenarios: see StationPricesContent.spec.ts,
  * StationManagerTable.spec.ts, and HomePageContent.spec.ts.
+ *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   8  — remote-file fetch org-restricted 403 sets syncError to {owner}, local data untouched
+ *   9  — remote-file fetch non-org 403 falls back to the generic fetch-failed message
+ *   10 — remote-file fetch 401 is unchanged (regression guard)
+ *   11 — remote-file fetch 200 with a valid file applies normally, no syncError (regression guard)
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -71,6 +77,30 @@ const REMOTE_FETCH_FAILED_MESSAGE =
 const INVALID_REMOTE_CONTENT_MESSAGE =
   'Le fichier de préférences distant est invalide. Vos données locales sont conservées.'
 const REMOTE_FETCH_TIMEOUT_MS = 10_000
+
+// ---------------------------------------------------------------------------
+// Org-OAuth-restriction 403 helpers (issue #108)
+// ---------------------------------------------------------------------------
+
+function orgRestrictedResponse() {
+  return {
+    status: 403,
+    json: () =>
+      Promise.resolve({
+        message:
+          "Although you appear to have the correct authorization credentials, the `alice` organization has enabled OAuth App access restrictions, meaning that data access to third-parties is limited. For more information on these restrictions, including how to enable this app, visit https://docs.github.com/articles/restricting-access-to-your-organization-s-data/",
+        documentation_url: 'https://docs.github.com/rest/repos/contents#create-or-update-file-contents',
+        status: '403',
+      }),
+  }
+}
+
+function rateLimited403Response() {
+  return {
+    status: 403,
+    json: () => Promise.resolve({ message: 'API rate limit exceeded for user ID.' }),
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -415,6 +445,80 @@ describe('C-15: the invalid-content message is distinct from the re-authenticati
     expect(unauthorizedMessage).toBe(ACCESS_REVOKED_MESSAGE)
     expect(invalidContentMessage).not.toBe(unauthorizedMessage)
     expect(invalidContentMessage).not.toMatch(/reconnect|reconnecter|se connecter/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 8: remote-file fetch org-restricted 403 sets syncError to {owner}
+// ---------------------------------------------------------------------------
+
+describe('Scenario 8: remote-file fetch org-restricted 403 sets syncError to {owner}', () => {
+  it('sets syncError to {owner}, never applies remote data, distinct from the fetch-failed and re-auth messages', async () => {
+    staleOverride = true
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(orgRestrictedResponse()))
+    const applyRemotePreferences = vi.fn()
+
+    const { syncError, syncOnLoad } = await freshComposable()
+    await syncOnLoad(true, REPO_CONFIG, applyRemotePreferences)
+
+    expect(syncError.value).toEqual({ owner: 'alice' })
+    expect(syncError.value).not.toBe(REMOTE_FETCH_FAILED_MESSAGE)
+    expect(syncError.value).not.toBe(ACCESS_REVOKED_MESSAGE)
+    expect(applyRemotePreferences).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 9: remote-file fetch non-org 403 falls back to the generic fetch-failed message
+// ---------------------------------------------------------------------------
+
+describe('Scenario 9: remote-file fetch non-org 403 falls back to the generic fetch-failed message', () => {
+  it('sets syncError to REMOTE_FETCH_FAILED_MESSAGE, unchanged from today', async () => {
+    staleOverride = true
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(rateLimited403Response()))
+    const applyRemotePreferences = vi.fn()
+
+    const { syncError, syncOnLoad } = await freshComposable()
+    await syncOnLoad(true, REPO_CONFIG, applyRemotePreferences)
+
+    expect(syncError.value).toBe(REMOTE_FETCH_FAILED_MESSAGE)
+    expect(applyRemotePreferences).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 10: remote-file fetch 401 is unchanged (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 10: remote-file fetch 401 is unchanged (regression guard)', () => {
+  it('sets syncError to the existing access-revoked message', async () => {
+    staleOverride = true
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
+    const applyRemotePreferences = vi.fn()
+
+    const { syncError, syncOnLoad } = await freshComposable()
+    await syncOnLoad(true, REPO_CONFIG, applyRemotePreferences)
+
+    expect(syncError.value).toBe(ACCESS_REVOKED_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 11: remote-file fetch 200 with a valid file applies normally (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 11: remote-file fetch 200 with a valid file applies normally, no syncError (regression guard)', () => {
+  it('applies the remote preferences and leaves syncError null', async () => {
+    staleOverride = true
+    const remoteData: PreferencesFile = { favoriteStations: [], fuelTypeDefault: 'SP95' }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(githubContentResponse(remoteData)))
+    const applyRemotePreferences = vi.fn().mockResolvedValue(undefined)
+
+    const { syncError, syncOnLoad } = await freshComposable()
+    await syncOnLoad(true, REPO_CONFIG, applyRemotePreferences)
+
+    expect(applyRemotePreferences).toHaveBeenCalledWith(remoteData)
+    expect(syncError.value).toBeNull()
   })
 })
 

--- a/src/composables/useRemotePreferencesSync.ts
+++ b/src/composables/useRemotePreferencesSync.ts
@@ -55,6 +55,15 @@ const REMOTE_FETCH_FAILED_MESSAGE =
   'Impossible de récupérer vos préférences depuis GitHub. Merci de vous reconnecter.'
 const INVALID_REMOTE_CONTENT_MESSAGE =
   'Le fichier de préférences distant est invalide. Vos données locales sont conservées.'
+const ORG_RESTRICTION_INDICATOR = 'OAuth App access restrictions'
+// Hardcoded literal (security-guidelines.md rule 2) — never built from the
+// proxy response body's own `documentation_url`.
+const ORG_RESTRICTION_DOCS_URL =
+  'https://docs.github.com/articles/restricting-access-to-your-organization-s-data/'
+const ORG_RESTRICTION_MESSAGE_PREFIX =
+  "Votre organisation GitHub restreint l'accès aux applications OAuth tierces. "
+const ORG_RESTRICTION_MESSAGE_SUFFIX =
+  " Vos données locales sont utilisées. Plus d'informations : "
 
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
 type ApplyRemotePreferences = (data: PreferencesFile) => Promise<void>
@@ -66,6 +75,57 @@ interface OwnerRepo {
 
 class RemoteUnauthorizedError extends Error {}
 class RemoteContentInvalidError extends Error {}
+class RemoteOrgRestrictedError extends Error {}
+
+// Ranges of Unicode control / bidi-override / invisible characters to strip
+// from GitHub's echoed message text (security-guidelines.md rule 3). Built
+// from numeric code points rather than typed literally, so this source file
+// never itself contains the invisible/bidi characters it defends against.
+const CONTROL_CHAR_CODE_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x0000, 0x0008],
+  [0x000b, 0x000c],
+  [0x000e, 0x001f],
+  [0x007f, 0x009f],
+  [0x200b, 0x200f],
+  [0x202a, 0x202e],
+  [0x2060, 0x2069],
+  [0xfeff, 0xfeff],
+]
+
+function buildControlCharsPattern(): RegExp {
+  const classBody = CONTROL_CHAR_CODE_RANGES.map(
+    ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end),
+  ).join('')
+  return new RegExp('[' + classBody + ']', 'g')
+}
+
+const CONTROL_CHARS_PATTERN = buildControlCharsPattern()
+
+function sanitizeGitHubText(text: string): string {
+  const withoutControlChars = text.replace(CONTROL_CHARS_PATTERN, '')
+  return withoutControlChars.trim()
+}
+
+function buildOrgRestrictionMessage(githubMessage: string): string {
+  return ORG_RESTRICTION_MESSAGE_PREFIX + githubMessage + ORG_RESTRICTION_MESSAGE_SUFFIX + ORG_RESTRICTION_DOCS_URL
+}
+
+// Wrapped in try/catch (security-guidelines.md rule 1): the 403 body's exact
+// shape is GitHub's, not a contract this project controls, so any parse
+// failure or unexpected shape resolves to null (the generic-failure path)
+// instead of throwing.
+async function extractOrgRestrictionMessage(response: Response): Promise<string | null> {
+  try {
+    const body: unknown = await response.json()
+    if (typeof body !== 'object' || body === null) return null
+    const record = body as Record<string, unknown>
+    if (typeof record.message !== 'string') return null
+    if (!record.message.includes(ORG_RESTRICTION_INDICATOR)) return null
+    return sanitizeGitHubText(record.message)
+  } catch {
+    return null
+  }
+}
 
 // Module-level state — all consumers share the same reference (ADR-002).
 const syncError: Ref<string | null> = ref(null)
@@ -112,6 +172,10 @@ async function requestRemoteFile(ownerRepo: OwnerRepo, path: string): Promise<Re
   const response = await fetchWithTimeout(buildProxyUrl(ownerRepo, path))
   if (response.status === 401) {
     throw new RemoteUnauthorizedError('GitHub access is unauthorized.')
+  }
+  if (response.status === 403) {
+    const message = await extractOrgRestrictionMessage(response)
+    if (message !== null) throw new RemoteOrgRestrictedError(message)
   }
   if (response.status !== 200) {
     throw new Error(`GitHub proxy returned unexpected status ${response.status}.`)
@@ -205,6 +269,13 @@ async function handleFetchFailure(
   }
   if (error instanceof RemoteContentInvalidError) {
     syncError.value = INVALID_REMOTE_CONTENT_MESSAGE
+    return null
+  }
+  // Distinct, non-retryable failure (business-specifications.md rule 6):
+  // re-authenticating would not fix an org-level restriction, so this is
+  // neither the generic fetch-failed message nor the re-auth message above.
+  if (error instanceof RemoteOrgRestrictedError) {
+    syncError.value = buildOrgRestrictionMessage(error.message)
     return null
   }
   syncError.value = REMOTE_FETCH_FAILED_MESSAGE

--- a/src/composables/useRemotePreferencesSync.ts
+++ b/src/composables/useRemotePreferencesSync.ts
@@ -45,6 +45,7 @@ import { ref } from 'vue'
 import type { Ref } from 'vue'
 import type { RepoConfigDraft } from '@/types/repo-config'
 import type { PreferencesFile } from '@/types/preferences'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 import { isPreferencesStale } from '@/utils/preferencesSyncTimestamp'
 import { parseJsonFile } from '@/utils/preferencesImport'
 
@@ -55,15 +56,10 @@ const REMOTE_FETCH_FAILED_MESSAGE =
   'Impossible de récupérer vos préférences depuis GitHub. Merci de vous reconnecter.'
 const INVALID_REMOTE_CONTENT_MESSAGE =
   'Le fichier de préférences distant est invalide. Vos données locales sont conservées.'
+// Detection only (business-specifications.md rule 1) — never shown to the
+// user; the fixed, owner-linked message text lives in OrgRestrictionNotice.vue
+// (security-guidelines.md rule 2).
 const ORG_RESTRICTION_INDICATOR = 'OAuth App access restrictions'
-// Hardcoded literal (security-guidelines.md rule 2) — never built from the
-// proxy response body's own `documentation_url`.
-const ORG_RESTRICTION_DOCS_URL =
-  'https://docs.github.com/articles/restricting-access-to-your-organization-s-data/'
-const ORG_RESTRICTION_MESSAGE_PREFIX =
-  "Votre organisation GitHub restreint l'accès aux applications OAuth tierces. "
-const ORG_RESTRICTION_MESSAGE_SUFFIX =
-  " Vos données locales sont utilisées. Plus d'informations : "
 
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
 type ApplyRemotePreferences = (data: PreferencesFile) => Promise<void>
@@ -75,60 +71,29 @@ interface OwnerRepo {
 
 class RemoteUnauthorizedError extends Error {}
 class RemoteContentInvalidError extends Error {}
+// Carries the repo owner (never GitHub response text) via the standard
+// Error.message property, mirroring RemoteUnauthorizedError's pattern.
 class RemoteOrgRestrictedError extends Error {}
-
-// Ranges of Unicode control / bidi-override / invisible characters to strip
-// from GitHub's echoed message text (security-guidelines.md rule 3). Built
-// from numeric code points rather than typed literally, so this source file
-// never itself contains the invisible/bidi characters it defends against.
-const CONTROL_CHAR_CODE_RANGES: ReadonlyArray<readonly [number, number]> = [
-  [0x0000, 0x0008],
-  [0x000b, 0x000c],
-  [0x000e, 0x001f],
-  [0x007f, 0x009f],
-  [0x200b, 0x200f],
-  [0x202a, 0x202e],
-  [0x2060, 0x2069],
-  [0xfeff, 0xfeff],
-]
-
-function buildControlCharsPattern(): RegExp {
-  const classBody = CONTROL_CHAR_CODE_RANGES.map(
-    ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end),
-  ).join('')
-  return new RegExp('[' + classBody + ']', 'g')
-}
-
-const CONTROL_CHARS_PATTERN = buildControlCharsPattern()
-
-function sanitizeGitHubText(text: string): string {
-  const withoutControlChars = text.replace(CONTROL_CHARS_PATTERN, '')
-  return withoutControlChars.trim()
-}
-
-function buildOrgRestrictionMessage(githubMessage: string): string {
-  return ORG_RESTRICTION_MESSAGE_PREFIX + githubMessage + ORG_RESTRICTION_MESSAGE_SUFFIX + ORG_RESTRICTION_DOCS_URL
-}
 
 // Wrapped in try/catch (security-guidelines.md rule 1): the 403 body's exact
 // shape is GitHub's, not a contract this project controls, so any parse
-// failure or unexpected shape resolves to null (the generic-failure path)
-// instead of throwing.
-async function extractOrgRestrictionMessage(response: Response): Promise<string | null> {
+// failure or unexpected shape resolves to false (the generic-failure path)
+// instead of throwing. The body's `message` text itself is never returned —
+// only this boolean — per security-guidelines.md rule 2.
+async function isOrgRestrictedResponse(response: Response): Promise<boolean> {
   try {
     const body: unknown = await response.json()
-    if (typeof body !== 'object' || body === null) return null
+    if (typeof body !== 'object' || body === null) return false
     const record = body as Record<string, unknown>
-    if (typeof record.message !== 'string') return null
-    if (!record.message.includes(ORG_RESTRICTION_INDICATOR)) return null
-    return sanitizeGitHubText(record.message)
+    if (typeof record.message !== 'string') return false
+    return record.message.includes(ORG_RESTRICTION_INDICATOR)
   } catch {
-    return null
+    return false
   }
 }
 
 // Module-level state — all consumers share the same reference (ADR-002).
-const syncError: Ref<string | null> = ref(null)
+const syncError: Ref<string | OrgRestrictionNotice | null> = ref(null)
 
 function hasCompleteRepoConfig(
   config: RepoConfigDraft,
@@ -173,9 +138,8 @@ async function requestRemoteFile(ownerRepo: OwnerRepo, path: string): Promise<Re
   if (response.status === 401) {
     throw new RemoteUnauthorizedError('GitHub access is unauthorized.')
   }
-  if (response.status === 403) {
-    const message = await extractOrgRestrictionMessage(response)
-    if (message !== null) throw new RemoteOrgRestrictedError(message)
+  if (response.status === 403 && (await isOrgRestrictedResponse(response))) {
+    throw new RemoteOrgRestrictedError(ownerRepo.owner)
   }
   if (response.status !== 200) {
     throw new Error(`GitHub proxy returned unexpected status ${response.status}.`)
@@ -271,11 +235,12 @@ async function handleFetchFailure(
     syncError.value = INVALID_REMOTE_CONTENT_MESSAGE
     return null
   }
-  // Distinct, non-retryable failure (business-specifications.md rule 6):
+  // Distinct, non-retryable failure (business-specifications.md rule 5):
   // re-authenticating would not fix an org-level restriction, so this is
   // neither the generic fetch-failed message nor the re-auth message above.
+  // error.message carries the repo owner (never GitHub response text).
   if (error instanceof RemoteOrgRestrictedError) {
-    syncError.value = buildOrgRestrictionMessage(error.message)
+    syncError.value = { owner: error.message }
     return null
   }
   syncError.value = REMOTE_FETCH_FAILED_MESSAGE

--- a/src/composables/useRemotePreferencesWrite.spec.ts
+++ b/src/composables/useRemotePreferencesWrite.spec.ts
@@ -48,6 +48,13 @@
  *   TC-15 — no remote file: creates directly, no dialog, clears pending on success
  *   TC-16 — after a successful push, a new markStationChange makes hasPendingChanges true again
  *   TC-21 — includeStationChanges: false never bundles or clears pendingStationChanges
+ *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   12 — existing-file check org-restricted 403 sets writeError to {owner}, no generic/re-auth message
+ *   13 — existing-file check non-org 403 falls back to the generic write-failed message
+ *   14 — final PUT org-restricted 403 sets writeError to the same {owner} notice
+ *   15 — final PUT 401 is unchanged (regression guard)
+ *   16 — final PUT 409 is unchanged (regression guard)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -61,6 +68,8 @@ import type { PreferencesFile, StationChange } from '@/types/preferences'
 const UNAUTHORIZED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
 const CONFLICT_MESSAGE =
   'Le fichier distant a été modifié entre-temps. Merci de rafraîchir la page et réessayer.'
+const WRITE_FAILED_MESSAGE =
+  "Impossible d'enregistrer vos préférences sur GitHub. Vos données locales sont conservées."
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,6 +143,30 @@ function githubReadResponse(data: PreferencesFile, sha: string) {
 
 function githubNotFoundResponse() {
   return { status: 404, json: () => Promise.resolve({}) }
+}
+
+// ---------------------------------------------------------------------------
+// Org-OAuth-restriction 403 helpers (issue #108)
+// ---------------------------------------------------------------------------
+
+function orgRestrictedResponse() {
+  return {
+    status: 403,
+    json: () =>
+      Promise.resolve({
+        message:
+          "Although you appear to have the correct authorization credentials, the `alice` organization has enabled OAuth App access restrictions, meaning that data access to third-parties is limited. For more information on these restrictions, including how to enable this app, visit https://docs.github.com/articles/restricting-access-to-your-organization-s-data/",
+        documentation_url: 'https://docs.github.com/rest/repos/contents#create-or-update-file-contents',
+        status: '403',
+      }),
+  }
+}
+
+function rateLimited403Response() {
+  return {
+    status: 403,
+    json: () => Promise.resolve({ message: 'API rate limit exceeded for user ID.' }),
+  }
 }
 
 function githubWriteResponse(status = 200) {
@@ -635,5 +668,107 @@ describe('TC-21: a fuel-type-only push (includeStationChanges: false) is unaffec
 
     // The station edit was never bundled into this push, so it is still pending.
     expect(hasPendingChanges.value).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 12: existing-file check org-restricted 403 sets writeError to {owner}
+// ---------------------------------------------------------------------------
+
+describe('Scenario 12: existing-file check org-restricted 403 sets writeError to {owner}', () => {
+  it('sets writeError to {owner}, never sends a PUT, distinct from the generic and re-auth messages', async () => {
+    const fetchMock = buildFetchMock(orgRestrictedResponse(), githubWriteResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { writeError, markStationChange, pushPreferences } = await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+
+    expect(writeError.value).toEqual({ owner: 'alice' })
+    expect(writeError.value).not.toBe(WRITE_FAILED_MESSAGE)
+    expect(writeError.value).not.toBe(UNAUTHORIZED_MESSAGE)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 13: existing-file check non-org 403 falls back to the generic write-failed message
+// ---------------------------------------------------------------------------
+
+describe('Scenario 13: existing-file check non-org 403 falls back to the generic write-failed message', () => {
+  it('sets writeError to WRITE_FAILED_MESSAGE, unchanged from today', async () => {
+    const fetchMock = buildFetchMock(rateLimited403Response(), githubWriteResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { writeError, markStationChange, pushPreferences } = await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+
+    expect(writeError.value).toBe(WRITE_FAILED_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 14: final PUT org-restricted 403 sets writeError to the same {owner} notice
+// ---------------------------------------------------------------------------
+
+describe('Scenario 14: final PUT org-restricted 403 sets writeError to the same {owner} notice', () => {
+  it('sets writeError to {owner} after a confirmed write is rejected by an org-restricted 403', async () => {
+    const fetchMock = buildFetchMock(
+      githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA),
+      orgRestrictedResponse(),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { writeError, writeSuccess, markStationChange, pushPreferences, confirmWrite } =
+      await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    await confirmWrite()
+
+    expect(writeError.value).toEqual({ owner: 'alice' })
+    expect(writeSuccess.value).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 15: final PUT 401 is unchanged (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 15: final PUT 401 is unchanged (regression guard)', () => {
+  it('sets writeError to the existing re-authentication message', async () => {
+    const fetchMock = buildFetchMock(githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA), {
+      status: 401,
+      json: () => Promise.resolve({}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { writeError, markStationChange, pushPreferences, confirmWrite } = await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    await confirmWrite()
+
+    expect(writeError.value).toBe(UNAUTHORIZED_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 16: final PUT 409 is unchanged (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 16: final PUT 409 is unchanged (regression guard)', () => {
+  it('sets writeError to the existing conflict message', async () => {
+    const fetchMock = buildFetchMock(githubReadResponse(EXISTING_PREFERENCES, EXISTING_SHA), {
+      status: 409,
+      json: () => Promise.resolve({}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { writeError, markStationChange, pushPreferences, confirmWrite } = await freshComposable()
+    markStationChange(ADDED_STATION_CHANGE)
+    await pushPreferences(true, REPO_CONFIG, UPDATED_PREFERENCES_ADD, true)
+    await confirmWrite()
+
+    expect(writeError.value).toBe(CONFLICT_MESSAGE)
   })
 })

--- a/src/composables/useRemotePreferencesWrite.ts
+++ b/src/composables/useRemotePreferencesWrite.ts
@@ -49,6 +49,7 @@ import type {
   RemoteWritePreview,
   StationChange,
 } from '@/types/preferences'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 import { parseJsonFile } from '@/utils/preferencesImport'
 
 const PROXY_PATH = '/.netlify/functions/github-api-proxy'
@@ -63,15 +64,10 @@ const WRITE_FAILED_MESSAGE =
 const INVALID_CONFIG_MESSAGE =
   'Le format du dépôt GitHub configuré est invalide. Vos données locales sont conservées.'
 const DIVERGED_MESSAGE = 'Vos préférences locales diffèrent du fichier distant sur GitHub.'
+// Detection only (business-specifications.md rule 1) — never shown to the
+// user; the fixed, owner-linked message text lives in OrgRestrictionNotice.vue
+// (security-guidelines.md rule 2).
 const ORG_RESTRICTION_INDICATOR = 'OAuth App access restrictions'
-// Hardcoded literal (security-guidelines.md rule 2) — never built from the
-// proxy response body's own `documentation_url`.
-const ORG_RESTRICTION_DOCS_URL =
-  'https://docs.github.com/articles/restricting-access-to-your-organization-s-data/'
-const ORG_RESTRICTION_MESSAGE_PREFIX =
-  "Votre organisation GitHub restreint l'accès aux applications OAuth tierces. "
-const ORG_RESTRICTION_MESSAGE_SUFFIX =
-  " Vos données locales sont conservées. Plus d'informations : "
 
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
 
@@ -97,62 +93,31 @@ interface ExistingFile {
 class RemoteWriteUnauthorizedError extends Error {}
 class RemoteWriteConflictError extends Error {}
 class RemoteWriteContentInvalidError extends Error {}
+// Carries the repo owner (never GitHub response text) via the standard
+// Error.message property, mirroring RemoteWriteUnauthorizedError's pattern.
 class RemoteWriteOrgRestrictedError extends Error {}
-
-// Ranges of Unicode control / bidi-override / invisible characters to strip
-// from GitHub's echoed message text (security-guidelines.md rule 3). Built
-// from numeric code points rather than typed literally, so this source file
-// never itself contains the invisible/bidi characters it defends against.
-const CONTROL_CHAR_CODE_RANGES: ReadonlyArray<readonly [number, number]> = [
-  [0x0000, 0x0008],
-  [0x000b, 0x000c],
-  [0x000e, 0x001f],
-  [0x007f, 0x009f],
-  [0x200b, 0x200f],
-  [0x202a, 0x202e],
-  [0x2060, 0x2069],
-  [0xfeff, 0xfeff],
-]
-
-function buildControlCharsPattern(): RegExp {
-  const classBody = CONTROL_CHAR_CODE_RANGES.map(
-    ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end),
-  ).join('')
-  return new RegExp('[' + classBody + ']', 'g')
-}
-
-const CONTROL_CHARS_PATTERN = buildControlCharsPattern()
-
-function sanitizeGitHubText(text: string): string {
-  const withoutControlChars = text.replace(CONTROL_CHARS_PATTERN, '')
-  return withoutControlChars.trim()
-}
-
-function buildOrgRestrictionMessage(githubMessage: string): string {
-  return ORG_RESTRICTION_MESSAGE_PREFIX + githubMessage + ORG_RESTRICTION_MESSAGE_SUFFIX + ORG_RESTRICTION_DOCS_URL
-}
 
 // Wrapped in try/catch (security-guidelines.md rule 1): the 403 body's exact
 // shape is GitHub's, not a contract this project controls, so any parse
-// failure or unexpected shape resolves to null (the generic-failure path)
-// instead of throwing.
-async function extractOrgRestrictionMessage(response: Response): Promise<string | null> {
+// failure or unexpected shape resolves to false (the generic-failure path)
+// instead of throwing. The body's `message` text itself is never returned —
+// only this boolean — per security-guidelines.md rule 2.
+async function isOrgRestrictedResponse(response: Response): Promise<boolean> {
   try {
     const body: unknown = await response.json()
-    if (typeof body !== 'object' || body === null) return null
+    if (typeof body !== 'object' || body === null) return false
     const record = body as Record<string, unknown>
-    if (typeof record.message !== 'string') return null
-    if (!record.message.includes(ORG_RESTRICTION_INDICATOR)) return null
-    return sanitizeGitHubText(record.message)
+    if (typeof record.message !== 'string') return false
+    return record.message.includes(ORG_RESTRICTION_INDICATOR)
   } catch {
-    return null
+    return false
   }
 }
 
 // Module-level state — all consumers share the same reference (ADR-002).
 const writeDiff: Ref<RemoteWritePreview | null> = ref(null)
 const isWriteDialogOpen: Ref<boolean> = ref(false)
-const writeError: Ref<string | null> = ref(null)
+const writeError: Ref<string | OrgRestrictionNotice | null> = ref(null)
 const writeSuccess: Ref<boolean> = ref(false)
 const divergedNotice: Ref<string | null> = ref(null)
 const isWriting: Ref<boolean> = ref(false)
@@ -224,9 +189,8 @@ async function fetchExistingFile(
 ): Promise<ExistingFile | null> {
   const response = await fetch(buildProxyUrl(ownerRepo, path))
   if (response.status === 401) throw new RemoteWriteUnauthorizedError()
-  if (response.status === 403) {
-    const message = await extractOrgRestrictionMessage(response)
-    if (message !== null) throw new RemoteWriteOrgRestrictedError(message)
+  if (response.status === 403 && (await isOrgRestrictedResponse(response))) {
+    throw new RemoteWriteOrgRestrictedError(ownerRepo.owner)
   }
   if (response.status === 404) return null
   if (response.status !== 200) {
@@ -280,11 +244,10 @@ function clearPendingStationChanges(pushed: StationChange[]): void {
   )
 }
 
-async function handlePutResponse(response: Response): Promise<void> {
+async function handlePutResponse(response: Response, owner: string): Promise<void> {
   if (response.status === 401) throw new RemoteWriteUnauthorizedError()
-  if (response.status === 403) {
-    const message = await extractOrgRestrictionMessage(response)
-    if (message !== null) throw new RemoteWriteOrgRestrictedError(message)
+  if (response.status === 403 && (await isOrgRestrictedResponse(response))) {
+    throw new RemoteWriteOrgRestrictedError(owner)
   }
   if (response.status === 409) throw new RemoteWriteConflictError()
   if (!response.ok) throw new Error(`GitHub proxy returned unexpected status ${response.status}.`)
@@ -308,7 +271,7 @@ async function putRemoteFile(
       sha,
     }),
   })
-  await handlePutResponse(response)
+  await handlePutResponse(response, ownerRepo.owner)
 }
 
 function openWriteDialog(preview: RemoteWritePreview): void {
@@ -352,11 +315,12 @@ async function handleWriteFailure(
     writeError.value = INVALID_REMOTE_CONTENT_MESSAGE
     return
   }
-  // Distinct, non-retryable failure (business-specifications.md rule 6):
+  // Distinct, non-retryable failure (business-specifications.md rule 5):
   // re-authenticating would not fix an org-level restriction, so this is
   // neither the generic write-failed message nor the re-auth message above.
+  // error.message carries the repo owner (never GitHub response text).
   if (error instanceof RemoteWriteOrgRestrictedError) {
-    writeError.value = buildOrgRestrictionMessage(error.message)
+    writeError.value = { owner: error.message }
     return
   }
   writeError.value = WRITE_FAILED_MESSAGE

--- a/src/composables/useRemotePreferencesWrite.ts
+++ b/src/composables/useRemotePreferencesWrite.ts
@@ -63,6 +63,15 @@ const WRITE_FAILED_MESSAGE =
 const INVALID_CONFIG_MESSAGE =
   'Le format du dépôt GitHub configuré est invalide. Vos données locales sont conservées.'
 const DIVERGED_MESSAGE = 'Vos préférences locales diffèrent du fichier distant sur GitHub.'
+const ORG_RESTRICTION_INDICATOR = 'OAuth App access restrictions'
+// Hardcoded literal (security-guidelines.md rule 2) — never built from the
+// proxy response body's own `documentation_url`.
+const ORG_RESTRICTION_DOCS_URL =
+  'https://docs.github.com/articles/restricting-access-to-your-organization-s-data/'
+const ORG_RESTRICTION_MESSAGE_PREFIX =
+  "Votre organisation GitHub restreint l'accès aux applications OAuth tierces. "
+const ORG_RESTRICTION_MESSAGE_SUFFIX =
+  " Vos données locales sont conservées. Plus d'informations : "
 
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
 
@@ -88,6 +97,57 @@ interface ExistingFile {
 class RemoteWriteUnauthorizedError extends Error {}
 class RemoteWriteConflictError extends Error {}
 class RemoteWriteContentInvalidError extends Error {}
+class RemoteWriteOrgRestrictedError extends Error {}
+
+// Ranges of Unicode control / bidi-override / invisible characters to strip
+// from GitHub's echoed message text (security-guidelines.md rule 3). Built
+// from numeric code points rather than typed literally, so this source file
+// never itself contains the invisible/bidi characters it defends against.
+const CONTROL_CHAR_CODE_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x0000, 0x0008],
+  [0x000b, 0x000c],
+  [0x000e, 0x001f],
+  [0x007f, 0x009f],
+  [0x200b, 0x200f],
+  [0x202a, 0x202e],
+  [0x2060, 0x2069],
+  [0xfeff, 0xfeff],
+]
+
+function buildControlCharsPattern(): RegExp {
+  const classBody = CONTROL_CHAR_CODE_RANGES.map(
+    ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end),
+  ).join('')
+  return new RegExp('[' + classBody + ']', 'g')
+}
+
+const CONTROL_CHARS_PATTERN = buildControlCharsPattern()
+
+function sanitizeGitHubText(text: string): string {
+  const withoutControlChars = text.replace(CONTROL_CHARS_PATTERN, '')
+  return withoutControlChars.trim()
+}
+
+function buildOrgRestrictionMessage(githubMessage: string): string {
+  return ORG_RESTRICTION_MESSAGE_PREFIX + githubMessage + ORG_RESTRICTION_MESSAGE_SUFFIX + ORG_RESTRICTION_DOCS_URL
+}
+
+// Wrapped in try/catch (security-guidelines.md rule 1): the 403 body's exact
+// shape is GitHub's, not a contract this project controls, so any parse
+// failure or unexpected shape resolves to null (the generic-failure path)
+// instead of throwing.
+async function extractOrgRestrictionMessage(response: Response): Promise<string | null> {
+  try {
+    const body: unknown = await response.json()
+    if (typeof body !== 'object' || body === null) return null
+    const record = body as Record<string, unknown>
+    if (typeof record.message !== 'string') return null
+    if (!record.message.includes(ORG_RESTRICTION_INDICATOR)) return null
+    return sanitizeGitHubText(record.message)
+  } catch {
+    return null
+  }
+}
 
 // Module-level state — all consumers share the same reference (ADR-002).
 const writeDiff: Ref<RemoteWritePreview | null> = ref(null)
@@ -164,6 +224,10 @@ async function fetchExistingFile(
 ): Promise<ExistingFile | null> {
   const response = await fetch(buildProxyUrl(ownerRepo, path))
   if (response.status === 401) throw new RemoteWriteUnauthorizedError()
+  if (response.status === 403) {
+    const message = await extractOrgRestrictionMessage(response)
+    if (message !== null) throw new RemoteWriteOrgRestrictedError(message)
+  }
   if (response.status === 404) return null
   if (response.status !== 200) {
     throw new Error(`GitHub proxy returned unexpected status ${response.status}.`)
@@ -218,6 +282,10 @@ function clearPendingStationChanges(pushed: StationChange[]): void {
 
 async function handlePutResponse(response: Response): Promise<void> {
   if (response.status === 401) throw new RemoteWriteUnauthorizedError()
+  if (response.status === 403) {
+    const message = await extractOrgRestrictionMessage(response)
+    if (message !== null) throw new RemoteWriteOrgRestrictedError(message)
+  }
   if (response.status === 409) throw new RemoteWriteConflictError()
   if (!response.ok) throw new Error(`GitHub proxy returned unexpected status ${response.status}.`)
 }
@@ -282,6 +350,13 @@ async function handleWriteFailure(
   }
   if (error instanceof RemoteWriteContentInvalidError) {
     writeError.value = INVALID_REMOTE_CONTENT_MESSAGE
+    return
+  }
+  // Distinct, non-retryable failure (business-specifications.md rule 6):
+  // re-authenticating would not fix an org-level restriction, so this is
+  // neither the generic write-failed message nor the re-auth message above.
+  if (error instanceof RemoteWriteOrgRestrictedError) {
+    writeError.value = buildOrgRestrictionMessage(error.message)
     return
   }
   writeError.value = WRITE_FAILED_MESSAGE

--- a/src/composables/useRepoConfig.spec.ts
+++ b/src/composables/useRepoConfig.spec.ts
@@ -23,6 +23,15 @@
  *   B-2 — valid repo config saves without validation while unauthenticated
  *   B-3 — saved config persists across reloads and after login
  *   B-4 — invalid repo config shows human-readable error once authenticated
+ *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   1 — file-path check org-restricted 403 resolves {owner} and skips the repo-level fallback
+ *   2 — file-path check non-org 403 falls back to the generic unavailable message
+ *   3 — file-path check 403 with unparseable JSON falls back to the generic message, no throw
+ *   4 — file-path check 404 falls through, repo-level check org-restricted 403 resolves {owner}
+ *   5 — file-path check 401 is unchanged (regression guard)
+ *   6 — file-path check 404 still falls through to the repo-level check (regression guard)
+ *   7 — file-path check 200 leaves validationError null (regression guard)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -53,6 +62,40 @@ vi.mock('@/utils/indexedDb', () => ({
 const REPO_CONFIG_KEY = 'repoConfig'
 const REPO_NOT_REACHABLE_MESSAGE =
   "Le dépôt GitHub est introuvable ou inaccessible. Vérifiez son nom et vos droits d'accès."
+const VALIDATION_UNAVAILABLE_MESSAGE =
+  'Impossible de vérifier le dépôt GitHub pour le moment. Réessayez plus tard.'
+const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
+
+// ---------------------------------------------------------------------------
+// Org-OAuth-restriction 403 helpers (issue #108)
+// ---------------------------------------------------------------------------
+
+function orgRestrictedResponse() {
+  return {
+    status: 403,
+    json: () =>
+      Promise.resolve({
+        message:
+          "Although you appear to have the correct authorization credentials, the `acme-corp` organization has enabled OAuth App access restrictions, meaning that data access to third-parties is limited. For more information on these restrictions, including how to enable this app, visit https://docs.github.com/articles/restricting-access-to-your-organization-s-data/",
+        documentation_url: 'https://docs.github.com/rest/repos/contents#create-or-update-file-contents',
+        status: '403',
+      }),
+  }
+}
+
+function rateLimited403Response() {
+  return {
+    status: 403,
+    json: () => Promise.resolve({ message: 'API rate limit exceeded for user ID.' }),
+  }
+}
+
+function unparseable403Response() {
+  return {
+    status: 403,
+    json: () => Promise.reject(new Error('Unexpected token < in JSON')),
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,5 +177,133 @@ describe('B-4: invalid repo config shows human-readable error once authenticated
 
     expect(store.get(REPO_CONFIG_KEY)).toEqual(invalidDraft)
     expect(validationError.value).toBe(REPO_NOT_REACHABLE_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 1: file-path check org-restricted 403 skips the repo-level fallback
+// ---------------------------------------------------------------------------
+
+describe('Scenario 1: file-path check org-restricted 403 resolves {owner} and skips the repo-level fallback', () => {
+  it('sets validationError to {owner} from the configured repo and calls fetch only once', async () => {
+    const draft: RepoConfigDraft = {
+      ownerRepo: 'acme-corp/repo',
+      filePath: 'stations.json',
+      revalidateCacheDays: 7,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(orgRestrictedResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(draft, true)
+
+    expect(validationError.value).toEqual({ owner: 'acme-corp' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 2: file-path check non-org 403 falls back to the generic message
+// ---------------------------------------------------------------------------
+
+describe('Scenario 2: file-path check non-org 403 falls back to the generic unavailable message', () => {
+  it('sets validationError to VALIDATION_UNAVAILABLE_MESSAGE, unchanged from today', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(rateLimited403Response()))
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(VALID_CONFIG, true)
+
+    expect(validationError.value).toBe(VALIDATION_UNAVAILABLE_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 3: file-path check 403 with unparseable JSON falls back to the generic message
+// ---------------------------------------------------------------------------
+
+describe('Scenario 3: file-path check 403 with unparseable JSON falls back to the generic message', () => {
+  it('sets validationError to VALIDATION_UNAVAILABLE_MESSAGE without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(unparseable403Response()))
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await expect(saveRepoConfig(VALID_CONFIG, true)).resolves.toBeUndefined()
+    expect(validationError.value).toBe(VALIDATION_UNAVAILABLE_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 4: file-path check 404 falls through, repo-level check org-restricted 403
+// ---------------------------------------------------------------------------
+
+describe('Scenario 4: file-path check 404 falls through to a repo-level org-restricted 403', () => {
+  it('sets validationError to {owner} once the repo-level check reports the org restriction', async () => {
+    const draft: RepoConfigDraft = {
+      ownerRepo: 'acme-corp/repo',
+      filePath: 'stations.json',
+      revalidateCacheDays: 7,
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 404 })
+      .mockResolvedValueOnce(orgRestrictedResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(draft, true)
+
+    expect(validationError.value).toEqual({ owner: 'acme-corp' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 5: file-path check 401 is unchanged (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 5: file-path check 401 is unchanged (regression guard)', () => {
+  it('sets validationError to the existing session-expired message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(VALID_CONFIG, true)
+
+    expect(validationError.value).toBe(SESSION_EXPIRED_MESSAGE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 6: file-path check 404 still falls through to the repo-level check (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 6: file-path check 404 still falls through to the repo-level check (regression guard)', () => {
+  it('reflects the repo-level check outcome and calls fetch twice', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 404 })
+      .mockResolvedValueOnce({ status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(VALID_CONFIG, true)
+
+    expect(validationError.value).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 7: file-path check 200 leaves validationError null (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 7: file-path check 200 leaves validationError null (regression guard)', () => {
+  it('sets validationError to null and calls fetch only once', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+    const { validationError, saveRepoConfig } = await freshComposable()
+
+    await saveRepoConfig(VALID_CONFIG, true)
+
+    expect(validationError.value).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/composables/useRepoConfig.ts
+++ b/src/composables/useRepoConfig.ts
@@ -26,6 +26,7 @@ import { ref, toRaw } from 'vue'
 import type { Ref } from 'vue'
 import { get, set } from '@/utils/indexedDb'
 import type { RepoConfigDraft } from '@/types/repo-config'
+import type { OrgRestrictionNotice } from '@/types/org-restriction-notice'
 
 const REPO_CONFIG_KEY = 'repoConfig'
 const DEFAULT_REVALIDATE_CACHE_DAYS = 7
@@ -38,44 +39,12 @@ const REPO_NOT_REACHABLE_MESSAGE =
 const VALIDATION_UNAVAILABLE_MESSAGE =
   'Impossible de vérifier le dépôt GitHub pour le moment. Réessayez plus tard.'
 const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
+// Detection only (business-specifications.md rule 1) — never shown to the
+// user; the fixed, owner-linked message text lives in OrgRestrictionNotice.vue
+// (security-guidelines.md rule 2).
 const ORG_RESTRICTION_INDICATOR = 'OAuth App access restrictions'
-// Hardcoded literal (security-guidelines.md rule 2) — never built from the
-// proxy response body's own `documentation_url`.
-const ORG_RESTRICTION_DOCS_URL =
-  'https://docs.github.com/articles/restricting-access-to-your-organization-s-data/'
-const ORG_RESTRICTION_MESSAGE_PREFIX =
-  "Votre organisation GitHub restreint l'accès aux applications OAuth tierces : "
-const ORG_RESTRICTION_MESSAGE_SUFFIX = " Plus d'informations : "
-// Ranges of Unicode control / bidi-override / invisible characters to strip
-// from GitHub's echoed message text (security-guidelines.md rule 3). Built
-// from numeric code points rather than typed literally, so this source file
-// never itself contains the invisible/bidi characters it defends against.
-const CONTROL_CHAR_CODE_RANGES: ReadonlyArray<readonly [number, number]> = [
-  [0x0000, 0x0008],
-  [0x000b, 0x000c],
-  [0x000e, 0x001f],
-  [0x007f, 0x009f],
-  [0x200b, 0x200f],
-  [0x202a, 0x202e],
-  [0x2060, 0x2069],
-  [0xfeff, 0xfeff],
-]
 
-function buildControlCharsPattern(): RegExp {
-  const classBody = CONTROL_CHAR_CODE_RANGES.map(
-    ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end),
-  ).join('')
-  return new RegExp('[' + classBody + ']', 'g')
-}
-
-const CONTROL_CHARS_PATTERN = buildControlCharsPattern()
-
-type ProxyCheckResult =
-  | { kind: 'ok' }
-  | { kind: 'notFound' }
-  | { kind: 'unauthorized' }
-  | { kind: 'orgRestricted'; message: string }
-  | { kind: 'error' }
+type ProxyCheckResult = 'ok' | 'notFound' | 'unauthorized' | 'orgRestricted' | 'error'
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
 
 interface OwnerRepo {
@@ -85,7 +54,7 @@ interface OwnerRepo {
 
 // Module-level state — all consumers share the same reference (ADR-002).
 const repoConfig: Ref<RepoConfigDraft> = ref(emptyRepoConfig())
-const validationError: Ref<string | null> = ref(null)
+const validationError: Ref<string | OrgRestrictionNotice | null> = ref(null)
 
 // Object Calisthenics exception: a third module-level variable, beyond the two above.
 // It exists solely to guard against a stale, slower `saveRepoConfig` call overwriting
@@ -118,41 +87,29 @@ function buildProxyUrl(ownerRepo: OwnerRepo, path?: string): string {
   return `${PROXY_PATH}?${params.toString()}`
 }
 
-function sanitizeGitHubText(text: string): string {
-  const withoutControlChars = text.replace(CONTROL_CHARS_PATTERN, '')
-  return withoutControlChars.trim()
-}
-
 // Wrapped in try/catch (security-guidelines.md rule 1): the 403 body's exact
 // shape is GitHub's, not a contract this project controls, so any parse
-// failure or unexpected shape resolves to null (the generic-failure path)
-// instead of throwing.
-async function extractOrgRestrictionMessage(response: Response): Promise<string | null> {
+// failure or unexpected shape resolves to false (the generic-failure path)
+// instead of throwing. The body's `message` text itself is never returned —
+// only this boolean — per security-guidelines.md rule 2.
+async function isOrgRestrictedResponse(response: Response): Promise<boolean> {
   try {
     const body: unknown = await response.json()
-    if (typeof body !== 'object' || body === null) return null
+    if (typeof body !== 'object' || body === null) return false
     const record = body as Record<string, unknown>
-    if (typeof record.message !== 'string') return null
-    if (!record.message.includes(ORG_RESTRICTION_INDICATOR)) return null
-    return sanitizeGitHubText(record.message)
+    if (typeof record.message !== 'string') return false
+    return record.message.includes(ORG_RESTRICTION_INDICATOR)
   } catch {
-    return null
+    return false
   }
-}
-
-function buildOrgRestrictionMessage(githubMessage: string): string {
-  return ORG_RESTRICTION_MESSAGE_PREFIX + githubMessage + ORG_RESTRICTION_MESSAGE_SUFFIX + ORG_RESTRICTION_DOCS_URL
 }
 
 async function classifyProxyResponse(response: Response): Promise<ProxyCheckResult> {
-  if (response.status === 200) return { kind: 'ok' }
-  if (response.status === 401) return { kind: 'unauthorized' }
-  if (response.status === 404) return { kind: 'notFound' }
-  if (response.status === 403) {
-    const message = await extractOrgRestrictionMessage(response)
-    if (message !== null) return { kind: 'orgRestricted', message }
-  }
-  return { kind: 'error' }
+  if (response.status === 200) return 'ok'
+  if (response.status === 401) return 'unauthorized'
+  if (response.status === 404) return 'notFound'
+  if (response.status === 403 && (await isOrgRestrictedResponse(response))) return 'orgRestricted'
+  return 'error'
 }
 
 async function checkProxyReachable(ownerRepo: OwnerRepo, path?: string): Promise<ProxyCheckResult> {
@@ -160,7 +117,7 @@ async function checkProxyReachable(ownerRepo: OwnerRepo, path?: string): Promise
     const response = await fetch(buildProxyUrl(ownerRepo, path))
     return await classifyProxyResponse(response)
   } catch {
-    return { kind: 'error' }
+    return 'error'
   }
 }
 
@@ -187,24 +144,24 @@ async function notifyUnauthorized(onUnauthorized: UnauthorizedCallback): Promise
 async function resolveValidationError(
   draft: RepoConfigDraft,
   onUnauthorized: UnauthorizedCallback,
-): Promise<string | null> {
+): Promise<string | OrgRestrictionNotice | null> {
   const ownerRepo = splitOwnerRepo(draft.ownerRepo)
   if (!ownerRepo) return INVALID_FORMAT_MESSAGE
   const filePath = draft.filePath.trim()
   if (!filePath) return MISSING_FILE_PATH_MESSAGE
   const fileCheck = await checkProxyReachable(ownerRepo, filePath)
-  if (fileCheck.kind === 'ok') return null
-  if (fileCheck.kind === 'unauthorized') return notifyUnauthorized(onUnauthorized)
-  // Short-circuits like a 401 (business-specifications.md rule 5): an
+  if (fileCheck === 'ok') return null
+  if (fileCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  // Short-circuits like a 401 (business-specifications.md rule 4): an
   // org-OAuth-restriction 403 would 403 again for the same organization-wide
   // reason, so the repo-level fallback below is skipped.
-  if (fileCheck.kind === 'orgRestricted') return buildOrgRestrictionMessage(fileCheck.message)
-  if (fileCheck.kind === 'error') return VALIDATION_UNAVAILABLE_MESSAGE
+  if (fileCheck === 'orgRestricted') return { owner: ownerRepo.owner }
+  if (fileCheck === 'error') return VALIDATION_UNAVAILABLE_MESSAGE
   const repoCheck = await checkProxyReachable(ownerRepo)
-  if (repoCheck.kind === 'ok') return null
-  if (repoCheck.kind === 'unauthorized') return notifyUnauthorized(onUnauthorized)
-  if (repoCheck.kind === 'orgRestricted') return buildOrgRestrictionMessage(repoCheck.message)
-  if (repoCheck.kind === 'notFound') return REPO_NOT_REACHABLE_MESSAGE
+  if (repoCheck === 'ok') return null
+  if (repoCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  if (repoCheck === 'orgRestricted') return { owner: ownerRepo.owner }
+  if (repoCheck === 'notFound') return REPO_NOT_REACHABLE_MESSAGE
   return VALIDATION_UNAVAILABLE_MESSAGE
 }
 

--- a/src/composables/useRepoConfig.ts
+++ b/src/composables/useRepoConfig.ts
@@ -38,8 +38,44 @@ const REPO_NOT_REACHABLE_MESSAGE =
 const VALIDATION_UNAVAILABLE_MESSAGE =
   'Impossible de vérifier le dépôt GitHub pour le moment. Réessayez plus tard.'
 const SESSION_EXPIRED_MESSAGE = 'Votre session GitHub a expiré. Merci de vous reconnecter.'
+const ORG_RESTRICTION_INDICATOR = 'OAuth App access restrictions'
+// Hardcoded literal (security-guidelines.md rule 2) — never built from the
+// proxy response body's own `documentation_url`.
+const ORG_RESTRICTION_DOCS_URL =
+  'https://docs.github.com/articles/restricting-access-to-your-organization-s-data/'
+const ORG_RESTRICTION_MESSAGE_PREFIX =
+  "Votre organisation GitHub restreint l'accès aux applications OAuth tierces : "
+const ORG_RESTRICTION_MESSAGE_SUFFIX = " Plus d'informations : "
+// Ranges of Unicode control / bidi-override / invisible characters to strip
+// from GitHub's echoed message text (security-guidelines.md rule 3). Built
+// from numeric code points rather than typed literally, so this source file
+// never itself contains the invisible/bidi characters it defends against.
+const CONTROL_CHAR_CODE_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x0000, 0x0008],
+  [0x000b, 0x000c],
+  [0x000e, 0x001f],
+  [0x007f, 0x009f],
+  [0x200b, 0x200f],
+  [0x202a, 0x202e],
+  [0x2060, 0x2069],
+  [0xfeff, 0xfeff],
+]
 
-type ProxyCheckResult = 'ok' | 'notFound' | 'unauthorized' | 'error'
+function buildControlCharsPattern(): RegExp {
+  const classBody = CONTROL_CHAR_CODE_RANGES.map(
+    ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end),
+  ).join('')
+  return new RegExp('[' + classBody + ']', 'g')
+}
+
+const CONTROL_CHARS_PATTERN = buildControlCharsPattern()
+
+type ProxyCheckResult =
+  | { kind: 'ok' }
+  | { kind: 'notFound' }
+  | { kind: 'unauthorized' }
+  | { kind: 'orgRestricted'; message: string }
+  | { kind: 'error' }
 type UnauthorizedCallback = (() => void | Promise<void>) | undefined
 
 interface OwnerRepo {
@@ -82,19 +118,49 @@ function buildProxyUrl(ownerRepo: OwnerRepo, path?: string): string {
   return `${PROXY_PATH}?${params.toString()}`
 }
 
-function classifyProxyResponse(status: number): ProxyCheckResult {
-  if (status === 200) return 'ok'
-  if (status === 401) return 'unauthorized'
-  if (status === 404) return 'notFound'
-  return 'error'
+function sanitizeGitHubText(text: string): string {
+  const withoutControlChars = text.replace(CONTROL_CHARS_PATTERN, '')
+  return withoutControlChars.trim()
+}
+
+// Wrapped in try/catch (security-guidelines.md rule 1): the 403 body's exact
+// shape is GitHub's, not a contract this project controls, so any parse
+// failure or unexpected shape resolves to null (the generic-failure path)
+// instead of throwing.
+async function extractOrgRestrictionMessage(response: Response): Promise<string | null> {
+  try {
+    const body: unknown = await response.json()
+    if (typeof body !== 'object' || body === null) return null
+    const record = body as Record<string, unknown>
+    if (typeof record.message !== 'string') return null
+    if (!record.message.includes(ORG_RESTRICTION_INDICATOR)) return null
+    return sanitizeGitHubText(record.message)
+  } catch {
+    return null
+  }
+}
+
+function buildOrgRestrictionMessage(githubMessage: string): string {
+  return ORG_RESTRICTION_MESSAGE_PREFIX + githubMessage + ORG_RESTRICTION_MESSAGE_SUFFIX + ORG_RESTRICTION_DOCS_URL
+}
+
+async function classifyProxyResponse(response: Response): Promise<ProxyCheckResult> {
+  if (response.status === 200) return { kind: 'ok' }
+  if (response.status === 401) return { kind: 'unauthorized' }
+  if (response.status === 404) return { kind: 'notFound' }
+  if (response.status === 403) {
+    const message = await extractOrgRestrictionMessage(response)
+    if (message !== null) return { kind: 'orgRestricted', message }
+  }
+  return { kind: 'error' }
 }
 
 async function checkProxyReachable(ownerRepo: OwnerRepo, path?: string): Promise<ProxyCheckResult> {
   try {
     const response = await fetch(buildProxyUrl(ownerRepo, path))
-    return classifyProxyResponse(response.status)
+    return await classifyProxyResponse(response)
   } catch {
-    return 'error'
+    return { kind: 'error' }
   }
 }
 
@@ -127,13 +193,18 @@ async function resolveValidationError(
   const filePath = draft.filePath.trim()
   if (!filePath) return MISSING_FILE_PATH_MESSAGE
   const fileCheck = await checkProxyReachable(ownerRepo, filePath)
-  if (fileCheck === 'ok') return null
-  if (fileCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
-  if (fileCheck === 'error') return VALIDATION_UNAVAILABLE_MESSAGE
+  if (fileCheck.kind === 'ok') return null
+  if (fileCheck.kind === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  // Short-circuits like a 401 (business-specifications.md rule 5): an
+  // org-OAuth-restriction 403 would 403 again for the same organization-wide
+  // reason, so the repo-level fallback below is skipped.
+  if (fileCheck.kind === 'orgRestricted') return buildOrgRestrictionMessage(fileCheck.message)
+  if (fileCheck.kind === 'error') return VALIDATION_UNAVAILABLE_MESSAGE
   const repoCheck = await checkProxyReachable(ownerRepo)
-  if (repoCheck === 'ok') return null
-  if (repoCheck === 'unauthorized') return notifyUnauthorized(onUnauthorized)
-  if (repoCheck === 'notFound') return REPO_NOT_REACHABLE_MESSAGE
+  if (repoCheck.kind === 'ok') return null
+  if (repoCheck.kind === 'unauthorized') return notifyUnauthorized(onUnauthorized)
+  if (repoCheck.kind === 'orgRestricted') return buildOrgRestrictionMessage(repoCheck.message)
+  if (repoCheck.kind === 'notFound') return REPO_NOT_REACHABLE_MESSAGE
   return VALIDATION_UNAVAILABLE_MESSAGE
 }
 

--- a/src/types/org-restriction-notice.ts
+++ b/src/types/org-restriction-notice.ts
@@ -1,0 +1,9 @@
+/**
+ * A GitHub org-OAuth-restriction 403 (issue #108): carries only the repo
+ * owner the user already configured, never any text read from GitHub's
+ * response body (security-guidelines.md rule 2). The fixed, owner-linked
+ * message text itself lives in `OrgRestrictionNotice.vue`, not here.
+ */
+export interface OrgRestrictionNotice {
+  owner: string
+}

--- a/src/utils/orgRestrictionNotice.spec.ts
+++ b/src/utils/orgRestrictionNotice.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for buildOrgRestrictionSettingsUrl — issue #108.
+ *
+ * Scenarios covered (test-cases.md, issue #108 — org OAuth 403 restriction):
+ *   18 — the link points to the configured owner's own OAuth App access settings page
+ *   19 — the link is built only from the owner, never from the response body's documentation_url
+ *   security-guidelines.md rule 3 — the owner segment is percent-encoded
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildOrgRestrictionSettingsUrl } from './orgRestrictionNotice'
+
+describe('Scenario 18: the link points to the configured owner\'s own OAuth App access settings page', () => {
+  it('builds the organizations/<owner>/settings/oauth_application_policy URL for the given owner', () => {
+    expect(buildOrgRestrictionSettingsUrl('acme-corp')).toBe(
+      'https://github.com/organizations/acme-corp/settings/oauth_application_policy',
+    )
+  })
+
+  it('builds a different URL for a different owner, not a generic GitHub docs page', () => {
+    const url = buildOrgRestrictionSettingsUrl('other-org')
+
+    expect(url).toBe('https://github.com/organizations/other-org/settings/oauth_application_policy')
+    expect(url).not.toContain('docs.github.com')
+  })
+})
+
+describe('security-guidelines.md rule 3: the owner is percent-encoded before insertion into the URL', () => {
+  it('percent-encodes characters that would otherwise break the URL structure', () => {
+    const url = buildOrgRestrictionSettingsUrl('acme/corp #1')
+
+    expect(url).toBe(
+      `https://github.com/organizations/${encodeURIComponent('acme/corp #1')}/settings/oauth_application_policy`,
+    )
+    expect(url).not.toContain('acme/corp #1')
+  })
+})

--- a/src/utils/orgRestrictionNotice.ts
+++ b/src/utils/orgRestrictionNotice.ts
@@ -1,0 +1,13 @@
+/**
+ * Builds the link target for an org-OAuth-restriction notice (issue #108):
+ * the organization's own OAuth App access policy settings page.
+ *
+ * The owner segment is percent-encoded (security-guidelines.md rule 3) even
+ * though GitHub org/user logins are alphanumeric-and-hyphen only today —
+ * building a URL by concatenating unencoded input is the kind of pattern
+ * that becomes a bug the day that assumption changes.
+ */
+export function buildOrgRestrictionSettingsUrl(owner: string): string {
+  const encodedOwner = encodeURIComponent(owner)
+  return `https://github.com/organizations/${encodedOwner}/settings/oauth_application_policy`
+}


### PR DESCRIPTION
## Summary

- Detect the GitHub org "OAuth App access restrictions" 403 case at all three
  `github-api-proxy` call sites (`useRepoConfig.ts`, `useRemotePreferencesSync.ts`,
  `useRemotePreferencesWrite.ts`) by checking the response body's `message` field —
  never surfacing GitHub's own text to the user.
- Show a single, identical, non-retryable message via a new `OrgRestrictionNotice.vue`
  component, with a link (built only from the app's own configured owner, never from
  the response body) to that organization's OAuth App access settings page.
- `useRepoConfig.ts` short-circuits on this 403 the same way it already does for a 401,
  instead of falling through to a redundant repo-reachability check.
- Other statuses (401, 404, 409, 200, unmatched 403 bodies) are unchanged.

## Test plan

- [x] `npx vitest run` — 409 files / 484 tests, all passing (see `test-results.md`)
- [x] Type-check and lint clean on changed files (see `review-results.md`)
- [x] Manual review confirms no response text reaches the DOM/refs and the settings
      link is percent-encoded and owner-only

Closes #108
