### PR TITLE
ci(commands): add hard CI-check gate to jli-ships before merge

### DIFF
--- a/.claude/commands/jli-ships.md
+++ b/.claude/commands/jli-ships.md
@@ -8,8 +8,9 @@ opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and 
 
 Run from the feature worktree root (your current directory). Parse the issue `[id]` from the
 task-folder name. The pipeline scripts resolve the bare repo automatically. This command is
-outward-facing and irreversible — honour the two approval gates below. It does NOT remove the
-worktree (you are standing in it); cleanup is a separate command run from `develop`.
+outward-facing and irreversible — honour the CI-check gate and the two approval gates below.
+It does NOT remove the worktree (you are standing in it); cleanup is a separate command run
+from `develop`.
 
 ## Sub-issue task folders
 
@@ -43,10 +44,25 @@ bash scripts/pipeline/pr-create.sh "$(pwd)" "<title>" /tmp/pr-body.md
 **Approval gate 1:** before running `pr-create.sh`, show the user the proposed PR title and
 body and ask for approval. If they decline, stop.
 
-## Step 2 — Merge (after approval)
+## Step 2 — Verify CI checks (hard gate, before merge)
 
-**Approval gate 2:** show the user the PR URL and ask for approval to merge. If they decline,
-stop — the PR stays open for them to merge manually.
+```bash
+rtk gh pr checks <pr-url>
+```
+
+Every required check must show `pass`. If any check is `fail`, `pending`, or `queued`, stop —
+do not proceed to Step 3 or ask for merge approval. Tell the user exactly which checks are not
+green and wait: either they fix the failure and push a new commit (loop back to
+`/jli-runs-tests`/`/jli-codes` as appropriate), or they explicitly tell you to proceed anyway
+(e.g. a known-flaky, non-blocking check). Never decide on your own to bypass a red or pending
+check — merging only on the human's explicit say-so once checks are green (or explicitly
+overridden) is the whole point of this gate.
+
+## Step 3 — Merge (after approval)
+
+**Approval gate 2:** show the user the PR URL, confirm the CI checks are green (per Step 2),
+and ask for approval to merge. If they decline, stop — the PR stays open for them to merge
+manually.
 
 ```bash
 bash scripts/pipeline/pr-complete.sh <pr-url>

--- a/AGENT-COMMAND-MIGRATION.md
+++ b/AGENT-COMMAND-MIGRATION.md
@@ -239,7 +239,11 @@ hints:
 - `/jli-writes-spec` and `/jli-codes` warn when their artifact contains `### ADR Required` —
   approve the ADR (add it under `docs/decisions/`, update the index) before continuing.
 - `/jli-ships` pauses for confirmation before opening the PR and again before merging,
-  because those actions are outward-facing and irreversible.
+  because those actions are outward-facing and irreversible. Between the two, it runs a hard
+  CI-check gate (`gh pr checks`): every required check must be green before the merge
+  confirmation is even asked for. A red or pending check stops the command outright — the
+  human must either fix it (looping back into the chain) or explicitly say to proceed anyway,
+  rather than the merge happening unconditionally.
 
 ## Maintaining the chain
 


### PR DESCRIPTION
## Summary

- `/jli-ships` only checked the local `test-results.md` artifact before opening a PR; it never verified the PR's actual GitHub CI status, and `pr-complete.sh` merged unconditionally.
- Adds a hard Step 2 (`rtk gh pr checks`) between opening the PR and asking for merge approval: any non-passing check stops the command outright instead of proceeding to the merge ask.
- Documents the new gate in `AGENT-COMMAND-MIGRATION.md`'s "Human approval gates" section.

## Files changed

- `.claude/commands/jli-ships.md` — new Step 2 CI-check gate; renumbers the old merge step to Step 3
- `AGENT-COMMAND-MIGRATION.md` — documents the gate in the approval-gates section

## Test plan

- [ ] N/A — chain-command markdown only, no application code or tests affected

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)