### PR TITLE
ci(commands): stop hard-wrapping prose in generated markdown artifacts

### DIFF
--- a/.claude/commands/jli-codes.md
+++ b/.claude/commands/jli-codes.md
@@ -60,6 +60,8 @@ Write `[task-folder]/technical-specifications.md`:
 - For every non-trivial decision (one a reasonable engineer could make differently — choice
   of data structure, helper vs inline, error-handling strategy, splitting responsibilities),
   a one-to-two sentence explanation of WHY.
+- Write each prose paragraph as a single unwrapped line — no manual line breaks
+  mid-paragraph; let the renderer soft-wrap.
 
 If the implementation introduces an architectural decision not yet in `docs/decisions/`, add
 before the final status line:

--- a/.claude/commands/jli-reviews-code.md
+++ b/.claude/commands/jli-reviews-code.md
@@ -71,6 +71,8 @@ what `/jli-codes` must act on:
 - No summary section.
 - End with `status: approved` as the last line. If any finding exists, use
   `status: changes requested` instead. The status line is always last.
+- Write each prose paragraph as a single unwrapped line — no manual line breaks
+  mid-paragraph; let the renderer soft-wrap.
 
 If you hit the 3-failing-shell-command limit, record the error output and end the file with
 `status: changes requested`.

--- a/.claude/commands/jli-reviews-specs.md
+++ b/.claude/commands/jli-reviews-specs.md
@@ -105,7 +105,8 @@ End the file with a status line as its last line:
 - `status: review specs` — amendments are needed (the common case).
 - `status: approved` — the feedback requests no changes and the artifacts are coherent.
 
-Do NOT use horizontal rules (`---`) anywhere in the file.
+Do NOT use horizontal rules (`---`) anywhere in the file. Write each prose paragraph as a
+single unwrapped line — no manual line breaks mid-paragraph; let the renderer soft-wrap.
 
 ## Commit rules reference
 

--- a/.claude/commands/jli-runs-tests.md
+++ b/.claude/commands/jli-runs-tests.md
@@ -97,6 +97,8 @@ Rules:
 - If any test fails, replace the Results section with failure details and replace
   `status: passed` with `status: failed`.
 - The status line is always the last line of the file.
+- Write each prose paragraph as a single unwrapped line — no manual line breaks
+  mid-paragraph; let the renderer soft-wrap.
 
 ## Shell command retry limit
 

--- a/.claude/commands/jli-ships.md
+++ b/.claude/commands/jli-ships.md
@@ -26,7 +26,9 @@ tell the user to finish `/jli-runs-tests @<task-folder>` first.
 
 Derive the PR title from `business-specifications.md` (short imperative summary, ≤70 chars).
 Write the PR body to a temp file: a summary of what changed and why, a test-plan checklist,
-and `Closes #[id]`. Target branch is always `develop` — never `main`.
+and `Closes #[id]`. Target branch is always `develop` — never `main`. Write each prose
+paragraph as a single unwrapped line — no manual line breaks mid-paragraph; let the renderer
+soft-wrap.
 
 ```bash
 cat > /tmp/pr-body.md << 'EOF'

--- a/.claude/commands/jli-verifies-security.md
+++ b/.claude/commands/jli-verifies-security.md
@@ -49,6 +49,8 @@ the final status line:
 ## Output contract
 
 Create `[task-folder]/security-guidelines.md`. End it with `status: ready` as the last line.
+Write each prose paragraph as a single unwrapped line — no manual line breaks mid-paragraph;
+let the renderer soft-wrap.
 
 ## Shell command retry limit
 

--- a/.claude/commands/jli-writes-spec.md
+++ b/.claude/commands/jli-writes-spec.md
@@ -70,7 +70,9 @@ architectural choice with its context, rationale, and consequences. In doubt, as
 
 Create or update `business-specifications.md` in the task folder (its parent for a sub-issue
 subfolder). End it with `status: ready` as the last line. Do NOT use horizontal rules (`---`)
-anywhere in the file.
+anywhere in the file. Write each prose paragraph as a single unwrapped line — no manual line
+breaks mid-paragraph; let the renderer soft-wrap. Only break lines for actual markdown
+structure (headings, list items, code fences).
 
 ## Shell command retry limit
 

--- a/.claude/commands/jli-writes-tests-spec.md
+++ b/.claude/commands/jli-writes-tests-spec.md
@@ -30,7 +30,9 @@ If the spec describes a structural/cleanup task with no runtime-observable behav
 
 ## Output contract
 
-Create `[task-folder]/test-cases.md`. End it with `status: ready` as the last line.
+Create `[task-folder]/test-cases.md`. End it with `status: ready` as the last line. Write each
+prose paragraph as a single unwrapped line — no manual line breaks mid-paragraph; let the
+renderer soft-wrap.
 
 ## Shell command retry limit
 


### PR DESCRIPTION
## Summary

- Several `jli-` chain commands were hard-wrapping generated prose at ~80 chars, which renders as forced mid-paragraph line breaks instead of reflowed text in the resulting markdown artifacts.
- Added an explicit soft-wrap rule ("write each prose paragraph as a single unwrapped line; let the renderer soft-wrap") to every chain command that writes prose markdown output.

## Files changed

- `.claude/commands/jli-writes-spec.md` — `business-specifications.md` output
- `.claude/commands/jli-verifies-security.md` — `security-guidelines.md` output
- `.claude/commands/jli-writes-tests-spec.md` — `test-cases.md` output
- `.claude/commands/jli-codes.md` — `technical-specifications.md` output
- `.claude/commands/jli-reviews-code.md` — `review-results.md` output
- `.claude/commands/jli-runs-tests.md` — `test-results.md` output
- `.claude/commands/jli-ships.md` — PR body output
- `.claude/commands/jli-reviews-specs.md` — `spec-review.md` output

## Test plan

- [ ] N/A — prompt-only change to chain command instructions; no runtime code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)