### PR TITLE
fix(ci): configure git identity before release.sh tags in publish

### DIFF
--- a/.github/workflows/release-bash.yml
+++ b/.github/workflows/release-bash.yml
@@ -123,6 +123,14 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
+      - name: Configure git identity for the GitHub App
+        env:
+          APP_ID: ${{ secrets.GH_APP_ID }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
       - name: Run release.sh
         shell: bash
         env:


### PR DESCRIPTION
## Summary

release.sh creates an annotated tag (`git tag -a`), which requires a committer identity. The publish job never configured one, so \`git tag -a\` failed: "Committer identity unknown ... fatal: empty ident name ... not allowed".

Found live during Stage 2 re-validation of \`docs/prompts/tasks/issue-133-release-bash-workflow/manual-validation-plan.md\` (PR #139, run 31490987707) — this ran right after the CI-environment fix (#138), so the App token step now succeeds and the failure moved one step further into \`release.sh\` itself.

## Fix

Add a step between checkout and running \`release.sh\` that sets \`git config user.name\`/\`user.email\` from the GitHub App's own slug/id (\`${app-id}+${app-slug}[bot]@users.noreply.github.com\`), matching GitHub's own convention for attributing git objects to an App rather than a generic \`github-actions[bot]\` identity.

## Test plan

- [x] YAML re-validated with js-yaml
- [ ] Re-run Stage 2 once this merges — expect the tag `v0.29.0` to actually get created and pushed, plus a matching GitHub release