### PR TITLE
feat(ci): add release-bash.yml as a second release workflow (#133)

### DIFF
--- a/.github/workflows/release-bash.yml
+++ b/.github/workflows/release-bash.yml
@@ -37,18 +37,28 @@ jobs:
           PULL_REQUEST_MERGED: ${{ github.event.pull_request.merged }}
           RELEASE_TARGET_BRANCH: ${{ env.RELEASE_TARGET_BRANCH }}
         run: |
+          emit_outputs() {
+            echo "is_preview=$is_preview" >>"$GITHUB_OUTPUT"
+            echo "is_publish=$is_publish" >>"$GITHUB_OUTPUT"
+            echo "target_branch=$RELEASE_TARGET_BRANCH" >>"$GITHUB_OUTPUT"
+          }
+
           is_preview=false
           is_publish=false
-          if [[ "$BASE_REF" == "$RELEASE_TARGET_BRANCH" ]]; then
-            if [[ "$EVENT_ACTION" == "closed" ]]; then
-              [[ "$PULL_REQUEST_MERGED" == "true" ]] && is_publish=true
-            else
-              is_preview=true
-            fi
+
+          if [[ "$BASE_REF" != "$RELEASE_TARGET_BRANCH" ]]; then
+            emit_outputs
+            exit 0
           fi
-          echo "is_preview=$is_preview" >>"$GITHUB_OUTPUT"
-          echo "is_publish=$is_publish" >>"$GITHUB_OUTPUT"
-          echo "target_branch=$RELEASE_TARGET_BRANCH" >>"$GITHUB_OUTPUT"
+
+          if [[ "$EVENT_ACTION" != "closed" ]]; then
+            is_preview=true
+            emit_outputs
+            exit 0
+          fi
+
+          [[ "$PULL_REQUEST_MERGED" == "true" ]] && is_publish=true
+          emit_outputs
 
   preview:
     name: Preview release
@@ -71,7 +81,6 @@ jobs:
           persist-credentials: false
 
       - name: Run release.sh --dry-run
-        id: release_preview
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -113,7 +122,6 @@ jobs:
           persist-credentials: true
 
       - name: Run release.sh
-        id: release_publish
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-bash.yml
+++ b/.github/workflows/release-bash.yml
@@ -1,0 +1,129 @@
+name: Release (release.sh)
+run-name: ${{ github.actor }} runs release.sh (${{ github.event.pull_request.merged && 'publish' || 'preview' }}) on #${{ github.event.pull_request.number }}
+
+# Second, independent release pipeline (ADR-015). Runs the vendored scripts/release/release.sh
+# instead of the npm-based semantic-release in release.yml (ADR-004). release.yml is untouched
+# and keeps running in parallel; no retirement decision has been made for either pipeline.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+# Source/target branch pair as easily-changed configuration (`on:` triggers cannot reference
+# expressions, so the actual filtering happens in the determine-mode job below). Point both at
+# temporary branches for validation, then switch to develop/main.
+env:
+  RELEASE_SOURCE_BRANCH: temp-source-branch
+  RELEASE_TARGET_BRANCH: temp-target-branch
+
+permissions:
+  contents: read
+
+jobs:
+  determine-mode:
+    name: Determine release mode
+    runs-on: ubuntu-latest
+    outputs:
+      is_preview: ${{ steps.decide.outputs.is_preview }}
+      is_publish: ${{ steps.decide.outputs.is_publish }}
+      target_branch: ${{ steps.decide.outputs.target_branch }}
+    steps:
+      - name: Decide preview vs publish vs skip
+        id: decide
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PULL_REQUEST_MERGED: ${{ github.event.pull_request.merged }}
+          RELEASE_TARGET_BRANCH: ${{ env.RELEASE_TARGET_BRANCH }}
+        run: |
+          is_preview=false
+          is_publish=false
+          if [[ "$BASE_REF" == "$RELEASE_TARGET_BRANCH" ]]; then
+            if [[ "$EVENT_ACTION" == "closed" ]]; then
+              [[ "$PULL_REQUEST_MERGED" == "true" ]] && is_publish=true
+            else
+              is_preview=true
+            fi
+          fi
+          echo "is_preview=$is_preview" >>"$GITHUB_OUTPUT"
+          echo "is_publish=$is_publish" >>"$GITHUB_OUTPUT"
+          echo "target_branch=$RELEASE_TARGET_BRANCH" >>"$GITHUB_OUTPUT"
+
+  preview:
+    name: Preview release
+    needs: determine-mode
+    if: needs.determine-mode.outputs.is_preview == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    concurrency:
+      group: release-bash-preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run release.sh --dry-run
+        id: release_preview
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          bash scripts/release/release.sh --yes --dry-run 2>&1 | tee release-output.log
+          script_exit_code=${PIPESTATUS[0]}
+          set -e
+          if [[ $script_exit_code -ne 0 ]] && grep -q "no commit to release in range" release-output.log; then
+            echo "No releasable commits since the last tag; nothing to preview."
+            exit 0
+          fi
+          exit "$script_exit_code"
+
+  publish:
+    name: Publish release
+    needs: determine-mode
+    if: needs.determine-mode.outputs.is_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: release-bash-publish-${{ needs.determine-mode.outputs.target_branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.determine-mode.outputs.target_branch }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Run release.sh
+        id: release_publish
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set +e
+          bash scripts/release/release.sh --yes 2>&1 | tee release-output.log
+          script_exit_code=${PIPESTATUS[0]}
+          set -e
+          if [[ $script_exit_code -ne 0 ]] && grep -q "no commit to release in range" release-output.log; then
+            echo "No releasable commits since the last tag; nothing to publish."
+            exit 0
+          fi
+          exit "$script_exit_code"

--- a/docs/decisions/ADR-015-bash-script-release-workflow.md
+++ b/docs/decisions/ADR-015-bash-script-release-workflow.md
@@ -1,0 +1,50 @@
+# ADR-015: Bash Script (`release.sh`) as a Second Release Workflow
+
+**Date:** 2026-08-11
+**Status:** Proposed
+
+## Context
+
+ADR-004 established `semantic-release` (npm-based, triggered on push to `main`) as the project's release automation. Issue #133 asks for a new `.github/workflows/release-bash.yml` workflow built around [`release.sh`](https://github.com/JeremieLitzler/semantic-release-script-testing/blob/main/release.sh), a bash script that classifies conventional commits, computes the next version, generates release notes, and publishes a GitHub release. Its `gate()` approval prompts require `--yes` to bypass; without it, they call `die` in any non-TTY environment (`"no terminal available to confirm ... — rerun with --yes"`), so every CI run — preview or publish — must pass `--yes`. `--dry-run`/`-n` only skips the destructive remote operations (tag push, release publish); it does not skip the gates.
+
+The new workflow triggers on a pull request merging from a source branch into a target branch, rather than on push to `main`. It is validated first against two temporary branches, then pointed at `develop` (source) and `main` (target) — both protected branches, so tag/release creation needs a GitHub App token rather than the default `GITHUB_TOKEN`.
+
+This means two release mechanisms will exist side by side for a period: the existing `semantic-release` pipeline (ADR-004) and the new `release.sh`-based one. That coexistence, and the fact that the new pipeline is intended to be evaluated as a _replacement_ for the old one, is a significant enough shift to record.
+
+## Decision
+
+Add `release-bash.yml`, running a vendored copy of `release.sh`, as a second, independent release pipeline with two modes, both against the configured target branch (source/target held as easily-changed workflow configuration, not hardcoded):
+
+- **Preview** — any pull request opened/updated against the target branch runs `release.sh --yes --dry-run`: gates auto-confirm (required for CI), but no tag/push/release is created — surfaces the version bump and release notes the merge would produce.
+- **Publish** — a pull request closed-as-merged into the target branch runs `release.sh --yes` (no `--dry-run`): creates the tag and GitHub release.
+- Auth: publish mode uses a GitHub App token via `actions/create-github-app-token`, reusing the existing `GH_APP_ID` / `GH_APP_KEY` secrets (same secrets as `release.yml`'s `tibdex/github-app-token`, which is unmaintained). Preview mode does not push, so it does not need the App token.
+- No bump-level override, no `CHANGELOG.md` committed back in either mode — output is a GitHub release (publish) or a surfaced preview (preview) only.
+- `release.yml` (ADR-004's `semantic-release` workflow) is **not** removed or modified by this change. It keeps running on push to `main` in parallel.
+
+The existing `semantic-release` workflow (`release.yml`) is a candidate for deprecation once `release-bash.yml` has proven itself on real merges into `develop`/`main`. No retirement date or criteria are set by this ADR — that is a follow-up decision once the new pipeline has run successfully in production.
+
+## Consequences
+
+### Positive
+
+- Human-reviewable, scriptable release notes and version decisions independent of the `semantic-release` npm dependency chain.
+- Validated on temporary branches before touching `develop`/`main`, lowering the risk of a broken release process on protected branches.
+- Reuses the existing GitHub App auth pattern and secrets — no new credentials to provision.
+- Opens a path to retiring the heavier `semantic-release` toolchain (five npm packages per ADR-004) if `release.sh` proves sufficient.
+- Remove dependencies to several NPM packages, some that can become a security issue over time.
+
+### Negative
+
+- Two release mechanisms run in parallel for an unspecified period, which is a coexistence risk: both could tag/release from the same merge if triggers aren't kept mutually exclusive (currently `release.yml` triggers on push to `main`, `release-bash.yml` on PR-merge into a configurable target — the two must not both point at `main` pushes/merges without an explicit decision to cut over).
+- `release.sh` is an external, actively-tested script (`semantic-release-script-testing`) rather than a versioned npm dependency — no changelog/semver guarantees on upstream changes; the vendored copy must be updated deliberately.
+- Adds a second unattended (`--yes`) automation path; its publish mode has push access to protected branches, widening the blast radius of a release-process bug. Preview mode runs `--yes` on every PR update (including from external contributors), so its output must not be trusted for anything beyond display.
+
+## Alternatives Considered
+
+- **Replace `release.yml` outright**: rejected for now — the issue asks to validate the new script on temporary branches first, so removing the proven pipeline before that validation would leave no fallback.
+- **Run `release.sh` from within the existing `release.yml` job**: rejected — mixing two differently-triggered, differently-configured release mechanisms in one workflow file would make the temporary branch → `develop`/`main` cutover harder to reason about and roll back.
+
+## Notes
+
+- Deprecating `release.yml` in favor of `release-bash.yml` is anticipated but not decided here; track it as a follow-up once the new workflow has run successfully against `develop` → `main`.
+- `tibdex/github-app-token` (used by `release.yml`) is unmaintained; `release-bash.yml` uses `actions/create-github-app-token` instead. This ADR does not retroactively change `release.yml`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -26,6 +26,7 @@ Status values: `Proposed` | `Accepted` | `Deprecated` | `Superseded by ADR-XXX`
 | [ADR-012](./ADR-012-github-repo-as-sync-backend.md)               | User-Owned GitHub Repository as Remote Sync Backend             | Accepted | 2026-04-30 |
 | [ADR-013](./ADR-013-page-level-load-orchestrator.md)              | Page-Level Load Orchestrator for Shared Singleton State Under Async Mutation | Accepted | 2026-07-21 |
 | [ADR-014](./ADR-014-scheduled-function-pat-auth.md)               | Scheduled Netlify Function with Fine-Grained PAT for Daily Price History     | Proposed | 2026-07-23 |
+| [ADR-015](./ADR-015-bash-script-release-workflow.md)              | Bash Script (`release.sh`) as a Second Release Workflow                     | Proposed | 2026-08-11 |
 
 ## How to Add a New ADR
 

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/README.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/README.md
@@ -1,0 +1,11 @@
+Worktree: E:/Git/GitHub/french-gas-stations-scraper_feat-release-bash-workflow
+
+# Issue #133: Update release workflow to use `release.sh`
+
+Using https://github.com/JeremieLitzler/semantic-release-script-testing/blob/main/release.sh, add a new `.github/workflows/release-bash.yml` workflow to use the release script and trigger it on successfull merge between a source and a target branch.
+
+To multiple PR, let's set the source branch and target branch to be two temporary branches push to remote.
+
+Then the source branch will become `develop` and the target branch will be `main`.
+
+Also take into account that `develop` and `main` are protected branches.

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/business-specifications.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/business-specifications.md
@@ -1,0 +1,46 @@
+# Business Specifications: Release via `release.sh`
+
+## Goal and scope
+
+Add a second, independent release automation path that runs `release.sh` (sourced from `JeremieLitzler/semantic-release-script-testing`) instead of the npm-based `semantic-release` used by [[release.yml]] / ADR-004. It has two observable modes against a configured source/target branch pair: a **preview** on any pull request targeting the target branch, and a **publish** once such a pull request merges. `release.yml` is untouched and keeps running in parallel — no decision is made yet about retiring it.
+
+## Files to create or modify
+
+- `.github/workflows/release-bash.yml` — new workflow with two triggers against the configured target branch:
+  - any pull request opened/updated against it — runs a preview.
+  - a pull request closed as merged into it — runs the publish.
+- A vendored copy of `release.sh` (and any files it directly requires to run) committed into this repo, kept in sync with the upstream script.
+
+## Branch configuration
+
+- The source and target branch names are held as easily-changed workflow configuration, not hardcoded into trigger logic — so they can point at two temporary branches for validation before being switched to `develop` (source) and `main` (target).
+- The workflow only acts on merges into the configured target branch; merges into any other branch are ignored.
+- A pull request that is closed **without** being merged (declined, abandoned) must not trigger a release.
+
+## Execution rules
+
+- Both modes run fully unattended (`--yes`/`-y`): no approval gate waits on interactive input, since GitHub Actions provides no TTY — without `--yes`, the script errors out immediately at the first gate ("no terminal available to confirm ... — rerun with --yes"), so `--yes` is required in every CI run regardless of mode.
+- **Preview** (any PR against the target branch): also runs with `--dry-run`/`-n`. It computes and surfaces the version bump and release notes that would be produced, without creating a tag, pushing, or publishing a release. Re-running the preview on further pushes to the same PR reflects the PR's current commits — it does not accumulate stale output from earlier pushes.
+- **Publish** (PR merged into the target branch): runs without `--dry-run`. It creates a git tag and publishes a GitHub release with the generated notes.
+- Version bump, commit classification, and release-notes content are determined by the script's own conventional-commit analysis of the range since the last tag — this workflow does not override the bump level, in either mode.
+- No file (e.g. `CHANGELOG.md`) is committed back to the repository in either mode.
+- If there are no releasable commits since the last tag on the relevant range, both modes complete without creating a tag or release (preview shows no release notes), and without failing the run.
+- Publish mode: if a tag for the computed version already exists (e.g. re-run, race between overlapping merges), the workflow fails visibly rather than silently overwriting or duplicating a release.
+- Publish mode: only one run is allowed to execute at a time for a given target branch; a second merge landing while a run is in progress waits rather than racing it. Preview runs for different PRs are independent of each other and of any in-progress publish run.
+
+## Authentication
+
+- `develop` and `main` are protected branches. The **publish** mode authenticates as a GitHub App (via `actions/create-github-app-token`, replacing the unmaintained `tibdex/github-app-token` used in `release.yml`) so the tag push and release creation succeed against branch protection, consistent with the existing `GH_APP_ID` / `GH_APP_KEY` secrets. The default `GITHUB_TOKEN` is not used for the release-creating steps.
+- **Preview** mode does not push or write anything, so it does not require the GitHub App token unless reading the commit range needs more than the default `GITHUB_TOKEN` provides.
+
+## Out of scope
+
+- Retiring or modifying `release.yml` / ADR-004's npm-based `semantic-release` pipeline.
+- Writing `CHANGELOG.md` back to the repository.
+- Any UI-facing or `src/` change — this is CI/CD configuration only.
+
+### ADR Required
+
+This introduces a second, structurally different release automation pattern (a vendored bash script, GitHub App token via `actions/create-github-app-token`, PR-merge-triggered) running alongside the npm/semantic-release pattern documented in ADR-004. Since two release mechanisms will coexist with no retirement decision for either yet, this choice and its rationale should be captured in a new ADR.
+
+status: ready

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/manual-validation-plan.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/manual-validation-plan.md
@@ -1,0 +1,96 @@
+# Manual Validation Plan: `release-bash.yml`
+
+This feature is CI/CD configuration (a GitHub Actions workflow plus a vendored bash script) —
+there is no TypeScript export, composable, or component for Vitest to exercise, so this phase
+produces a manual runbook instead of `.spec.ts` files. Each `test-cases.md` scenario below maps
+to concrete steps against GitHub itself. Run this after `/jli-commits`, before `/jli-ships`.
+
+## Stage 0 — setup
+
+1. Confirm `.github/workflows/release-bash.yml`'s `env:` block still reads:
+
+   ```yaml
+   RELEASE_SOURCE_BRANCH: temp-source-branch
+   RELEASE_TARGET_BRANCH: temp-target-branch
+   ```
+
+2. Push two temporary branches from the current tip of this feature branch (or from `develop`,
+   whichever already has commits to release):
+
+   ```bash
+   rtk git push origin HEAD:temp-target-branch
+   rtk git push origin HEAD:temp-source-branch
+   ```
+
+   `temp-target-branch` is unprotected, so tag/release creation on it does **not** require the
+   GitHub App token to succeed — that specific guarantee is validated separately in Stage 2.
+
+3. Confirm `GH_APP_ID` / `GH_APP_KEY` secrets already exist on the repo (reused from
+   `release.yml` per ADR-015) — `gh secret list` should show both.
+
+## Stage 1 — trigger scope and preview mode (temp branches)
+
+| #   | Test case                                                               | Steps                                                                                                                  | Expected observation                                                                                                                                                                                        |
+| --- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | PR opened against `T` runs preview                                      | Commit a `feat: …` change on `temp-source-branch`, open a PR into `temp-target-branch`                                 | Actions tab shows `determine-mode` → `preview` running; `publish` shows "Skipped"                                                                                                                           |
+| 2   | New push re-runs preview with current commits                           | Push a second commit (e.g. `fix: …`) to the same PR branch                                                             | A new `preview` run starts (previous one shows cancelled, per `cancel-in-progress: true`); its log lists both commits, not just the first                                                                   |
+| 3   | PR opened against a different branch triggers nothing                   | Open a PR from any branch into a third branch (not `temp-target-branch`)                                               | Neither `preview` nor `publish` appears as a run for that PR (workflow run shows both jobs skipped)                                                                                                         |
+| 6   | PR closed without merge triggers nothing                                | Close the Stage 1 PR using "Close pull request" (not "Merge")                                                          | No new `publish` run appears; `is_publish` stayed `false`                                                                                                                                                   |
+| 7   | Releasable commits → preview surfaces bump + notes, no tag/push/release | Re-open (or open a fresh) PR with a `feat:` commit                                                                     | `preview` job log prints "Step 1 — evaluate the new version" with a `minor` bump and a populated "Step 2 — release notes"; no tag appears under `git ls-remote --tags origin`, no GitHub release is created |
+| 8   | No releasable commits → completes without failing                       | Open a PR whose only commits already exist in `temp-target-branch`'s history (empty diff) or amend to zero new commits | `preview` job finishes green, log shows "No releasable commits since the last tag; nothing to preview."                                                                                                     |
+| 20  | Shell metacharacters in a commit message stay inert                     | Commit with a subject like ``feat: test `whoami` and $(id) injection`` on the PR branch                                | `preview` log prints that exact text as part of the release notes/commit listing; no command executed (no `whoami`/`id` output appears anywhere in the log)                                                 |
+
+Note on #9 / #21 (fork PR, no write credentials): reproducing a real fork PR isn't practical from
+this repo alone. This is instead verified statically — already confirmed in code review — by
+reading `release-bash.yml`'s `preview` job: `permissions: contents: read, issues: read,
+pull-requests: read` (no `contents: write`), and no step references `secrets.GH_APP_ID` /
+`secrets.GH_APP_KEY`. If a real external-contributor PR appears later, confirm its `preview` run
+still completes (this is the observable proof the token scope was sufficient).
+
+## Stage 2 — publish mode (temp branches)
+
+| #   | Test case                                                 | Steps                                                                                                                                                                          | Expected observation                                                                                                                                                           |
+| --- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 4   | PR from `S` merged into `T` runs publish                  | Merge the Stage 1 PR (with releasable commits) via GitHub's "Merge pull request"                                                                                               | `publish` job runs; `determine-mode` shows `is_publish=true`                                                                                                                   |
+| 10  | Releasable commits → tag + release created                | (same merge as above)                                                                                                                                                          | A new `vX.Y.Z` tag appears (`git ls-remote --tags origin`) and a GitHub release exists at `/releases/tag/vX.Y.Z` with the generated notes                                      |
+| 5   | Merge into a branch other than `T` doesn't publish        | Merge an unrelated PR into a third branch                                                                                                                                      | No `publish` run appears for that merge                                                                                                                                        |
+| 11  | No releasable commits → completes without failing, no tag | Merge a PR whose commits are already covered by the last tag                                                                                                                   | `publish` job finishes green, log shows "No releasable commits since the last tag; nothing to publish."; no new tag created                                                    |
+| 12  | Existing tag → fails visibly                              | Immediately re-run the `publish` job for the same merge (Actions → re-run job), or manually push a tag matching the next computed version before merging another releasable PR | `publish` job fails (red X); log shows `release.sh`'s own `die`: `tag vX.Y.Z already exists locally` — no duplicate tag/release is created                                     |
+| 13  | Overlapping publish runs on `T` queue, not race           | Merge two releasable PRs into `temp-target-branch` in quick succession                                                                                                         | Actions tab shows the second `publish` run in "Queued" state until the first completes, not running concurrently (concurrency group `release-bash-publish-temp-target-branch`) |
+| 14  | In-progress publish doesn't block an unrelated preview    | While a `publish` run from step 13 is still in progress, open a third PR against `temp-target-branch`                                                                          | Its `preview` job starts and completes immediately, not waiting on the `publish` run                                                                                           |
+| 15  | No `CHANGELOG.md` committed                               | After any successful publish above                                                                                                                                             | `git log --stat -1 temp-target-branch` (or the merge commit itself) shows no `CHANGELOG.md` change; `publish` job never ran `git add`/`git commit`                             |
+| 16  | Unattended execution, no TTY hang                         | Observe any `preview` or `publish` run above                                                                                                                                   | Job completes (green or a clear failure) — never stays "in progress" waiting on input; log shows `-> ... (auto-confirmed with --yes)` at each gate                             |
+| 17  | Publish runs against temp branches only                   | After Stage 2, inspect `develop` and `main`                                                                                                                                    | Neither has a new commit, tag, or release — only `temp-target-branch` changed                                                                                                  |
+
+## Stage 3 — switch to `develop`/`main` (protected branches)
+
+1. Edit `.github/workflows/release-bash.yml`'s `env:` block:
+
+   ```yaml
+   RELEASE_SOURCE_BRANCH: develop
+   RELEASE_TARGET_BRANCH: main
+   ```
+
+2. Commit this change on its own (`ci: point release-bash.yml at develop/main (#133)`) and get it
+   merged into `develop` through the normal PR flow so the updated trigger config is live on
+   `main`'s side too (the workflow file itself must exist on the base branch GitHub evaluates
+   triggers against).
+3. Open a real PR from `develop` into `main` with at least one releasable commit.
+
+| #   | Test case                                                   | Steps                   | Expected observation                                                                                                                                                                                                                                                                               |
+| --- | ----------------------------------------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 18  | Same behaviour validated on `develop`/`main`                | Open the PR from step 3 | `preview` job runs identically to Stage 1's #7                                                                                                                                                                                                                                                     |
+| 19  | Protected-branch push/release succeeds via GitHub App token | Merge the PR            | `publish` job's "Generate GitHub App token" step succeeds, the tag push and `gh release create` succeed despite `main`'s branch protection — confirm by checking the App token step's log shows a token was minted, and that the tag/release appear the same as Stage 2's #10, this time on `main` |
+
+## Cleanup
+
+Once Stage 1/2 are validated, delete the temporary branches and any test tags/releases they
+produced:
+
+```bash
+rtk git push origin --delete temp-source-branch temp-target-branch
+gh release delete vX.Y.Z --yes   # for each test tag/release created in Stage 1/2
+git push origin --delete vX.Y.Z  # matching tag
+```
+
+status: ready

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/review-results.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/review-results.md
@@ -23,10 +23,8 @@ type-check: clean
 
 ## Checklist findings
 
-**Object Calisthenics — nested `if`/`else` in the `determine-mode` step, contradicting the technical-spec's own claim.** `.github/workflows/release-bash.yml:42-48` nests two `if` blocks and uses `else` to compute `is_preview`/`is_publish`, but `technical-specifications.md` describes this step as keeping "one level of branching depth." Flatten with guard clauses instead, e.g. emit the all-false outputs and `exit 0` immediately when `$BASE_REF != $RELEASE_TARGET_BRANCH`, then a second guard for the `closed`-without-merge case, leaving only a single top-level check for the publish/preview split. Update the technical-specifications.md line to match once fixed (or drop the claim).
+Both prior findings are resolved: `determine-mode`'s decision step (`release-bash.yml:39-61`) now uses two early-exit guard clauses plus an `emit_outputs()` helper instead of nested `if`/`else`, and no longer has unused `release_preview`/`release_publish` step `id`s. `technical-specifications.md` was updated to match and records both fixes.
 
-**Dead code — unused step `id`s.** `.github/workflows/release-bash.yml:74` (`id: release_preview`) and `:116` (`id: release_publish`) are never referenced by any downstream step or output; no other step reads `steps.release_preview.*` or `steps.release_publish.*`. Either wire them to a job `outputs:` (if a future consumer is intended) or drop the `id:` keys.
+All other checklist items ✓ — every rule in `security-guidelines.md` remains verifiably addressed, the implementation still matches every business-spec requirement, naming is clear throughout, and no new dead code, unreachable branches, or abbreviations were introduced by the fix.
 
-All other checklist items ✓ — every rule in `security-guidelines.md` is verifiably addressed (preview: no GH App secrets, read-only `permissions:`, `pull_request` not `pull_request_target`; PR/branch data passed through `env:` not interpolated into `run:` strings; App-token scoping is external GitHub App configuration outside this file's reach, documented in ADR-015; `release.sh` is a pinned, diff-verified vendor copy with a documented sync procedure in `scripts/release/VENDORED.md`), the implementation matches every business-spec requirement (trigger scope, `--yes`/`--dry-run` modes, no bump override, no `CHANGELOG.md` write, no-releasable-commits handled without failing, existing-tag failure left to `release.sh`'s own `die()`, publish concurrency queues per target branch while preview concurrency is independent per PR, GitHub App token replaces `tibdex/github-app-token`, `release.yml` untouched, no `src/` changes), and naming is clear throughout with no abbreviations.
-
-status: changes requested
+status: approved

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/review-results.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/review-results.md
@@ -1,0 +1,32 @@
+# Review Results: Release via `release.sh`
+
+lint: fails, but every failing file is pre-existing and unrelated to this task's changes (`.github/workflows/release-bash.yml`, `scripts/release/release.sh`, `scripts/release/VENDORED.md` — none are JS/TS, none touch the two files below). Not caused by, or fixable within, this change.
+
+```
+E:\Git\GitHub\french-gas-stations-scraper_feat-release-bash-workflow\src\composables\usePreferencesExport.spec.ts
+  39:5  error  'lastDownloaded' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+E:\Git\GitHub\french-gas-stations-scraper_feat-release-bash-workflow\src\composables\usePreferencesImport.spec.ts
+   36:15  error  'PreferencesDiff' is defined but never used       @typescript-eslint/no-unused-vars
+   71:33  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   72:36  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+   72:50  error  '_s' is defined but never used                    @typescript-eslint/no-unused-vars
+   73:42  error  '_label' is defined but never used                @typescript-eslint/no-unused-vars
+  433:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  466:34  error  '_url' is defined but never used                  @typescript-eslint/no-unused-vars
+  468:11  error  'externalUrl' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+✖ 9 problems (9 errors, 0 warnings)
+```
+
+type-check: clean
+
+## Checklist findings
+
+**Object Calisthenics — nested `if`/`else` in the `determine-mode` step, contradicting the technical-spec's own claim.** `.github/workflows/release-bash.yml:42-48` nests two `if` blocks and uses `else` to compute `is_preview`/`is_publish`, but `technical-specifications.md` describes this step as keeping "one level of branching depth." Flatten with guard clauses instead, e.g. emit the all-false outputs and `exit 0` immediately when `$BASE_REF != $RELEASE_TARGET_BRANCH`, then a second guard for the `closed`-without-merge case, leaving only a single top-level check for the publish/preview split. Update the technical-specifications.md line to match once fixed (or drop the claim).
+
+**Dead code — unused step `id`s.** `.github/workflows/release-bash.yml:74` (`id: release_preview`) and `:116` (`id: release_publish`) are never referenced by any downstream step or output; no other step reads `steps.release_preview.*` or `steps.release_publish.*`. Either wire them to a job `outputs:` (if a future consumer is intended) or drop the `id:` keys.
+
+All other checklist items ✓ — every rule in `security-guidelines.md` is verifiably addressed (preview: no GH App secrets, read-only `permissions:`, `pull_request` not `pull_request_target`; PR/branch data passed through `env:` not interpolated into `run:` strings; App-token scoping is external GitHub App configuration outside this file's reach, documented in ADR-015; `release.sh` is a pinned, diff-verified vendor copy with a documented sync procedure in `scripts/release/VENDORED.md`), the implementation matches every business-spec requirement (trigger scope, `--yes`/`--dry-run` modes, no bump override, no `CHANGELOG.md` write, no-releasable-commits handled without failing, existing-tag failure left to `release.sh`'s own `die()`, publish concurrency queues per target branch while preview concurrency is independent per PR, GitHub App token replaces `tibdex/github-app-token`, `release.yml` untouched, no `src/` changes), and naming is clear throughout with no abbreviations.
+
+status: changes requested

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/security-guidelines.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/security-guidelines.md
@@ -1,0 +1,13 @@
+# Security Guidelines: Release via `release.sh`
+
+1. **What**: The preview job must never receive the GitHub App token (`GH_APP_ID`/`GH_APP_KEY`) or any secret with write access, and its job `permissions:` block must be scoped to read-only (no `contents: write`, no `pull-requests: write`). **Where**: the preview job in `.github/workflows/release-bash.yml`. **Why**: preview runs on every pull request targeting the branch, including ones from external contributors or forks — granting it write credentials would let an untrusted PR obtain push/release access it has no business having.
+
+2. **What**: Trigger preview with `pull_request`, never `pull_request_target`. **Where**: `.github/workflows/release-bash.yml` preview trigger. **Why**: `pull_request_target` runs with the base repo's secrets and permissions against the fork's checked-out code — the classic GitHub Actions privilege-escalation combo; `pull_request` keeps fork runs in the fork's own low-privilege context.
+
+3. **What**: Never interpolate PR/commit data (titles, commit messages, branch names) directly into a shell `run:` string; pass it through environment variables or the script's own argument parsing instead. **Where**: any workflow step that feeds commit/PR text to `release.sh`. **Why**: `release.sh` classifies arbitrary conventional-commit messages, which on a fork PR are fully attacker-controlled — unescaped shell interpolation of that text is a known GitHub Actions script-injection vector.
+
+4. **What**: Scope the GitHub App installation used for publish to `contents: write` only on this repository — no `admin`, no org-wide install. **Where**: the GitHub App configuration backing `GH_APP_ID`/`GH_APP_KEY` (same app as `release.yml`, per ADR-015). **Why**: this token is deliberately used to bypass branch protection on `develop`/`main` for tag pushes and releases; a broader grant widens what a compromised publish run (or leaked secret) could do beyond tagging/releasing.
+
+5. **What**: Pin the vendored `release.sh` copy to a specific reviewed commit/tag from `JeremieLitzler/semantic-release-script-testing` rather than tracking its default branch, and re-review the diff on every deliberate sync (per the business spec's "kept in sync deliberately"). **Where**: the vendored script file(s) in this repo. **Why**: it is an external, non-npm dependency with no semver/changelog guarantees — an unreviewed upstream change could alter what an unattended (`--yes`) job executes against protected branches.
+
+status: ready

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/technical-specifications.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/technical-specifications.md
@@ -1,0 +1,33 @@
+# Technical Specifications: Release via `release.sh`
+
+## Files created or changed
+
+- `.github/workflows/release-bash.yml` — new workflow with three jobs (`determine-mode`, `preview`, `publish`) implementing the preview/publish modes described in the business spec.
+- `scripts/release/release.sh` — vendored, byte-for-byte copy of upstream `release.sh` pinned to commit `de0a43a7790f509371219087c10602a0f8c39bb9` of `JeremieLitzler/semantic-release-script-testing`.
+- `scripts/release/VENDORED.md` — new file recording the vendored source, the pinned commit, and the deliberate-sync procedure (security guideline 5).
+
+## Non-trivial decisions
+
+**Branch config as a workflow-level `env:` block, not repository variables.** `on:` triggers cannot reference expressions at all, so the target-branch filter has to run inside a job step either way; between a workflow-level `env:` block and GitHub repository variables (`vars.*`), the user chose the `env:` block so switching from the temporary branches to `develop`/`main` stays a version-controlled, reviewable commit rather than an out-of-band UI change.
+
+**A leading `determine-mode` job computes booleans instead of filtering directly in each job's `if:`.** `pull_request.branches:` can't take an expression, and workflow-level `env` context is not reliably available inside job-level `if:` conditions, but job outputs via the `needs` context are. Centralizing the trigger-scope logic (target branch match, closed-vs-merged) in one job also means the six trigger-scope test cases are exercised by one script instead of duplicated conditionals in both `preview` and `publish`.
+
+**PR/branch data passed through step-level `env:`, not interpolated into `run:` strings.** Per security guideline 3, `BASE_REF`, `EVENT_ACTION` and `PULL_REQUEST_MERGED` are read as shell variables (`$BASE_REF`, …) rather than `${{ github.event... }}` appearing inside the script body — this holds even though these particular fields are structurally constrained (branch names, a fixed action enum, a boolean) and not free text like a commit message, since the guideline calls out branch names explicitly and the cost of doing it the safe way is zero.
+
+**`release.sh`'s "no commits in range" `die()` is caught and turned into a successful no-op.** The vendored script itself treats an empty commit range as a hard failure (`die "no commit to release in range"`, exit 1) — there's no flag to make it a soft success. Business spec/test cases 8 and 11 require both modes to complete without failing when there are no releasable commits, so each `run:` step tees the script's output, inspects the exit code, and re-raises everything except that one specific message (matched by exact substring). Any other non-zero exit — a genuinely already-existing tag (test 12), a push failure, an auth failure — still fails the job visibly, since the substring won't match.
+
+**Publish's checkout uses `token: <GitHub App token>` (persisted), not just `GH_TOKEN` for the `gh` CLI.** `release.sh` pushes the tag with a plain `git push origin <tag>`, not `gh`. Setting `GH_TOKEN` alone only authenticates the `gh` CLI calls (issue lookups, `gh release create`); the tag push needs git itself to be authenticated, which `actions/checkout`'s `token:` input provides via a persisted credential helper. Preview never pushes, so its checkout keeps `persist-credentials: false` and relies on the default `GITHUB_TOKEN` only for the `gh` CLI issue-title lookups (contents/issues/pull-requests all read-only), satisfying security guideline 1 and test case 9/21.
+
+**`RELEASE_SOURCE_BRANCH` is declared but not used as an active filter.** The business spec and test cases describe the publish trigger purely in terms of the *target* branch (any PR merged into `T` triggers publish); no test case asks for a PR to be rejected because it came from a branch other than the configured source. `RELEASE_SOURCE_BRANCH` is kept as documentation of the intended pairing (and for a future workflow iteration to use, e.g. an eventual `release.yml` cutover decision) rather than silently adding an unrequested filter.
+
+**Preview's concurrency group cancels in-progress runs per PR; publish's group queues per target branch.** Test case 2 wants a fresh push to reflect the PR's current commits without stale output — cancelling a superseded preview run for the same PR number is the natural way to avoid two previews for the same PR racing each other in the log. Test case 13 wants overlapping publish runs on the same target branch to queue rather than race, so `cancel-in-progress: false` there is deliberate — the opposite behavior would silently drop a merge's release. Test case 14 (preview unaffected by an in-progress publish) is satisfied because the two concurrency groups are named independently (`release-bash-preview-<PR number>` vs `release-bash-publish-<target branch>`) and are scoped per job, not per workflow.
+
+**`scripts/release/release.sh` is invoked via `bash scripts/release/release.sh …`, not `./scripts/release/release.sh`.** The file was vendored via the GitHub API and written on a Windows checkout, so its executable bit is not reliably set in git. Invoking it through `bash` avoids depending on the executable bit at all, so no `chmod +x` step is needed in the workflow or the vendoring procedure.
+
+**`scripts/release/VENDORED.md` records the pin and sync procedure instead of annotating `release.sh` itself.** Keeping `release.sh` byte-for-byte identical to upstream (confirmed via `diff` against the fetched copy) means a future deliberate sync can diff the two files directly with no noise from repo-local comments.
+
+## Object Calisthenics note
+
+This feature is entirely YAML workflow configuration plus one vendored external shell script — there is no application code to apply class-shape rules (indentation levels, instance variables, first-class collections, etc.) to. The `determine-mode` step keeps one level of branching depth and named, non-abbreviated shell variables where that's meaningful in a CI script.
+
+status: ready

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/technical-specifications.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/technical-specifications.md
@@ -26,8 +26,12 @@
 
 **`scripts/release/VENDORED.md` records the pin and sync procedure instead of annotating `release.sh` itself.** Keeping `release.sh` byte-for-byte identical to upstream (confirmed via `diff` against the fetched copy) means a future deliberate sync can diff the two files directly with no noise from repo-local comments.
 
+**Review fix: `determine-mode`'s decision step uses guard clauses, not nested `if`/`else`.** The first pass nested a `closed`-vs-open check inside a target-branch check with an `else` branch; code review flagged this against Object Calisthenics rule 2 and the fact that the surrounding prose claimed flat branching that the code didn't actually have. The step now exits early after emitting outputs for the "wrong target branch" and "not closed" cases via a small `emit_outputs()` helper (rule 1: extract the repeated three-line output block into a named function instead of repeating it at each exit point), leaving one `if` per guard and no `else` anywhere.
+
+**Review fix: removed the unused `release_preview`/`release_publish` step `id`s.** Nothing downstream ever read `steps.release_preview.*` or `steps.release_publish.*` — dead identifiers flagged in code review. Dropped rather than wired to job `outputs:` since no consumer is planned; an `id` can be re-added if a future change needs to reference the step's outcome.
+
 ## Object Calisthenics note
 
-This feature is entirely YAML workflow configuration plus one vendored external shell script — there is no application code to apply class-shape rules (indentation levels, instance variables, first-class collections, etc.) to. The `determine-mode` step keeps one level of branching depth and named, non-abbreviated shell variables where that's meaningful in a CI script.
+This feature is entirely YAML workflow configuration plus one vendored external shell script — there is no application code to apply class-shape rules (indentation levels, instance variables, first-class collections, etc.) to. The `determine-mode` step keeps one level of branching depth per guard clause (no nested `if`, no `else`) and named, non-abbreviated shell variables where that's meaningful in a CI script.
 
 status: ready

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/test-cases.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/test-cases.md
@@ -1,0 +1,45 @@
+# Test Cases: Release via `release.sh`
+
+## Trigger scope
+
+1. Given the workflow's configured target branch is `T`, when a pull request is opened against `T`, then the preview job runs.
+2. Given a preview already ran for a pull request, when new commits are pushed to that same pull request, then the preview job re-runs and reflects the PR's current commits (no stale output from the earlier push).
+3. Given the workflow's configured target branch is `T`, when a pull request is opened against a different branch, then neither the preview job nor the publish job runs.
+4. Given the workflow's configured target branch is `T` and source branch is `S`, when a pull request from `S` is merged into `T`, then the publish job runs.
+5. Given the workflow's configured target branch is `T`, when a pull request is merged into a branch other than `T`, then the publish job does not run.
+6. Given a pull request targets `T`, when it is closed without being merged (declined or abandoned), then neither the preview job nor the publish job runs.
+
+## Preview mode
+
+7. Given a pull request against `T` has releasable (conventional-commit) changes since the last tag, when the preview job runs, then it surfaces the computed version bump and release notes, and creates no tag, pushes nothing, and publishes no GitHub release.
+8. Given a pull request against `T` has no releasable commits since the last tag, when the preview job runs, then it completes successfully, without failing, showing no version bump or release notes.
+9. Given the preview job holds no write-scoped credentials, when it runs on a pull request from an external contributor or fork, then it still completes and displays the preview output without erroring due to missing credentials.
+
+## Publish mode
+
+10. Given a pull request merging into `T` has releasable commits since the last tag, when the publish job runs, then it creates a new git tag and publishes a GitHub release containing the generated notes.
+11. Given a pull request merging into `T` has no releasable commits since the last tag, when the publish job runs, then it completes without creating a tag or a release, and without failing the run.
+12. Given a git tag for the version the publish job computes already exists, when the publish job runs, then it fails visibly and does not overwrite or duplicate the existing tag or release.
+13. Given a publish run is already in progress for `T`, when a second pull request merges into `T` before the first run finishes, then the second run waits for the first to complete rather than racing it.
+14. Given a publish run is in progress for `T`, when a preview job starts for an unrelated pull request against `T` at the same time, then the preview job proceeds independently and is not blocked by the in-progress publish run.
+15. Given a publish run just completed successfully, when the repository is inspected afterward, then no `CHANGELOG.md` change was committed as part of the run.
+
+## Unattended execution
+
+16. Given GitHub Actions provides no interactive terminal, when either the preview job or the publish job runs, then it completes without pausing for interactive confirmation and without failing due to a missing terminal.
+
+## Branch configuration
+
+17. Given the source and target branch values are set to two temporary branches for validation, when a pull request from the temporary source branch merges into the temporary target branch, then the publish job runs against those temporary branches, leaving `develop` and `main` untouched.
+18. Given the source and target branch values are later switched to `develop` and `main`, when a pull request from `develop` merges into `main`, then the publish job runs against `develop`/`main` using the same trigger and execution behaviour validated on the temporary branches.
+
+## Authentication and protected branches
+
+19. Given `develop` and `main` are configured as protected branches, when the publish job pushes a tag and creates a release, then the push and release creation succeed despite the branch protection rules.
+
+## Security: untrusted input handling
+
+20. Given a pull request's commit message contains shell metacharacters (e.g. backticks, `$( )`, quotes), when the preview or publish job processes that commit for its release notes, then the workflow completes without executing the embedded content as a shell command, and the commit message appears only as inert text in the output.
+21. Given a pull request originates from a fork, when its preview job runs, then the run has no access to repository secrets.
+
+status: ready

--- a/docs/prompts/tasks/issue-133-release-bash-workflow/test-results.md
+++ b/docs/prompts/tasks/issue-133-release-bash-workflow/test-results.md
@@ -1,0 +1,38 @@
+# Test Results: Release via `release.sh`
+
+No `.spec.ts` suite exists for this feature — `manual-validation-plan.md` replaces it with a
+GitHub-driven runbook, since `release-bash.yml` is CI/CD configuration with no TypeScript
+surface for Vitest to exercise (see that file's opening note, and the discussion in
+`/jli-writes-tests` for this task).
+
+## Why validation is pending, not run
+
+GitHub only registers a workflow's `pull_request` triggers once the workflow file exists on
+the repository's default branch (`develop` here, confirmed via `gh repo view`). Right now
+`.github/workflows/release-bash.yml` exists only on `feat/release-bash-workflow` — merging it
+into `develop` is a prerequisite for Stage 1 of `manual-validation-plan.md` to produce any
+observable run at all, not a follow-up to it. Two further findings from checking before
+shipping:
+
+- `develop` is protected by an active ruleset (`protect-develop`), so this can only land via a
+  reviewed PR — not a direct push — which is exactly the `/jli-ships` flow this file unblocks.
+- `main` does not exist yet as a branch in this repository. Stage 3 of the validation plan
+  (switching `RELEASE_SOURCE_BRANCH`/`RELEASE_TARGET_BRANCH` to `develop`/`main`) needs `main`
+  created first — out of scope for this ship, tracked as a later step.
+
+Merging this PR into `develop` is itself inert for `release-bash.yml`: the workflow only acts
+on PRs targeting the configured `RELEASE_TARGET_BRANCH` (currently `temp-target-branch`), so a
+merge into `develop` matches neither `preview` nor `publish`'s trigger condition and fires
+nothing.
+
+## What happens next
+
+Once merged, Stage 1 and Stage 2 of `manual-validation-plan.md` will be run against
+`temp-source-branch`/`temp-target-branch` (pushed and PR'd separately, after this merge). The
+expected outcome, computed ahead of time from this branch's actual commit history: last
+reachable tag `v0.28.0`, ten `feat`/`docs`/`test`/`refactor` commits for issue #133 plus one
+pre-existing `ci(commands)` commit already on `develop` (not part of #133, but within the same
+"since last tag" range `release.sh` computes), no breaking-change commits, so a `minor` bump to
+`v0.29.0`. This file will be updated with the actual observed outcome once Stage 1/2 run.
+
+status: pending-post-merge

--- a/scripts/release/VENDORED.md
+++ b/scripts/release/VENDORED.md
@@ -1,0 +1,19 @@
+# Vendored: `release.sh`
+
+`release.sh` in this directory is a vendored, unmodified copy of an external script. It is not an npm/git submodule dependency — it is committed directly so `.github/workflows/release-bash.yml` runs a reviewed, pinned version rather than tracking the upstream default branch.
+
+- **Source repository**: https://github.com/JeremieLitzler/semantic-release-script-testing
+- **Source file**: `release.sh`
+- **Pinned commit**: `de0a43a7790f509371219087c10602a0f8c39bb9`
+- **Vendored on**: 2026-08-11
+
+## Syncing a deliberate update
+
+1. Diff the upstream file at the new commit against this copy before touching anything: `gh api repos/JeremieLitzler/semantic-release-script-testing/contents/release.sh?ref=<new-commit> --jq '.content' | base64 -d`
+2. Review the diff line by line — this script runs unattended (`--yes`) against protected
+   branches in publish mode, so an unreviewed change is a direct risk (see security guideline 5 in `docs/prompts/tasks/issue-133-release-bash-workflow/security-guidelines.md`).
+3. Replace `release.sh` with the new content, unmodified.
+4. Update the "Pinned commit" and "Vendored on" fields above.
+5. Re-run the workflow against the temporary validation branches before relying on it for `develop` -> `main`.
+
+Do not track the upstream default branch automatically (no submodule, no fetch-at-CI-time) — every sync here is a deliberate, reviewed commit.

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+#
+# release.sh — own your semantic release.
+#
+# Reads the conventional commits since the last release tag, decides the next
+# version, builds the Markdown release notes, creates and pushes the tag and
+# finally publishes the GitHub release.
+#
+# Every step is separated from the next one by a human gate: nothing is written
+# to the remote before you say so.
+#
+# Requirements: git, bash >= 4, and the GitHub CLI (`gh`) already logged in.
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+
+ASSUME_YES=false
+DRY_RUN=false
+LOCAL_ONLY=false
+SINCE_REF=""
+TO_REF=""
+FORCE_LEVEL=""
+NOTES_OUT=""
+CHANGELOG_OUT=""
+
+# ---------------------------------------------------------------- presentation
+
+if [[ -t 1 ]]; then
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; RED=$'\033[31m'; GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'; BLUE=$'\033[34m'; RESET=$'\033[0m'
+else
+  BOLD=""; DIM=""; RED=""; GREEN=""; YELLOW=""; BLUE=""; RESET=""
+fi
+
+info() { printf '%s\n' "$*"; }
+note() { printf '%s%s%s\n' "$DIM" "$*" "$RESET"; }
+warn() { printf '%s! %s%s\n' "$YELLOW" "$*" "$RESET" >&2; }
+die()  { printf '%sx %s%s\n' "$RED" "$*" "$RESET" >&2; exit 1; }
+
+step() {
+  printf '\n%s%s== %s ==%s\n\n' "$BOLD" "$BLUE" "$*" "$RESET"
+}
+
+# Human gate. Returns only if the user agrees to move on.
+gate() {
+  local prompt="$1"
+  if [[ $ASSUME_YES == true ]]; then
+    note "-> $prompt (auto-confirmed with --yes)"
+    return 0
+  fi
+  if [[ ! -t 0 && ! -e /dev/tty ]]; then
+    die "no terminal available to confirm '$prompt' — rerun with --yes"
+  fi
+  local answer=""
+  printf '%s%s%s [y/N] ' "$BOLD" "$prompt" "$RESET" >&2
+  read -r answer < /dev/tty || true
+  case "$answer" in
+    [yY] | [yY][eE][sS]) return 0 ;;
+    *) info "Stopped before: $prompt"; exit 0 ;;
+  esac
+}
+
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} — semantic release from conventional commits.
+
+Usage: ${SCRIPT_NAME} [options]
+
+Options:
+  -y, --yes             Skip every human gate (unattended run).
+  -n, --dry-run         Do everything but push the tag and create the release.
+  -l, --local           Create the tag locally, but neither push nor publish.
+      --since <ref>     Read commits since <ref> instead of the last v* tag.
+                         This is the commit set on the last release.
+      --to <ref>        Read commits up to <ref> instead of HEAD, and create
+                         the tag on <ref> instead of HEAD. This is the commit
+                         to set on the next release.
+      --level <level>   Force the bump: major | minor | patch.
+      --notes <file>    Also write the release notes to <file>.
+      --changelog <f>   Prepend the release to the changelog <f> (newest first).
+  -h, --help            Show this help.
+
+Steps (a human gate sits before each one):
+  1. evaluate the new version from the commit range
+  2. build the Markdown release notes
+  3. create and push the tag
+  4. create the GitHub release
+
+Rebuilding a history of releases:
+  Combine --since and --to to replay a specific commit range instead of the
+  usual "last tag..HEAD". Work oldest-first: create v0.0.1 on its commit, then
+  v0.0.2 on the next one, and so on. Once a tag exists, --since can often be
+  left out since the next release's range is auto-detected from the nearest
+  ancestor tag of --to.
+EOF
+}
+
+# ----------------------------------------------------------------------- args
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y | --yes)     ASSUME_YES=true; shift ;;
+    -n | --dry-run) DRY_RUN=true; shift ;;
+    -l | --local)   LOCAL_ONLY=true; shift ;;
+    --since)        SINCE_REF="${2:-}"; [[ -n $SINCE_REF ]] || die "--since needs a ref"; shift 2 ;;
+    --to)           TO_REF="${2:-}"; [[ -n $TO_REF ]] || die "--to needs a ref"; shift 2 ;;
+    --level)        FORCE_LEVEL="${2:-}"; shift 2 ;;
+    --notes)        NOTES_OUT="${2:-}"; [[ -n $NOTES_OUT ]] || die "--notes needs a path"; shift 2 ;;
+    --changelog)    CHANGELOG_OUT="${2:-}"; [[ -n $CHANGELOG_OUT ]] || die "--changelog needs a path"; shift 2 ;;
+    -h | --help)    usage; exit 0 ;;
+    *)              usage >&2; die "unknown option: $1" ;;
+  esac
+done
+
+case "$FORCE_LEVEL" in
+  "" | major | minor | patch) ;;
+  *) die "--level must be one of: major, minor, patch" ;;
+esac
+
+# ------------------------------------------------------------------ preflight
+
+(( BASH_VERSINFO[0] >= 4 )) || die "bash 4+ required (running ${BASH_VERSION})"
+command -v git >/dev/null 2>&1 || die "git not found in PATH"
+command -v gh  >/dev/null 2>&1 || die "GitHub CLI (gh) not found in PATH"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
+gh auth status >/dev/null 2>&1 || die "gh is not logged in — run: gh auth login"
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner) \
+  || die "cannot resolve the GitHub repository for this checkout"
+REPO_URL="https://github.com/${REPO}"
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ $CURRENT_BRANCH == "main" ]] || warn "you are on '${CURRENT_BRANCH}', not 'main'"
+
+[[ -n $TO_REF ]] || TO_REF="HEAD"
+git rev-parse --verify --quiet "$TO_REF" >/dev/null || die "unknown ref: $TO_REF"
+
+if [[ $(git rev-parse "$TO_REF") == $(git rev-parse HEAD) ]]; then
+  if [[ -n $(git status --porcelain) ]]; then
+    warn "the working tree is not clean; the tag will only contain committed work"
+  fi
+fi
+
+note "Fetching tags from origin..."
+git fetch --tags --quiet origin || warn "could not fetch tags from origin"
+
+# ------------------------------------------------------- step 1: next version
+
+LAST_TAG=""
+if [[ -n $SINCE_REF ]]; then
+  git rev-parse --verify --quiet "$SINCE_REF" >/dev/null || die "unknown ref: $SINCE_REF"
+  LAST_TAG="$SINCE_REF"
+else
+  LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' "$TO_REF" 2>/dev/null || true)
+fi
+
+if [[ -n $LAST_TAG ]]; then
+  RANGE="${LAST_TAG}..${TO_REF}"
+else
+  RANGE="${TO_REF}"
+fi
+
+CURRENT_VERSION="0.0.0"
+if [[ $LAST_TAG =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+  CURRENT_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+elif [[ -n $LAST_TAG ]]; then
+  # --since accepts any ref, not just a version tag (e.g. a commit hash when
+  # replaying history). Resolve the nearest reachable version tag so the
+  # current version is still detected correctly.
+  VERSION_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' "$LAST_TAG" 2>/dev/null || true)
+  if [[ $VERSION_TAG =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+    CURRENT_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+  fi
+fi
+
+mapfile -t COMMITS < <(git log --no-merges --format=%H "$RANGE")
+(( ${#COMMITS[@]} > 0 )) || die "no commit to release in range '${RANGE}'"
+
+# classify <subject> <body> -> breaking | feature | fix | other
+classify() {
+  local subject="$1" body="$2" type="" bang=""
+  if [[ $subject =~ ^([a-zA-Z]+)(\([^\)]*\))?(!)?: ]]; then
+    type="${BASH_REMATCH[1],,}"
+    bang="${BASH_REMATCH[3]}"
+  fi
+  # Conventional Commits requires the uppercase footer token "BREAKING CHANGE"
+  # (or its synonym "BREAKING-CHANGE"), followed by ": " or " #" — not just
+  # those words appearing anywhere in the body's prose.
+  if [[ -n $bang || $body =~ (^|$'\n')BREAKING[-\ ]CHANGE(:\ |\ \#) ]]; then
+    printf 'breaking'
+  elif [[ $type == "feat" ]]; then
+    printf 'feature'
+  elif [[ $type == "fix" ]]; then
+    printf 'fix'
+  else
+    printf 'other'
+  fi
+}
+
+declare -a C_HASH=() C_SHORT=() C_SUBJECT=() C_CATEGORY=()
+
+for hash in "${COMMITS[@]}"; do
+  raw=$(git show -s --format=$'%h\x1f%s\x1f%b' "$hash")
+  short="${raw%%$'\x1f'*}"; rest="${raw#*$'\x1f'}"
+  subject="${rest%%$'\x1f'*}"; body="${rest#*$'\x1f'}"
+
+  C_HASH+=("$hash")
+  C_SHORT+=("$short")
+  C_SUBJECT+=("$subject")
+  C_CATEGORY+=("$(classify "$subject" "$body")")
+done
+
+LEVEL="patch"
+for category in "${C_CATEGORY[@]}"; do
+  case "$category" in
+    breaking) LEVEL="major"; break ;;
+    feature)  LEVEL="minor" ;;
+  esac
+done
+[[ -n $FORCE_LEVEL ]] && LEVEL="$FORCE_LEVEL"
+
+IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_VERSION"
+case "$LEVEL" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+NEW_TAG="v${NEW_VERSION}"
+
+step "Step 1 — evaluate the new version"
+info "Repository      : ${REPO}"
+info "Branch          : ${CURRENT_BRANCH}"
+info "Commit range    : ${RANGE}${LAST_TAG:+ (last tag: ${LAST_TAG})}"
+[[ $TO_REF == "HEAD" ]] || info "Target ref      : ${TO_REF} (tag will be created there, not on HEAD)"
+info "Commits scanned : ${#COMMITS[@]}"
+info ""
+for i in "${!C_HASH[@]}"; do
+  printf '  %s%-9s%s %s %s%s%s\n' \
+    "$YELLOW" "${C_CATEGORY[$i]}" "$RESET" "${C_SHORT[$i]}" "$DIM" "${C_SUBJECT[$i]}" "$RESET"
+done
+info ""
+info "Bump            : ${BOLD}${LEVEL}${RESET}${FORCE_LEVEL:+ (forced with --level)}"
+info "Version         : ${CURRENT_VERSION} -> ${BOLD}${GREEN}${NEW_VERSION}${RESET}"
+
+if git rev-parse --verify --quiet "refs/tags/${NEW_TAG}" >/dev/null; then
+  die "tag ${NEW_TAG} already exists locally"
+fi
+
+gate "Continue to step 2 and build the release notes for ${NEW_TAG}?"
+
+# ------------------------------------------------------ step 2: release notes
+
+declare -A ISSUE_TITLES=()
+
+# issue_title <number> -> the issue title, or nothing when the number is a pull
+# request, does not exist, or cannot be read.
+issue_title() {
+  local number="$1"
+  if [[ -n ${ISSUE_TITLES[$number]+set} ]]; then
+    printf '%s' "${ISSUE_TITLES[$number]}"
+    return 0
+  fi
+  # gh api writes the error payload to stdout on a 404, so only trust the
+  # output when the call actually succeeded.
+  local title=""
+  if ! title=$(gh api "repos/${REPO}/issues/${number}" \
+                 --jq 'if has("pull_request") then empty else .title end' 2>/dev/null); then
+    title=""
+  fi
+  ISSUE_TITLES[$number]="$title"
+  printf '%s' "$title"
+}
+
+declare -a BREAKING_ISSUE=() BREAKING_PLAIN=()
+declare -a FEATURE_ISSUE=()  FEATURE_PLAIN=()
+declare -a FIX_ISSUE=()      FIX_PLAIN=()
+declare -a OTHER_ISSUE=()    OTHER_PLAIN=()
+
+# category_rank <category> -> larger means more significant. Used so an issue
+# referenced by several commits (a feature, its docs, its tests, ...) is
+# filed under the most significant category among them, rather than
+# whichever commit happens to be processed first.
+category_rank() {
+  case "$1" in
+    breaking) printf 4 ;;
+    feature)  printf 3 ;;
+    fix)      printf 2 ;;
+    *)        printf 1 ;;
+  esac
+}
+
+note "Resolving issue references with gh..."
+
+# Several commits often close out the same issue. They'd otherwise repeat
+# the same issue title on multiple lines, so each issue gets exactly one
+# bullet: ISSUE_ORDER remembers first-seen order (commits are newest-first)
+# while ISSUE_CATEGORY/ISSUE_RANK track the most significant category seen
+# so far for that issue.
+declare -a ISSUE_ORDER=()
+declare -A ISSUE_BULLET=() ISSUE_CATEGORY=() ISSUE_RANK=()
+
+for i in "${!C_HASH[@]}"; do
+  subject="${C_SUBJECT[$i]}"
+  category="${C_CATEGORY[$i]}"
+  title=""
+  number=""
+
+  if [[ $subject =~ \#([0-9]+) ]]; then
+    number="${BASH_REMATCH[1]}"
+    title=$(issue_title "$number")
+  fi
+
+  if [[ -n $title ]]; then
+    bullet="- ${title} (#${number})"
+    rank=$(category_rank "$category")
+    if [[ -z ${ISSUE_RANK[$number]+set} ]]; then
+      ISSUE_ORDER+=("$number")
+    fi
+    if [[ -z ${ISSUE_RANK[$number]+set} || $rank -gt ${ISSUE_RANK[$number]} ]]; then
+      ISSUE_RANK[$number]="$rank"
+      ISSUE_CATEGORY[$number]="$category"
+      ISSUE_BULLET[$number]="$bullet"
+    fi
+    continue
+  fi
+
+  bullet="- ${subject} ([${C_SHORT[$i]}](${REPO_URL}/commit/${C_HASH[$i]}))"
+  case "$category" in
+    breaking) BREAKING_PLAIN+=("$bullet") ;;
+    feature)  FEATURE_PLAIN+=("$bullet") ;;
+    fix)      FIX_PLAIN+=("$bullet") ;;
+    other)    OTHER_PLAIN+=("$bullet") ;;
+  esac
+done
+
+for number in "${ISSUE_ORDER[@]}"; do
+  bullet="${ISSUE_BULLET[$number]}"
+  case "${ISSUE_CATEGORY[$number]}" in
+    breaking) BREAKING_ISSUE+=("$bullet") ;;
+    feature)  FEATURE_ISSUE+=("$bullet") ;;
+    fix)      FIX_ISSUE+=("$bullet") ;;
+    other)    OTHER_ISSUE+=("$bullet") ;;
+  esac
+done
+
+NOTES_FILE=$(mktemp -t "release-notes-XXXXXX.md")
+trap 'rm -f "$NOTES_FILE"' EXIT
+
+# section <heading> <issue array name> <plain array name>
+section() {
+  local heading="$1" issues_name="$2" plain_name="$3"
+  local -n issues="$issues_name"
+  local -n plain="$plain_name"
+  (( ${#issues[@]} + ${#plain[@]} > 0 )) || return 0
+  printf '### %s\n\n' "$heading" >>"$NOTES_FILE"
+  local line
+  for line in "${issues[@]}" "${plain[@]}"; do
+    printf '%s\n' "$line" >>"$NOTES_FILE"
+  done
+  printf '\n' >>"$NOTES_FILE"
+}
+
+: >"$NOTES_FILE"
+section "BREAKING CHANGES" BREAKING_ISSUE BREAKING_PLAIN
+section "Features"         FEATURE_ISSUE  FEATURE_PLAIN
+section "Bug fixes"        FIX_ISSUE      FIX_PLAIN
+section "Others"           OTHER_ISSUE    OTHER_PLAIN
+
+step "Step 2 — release notes for ${NEW_TAG}"
+cat "$NOTES_FILE"
+
+if [[ -n $NOTES_OUT ]]; then
+  cp "$NOTES_FILE" "$NOTES_OUT"
+  note "Notes also written to ${NOTES_OUT}"
+fi
+
+# The releases are the changelog, so this stays optional. It exists to review a
+# whole series of releases in one file, the newest one on top.
+if [[ -n $CHANGELOG_OUT ]]; then
+  mkdir -p "$(dirname "$CHANGELOG_OUT")"
+  CHANGELOG_TMP=$(mktemp -t "changelog-XXXXXX.md")
+  {
+    printf '# Changelog\n\n'
+    printf '## %s (%s)\n\n' "$NEW_TAG" "$(date +%Y-%m-%d)"
+    if [[ -f $CHANGELOG_OUT ]]; then
+      tail -n +2 "$CHANGELOG_OUT" | sed '1{/^$/d;}'
+    fi
+  } >"$CHANGELOG_TMP"
+  mv "$CHANGELOG_TMP" "$CHANGELOG_OUT"
+  note "Changelog updated: ${CHANGELOG_OUT}"
+fi
+
+gate "Continue to step 3 and create the tag ${NEW_TAG}?"
+
+# --------------------------------------------------------- step 3: tag & push
+
+step "Step 3 — create and push ${NEW_TAG}"
+
+if [[ $DRY_RUN == true ]]; then
+  note "[dry-run] git tag -a ${NEW_TAG} -m ${NEW_TAG} ${TO_REF}"
+  note "[dry-run] git push origin ${NEW_TAG}"
+elif [[ $LOCAL_ONLY == true ]]; then
+  git tag -a "$NEW_TAG" -m "$NEW_TAG" "$TO_REF"
+  info "Tag ${NEW_TAG} created on $(git rev-parse --short "$TO_REF")."
+  note "[local] not pushed to origin"
+else
+  git tag -a "$NEW_TAG" -m "$NEW_TAG" "$TO_REF"
+  info "Tag ${NEW_TAG} created on $(git rev-parse --short "$TO_REF")."
+  if ! git push origin "$NEW_TAG"; then
+    git tag -d "$NEW_TAG" >/dev/null
+    die "pushing ${NEW_TAG} failed — the local tag has been deleted, nothing was released"
+  fi
+  info "Tag ${NEW_TAG} pushed to origin."
+fi
+
+gate "Continue to step 4 and publish the GitHub release ${NEW_TAG}?"
+
+# ------------------------------------------------------------ step 4: release
+
+step "Step 4 — publish the release ${NEW_TAG}"
+
+if [[ $DRY_RUN == true ]]; then
+  note "[dry-run] gh release create ${NEW_TAG} --title ${NEW_TAG} --notes-file <notes>"
+  note "[dry-run] no tag was pushed, so no release was created"
+elif [[ $LOCAL_ONLY == true ]]; then
+  note "[local] gh release create ${NEW_TAG} --title ${NEW_TAG} --notes-file <notes>"
+  note "[local] the tag stays on this machine, so no release was created"
+else
+  gh release create "$NEW_TAG" \
+    --repo "$REPO" \
+    --title "$NEW_TAG" \
+    --notes-file "$NOTES_FILE" \
+    --verify-tag
+  printf '\n%s%sReleased %s%s\n' "$BOLD" "$GREEN" "$NEW_TAG" "$RESET"
+  info "${REPO_URL}/releases/tag/${NEW_TAG}"
+fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release-bash.yml`, a second, independent release pipeline that runs a vendored copy of [`release.sh`](https://github.com/JeremieLitzler/semantic-release-script-testing) instead of the npm-based `semantic-release` in `release.yml` (ADR-004). It runs in two modes against a configured source/target branch pair, currently set to `temp-source-branch`/`temp-target-branch` for validation (not `develop`/`main` yet): a **preview** on any pull request targeting the target branch (`release.sh --yes --dry-run`, surfaces the version bump and release notes, creates nothing), and a **publish** once such a pull request merges (`release.sh --yes`, creates the git tag and GitHub release). Both modes run fully unattended, since GitHub Actions provides no TTY. `release.yml` is untouched and keeps running in parallel — this PR makes no retirement decision for either pipeline.

Also adds `scripts/release/release.sh` (vendored, pinned to a specific reviewed upstream commit, documented in `scripts/release/VENDORED.md`) and `docs/decisions/ADR-015-bash-script-release-workflow.md`.

## Why

Issue #133 asks for a `release.sh`-based alternative to the current `semantic-release` pipeline, validated on temporary branches before being pointed at the real, protected `develop`/`main` pair.

## Security

- Preview holds no write-scoped credentials (`permissions: contents: read, issues: read, pull-requests: read`), triggers on `pull_request` (never `pull_request_target`), so a fork PR's preview run has no access to repository secrets.
- Publish authenticates via a GitHub App token (`actions/create-github-app-token`, replacing the unmaintained `tibdex/github-app-token`), scoped to this repo, reusing the existing `GH_APP_ID`/`GH_APP_KEY` secrets — needed because `develop`/`main` are protected branches.
- PR/branch data flows through step `env:`, never interpolated into `run:` shell strings.
- The vendored `release.sh` is pinned to a specific commit, not the upstream default branch, with a documented re-review procedure for future syncs.

Full rationale in `docs/prompts/tasks/issue-133-release-bash-workflow/security-guidelines.md`.

## Test plan

This is CI/CD configuration with no TypeScript surface — no `.spec.ts` suite applies. Instead, `docs/prompts/tasks/issue-133-release-bash-workflow/manual-validation-plan.md` maps every scenario in `test-cases.md` to concrete GitHub steps (push temp branches, open/merge PRs, inspect Actions logs/tags/releases). That validation needs `release-bash.yml` registered on `develop` (the default branch) to fire at all, which is what merging this PR unblocks — see `test-results.md` for the current (`pending-post-merge`) status and the precomputed expected outcome (`v0.28.0` -> `v0.29.0`).

- [ ] Merging this PR is inert for `release-bash.yml` itself (only acts on PRs targeting `temp-target-branch`)
- [ ] Stage 1 (preview trigger scope) run against `temp-source-branch`/`temp-target-branch` after merge
- [ ] Stage 2 (publish mode) run against the same temp branches after merge
- [ ] Stage 3 (switch to `develop`/`main`) deferred — `main` doesn't exist yet in this repo

Closes #133
