### PR TITLE
fix(ci): scope release-bash.yml's publish job to the CI environment

### DIFF
--- a/.github/workflows/release-bash.yml
+++ b/.github/workflows/release-bash.yml
@@ -100,6 +100,8 @@ jobs:
     needs: determine-mode
     if: needs.determine-mode.outputs.is_publish == 'true'
     runs-on: ubuntu-latest
+    environment:
+      name: CI
     permissions:
       contents: read
     concurrency:


### PR DESCRIPTION
## Summary

The publish job in release-bash.yml never declared `environment: name: CI`, so it couldn't see the `GH_APP_ID`/`GH_APP_KEY` secrets, which are scoped to the `CI` GitHub Environment (same as `release.yml`'s existing `release` job, which does declare it). `actions/create-github-app-token` failed with "The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string" even after the secrets were added to the `CI` environment.

Found live while running Stage 2 of `docs/prompts/tasks/issue-133-release-bash-workflow/manual-validation-plan.md` against the temp branches (PR #137, run 31488472012).

## Fix

Add `environment: name: CI` to the `publish` job, matching `release.yml`'s pattern.

## Test plan

- [x] YAML re-validated with js-yaml
- [ ] Re-run the Stage 2 publish job on PR #137 once this merges, confirm it now succeeds and creates tag `v0.29.0` + a matching GitHub release