### PR TITLE
ci: point release-bash.yml at develop/main (#133)

### DIFF
--- a/.github/workflows/release-bash.yml
+++ b/.github/workflows/release-bash.yml
@@ -10,11 +10,11 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 # Source/target branch pair as easily-changed configuration (`on:` triggers cannot reference
-# expressions, so the actual filtering happens in the determine-mode job below). Point both at
-# temporary branches for validation, then switch to develop/main.
+# expressions, so the actual filtering happens in the determine-mode job below). Validated
+# against temp-source-branch/temp-target-branch (issue #133); now pointed at the real pair.
 env:
-  RELEASE_SOURCE_BRANCH: temp-source-branch
-  RELEASE_TARGET_BRANCH: temp-target-branch
+  RELEASE_SOURCE_BRANCH: develop
+  RELEASE_TARGET_BRANCH: main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Switches \`RELEASE_SOURCE_BRANCH\`/\`RELEASE_TARGET_BRANCH\` in \`release-bash.yml\` from \`temp-source-branch\`/\`temp-target-branch\` to \`develop\`/\`main\`, per Stage 3 of \`docs/prompts/tasks/issue-133-release-bash-workflow/manual-validation-plan.md\`.

Stage 1 and Stage 2 both passed against the temp branches (see PR #142, currently open) — trigger scope, preview, and publish (tag + release creation via the GitHub App token) all work as designed, including the two fixes from PRs #138 and #140.

## Important: this is currently inert

\`main\` does not exist yet as a branch in this repository (\`git ls-remote --heads origin main\` returns nothing). Until it does, no PR can target it, so \`publish\` cannot fire from this change alone. Once \`main\` is created and a PR from \`develop\` merges into it, this workflow will run for real against a protected branch with real tag/release creation.

## Test plan

- [x] YAML re-validated with js-yaml
- [ ] Full Stage 3 validation (open a real develop -> main PR, verify preview then publish) once main exists — tracked as a follow-up, not part of this PR

Closes #133