### PR TITLE
Fix vi.mock hoisting ReferenceError in applyRemotePreferences.spec.ts

### DIFF
--- a/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/business-specifications.md
+++ b/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/business-specifications.md
@@ -1,0 +1,42 @@
+# Business Specifications: Fix vi.mock Hoisting ReferenceError in applyRemotePreferences.spec.ts
+
+## Goal and Scope
+
+Restore `src/utils/applyRemotePreferences.spec.ts` to a runnable state: it currently fails at
+collection time with `ReferenceError: Cannot access 'mockGetPreferencesSyncedAt' before
+initialization`, so none of its test cases execute. Scope is limited to this one spec file's
+mock declaration; no application code and no other spec file are touched. This is a test-only
+fix per ADR-005's Vitest conventions.
+
+## Example Mapping
+
+**Rule:** The file loads and every test case it already contains (successful-merge scenarios,
+TC-6, TC-7) runs and passes with the same assertions and expected outcomes as before the
+`vi.mock` factory referenced not-yet-initialized values.
+- Example: running the suite reports zero collection errors for this file, and TC-6/TC-7 still
+  verify the same rollback and timestamp-restore behavior documented in `test-cases.md`
+  (issue #106).
+
+**Rule:** The observable behavior of the mocked `getPreferencesSyncedAt` /
+`restorePreferencesSyncedAt` functions — what each test configures them to return, how many
+times they're called, their call arguments, and their call order relative to
+`replaceStations` — is unchanged. Only how the mock is declared changes, not what it does.
+
+**Rule:** No other spec file, its mocking approach, or its pass/fail status is affected.
+- Edge case: `src/composables/useRemotePreferencesSync.spec.ts` also mocks
+  `@/utils/preferencesSyncTimestamp`, but via a dynamic-import pattern that isn't exposed to
+  this hoisting issue; it is out of scope and must keep passing unchanged.
+
+## Files
+
+- `src/utils/applyRemotePreferences.spec.ts` — the failing test file; its mock declaration for
+  `@/utils/preferencesSyncTimestamp` is corrected so the mocked functions are available to the
+  factory at the time Vitest's hoisting runs it.
+
+## Out of Scope
+
+- `src/utils/applyRemotePreferences.ts` and `src/utils/preferencesSyncTimestamp.ts`
+  (application code) — unmodified.
+- Any other `*.spec.ts` file using `vi.mock`.
+
+status: ready

--- a/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/security-guidelines.md
+++ b/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/security-guidelines.md
@@ -1,0 +1,8 @@
+# Security Guidelines: Fix vi.mock Hoisting ReferenceError in applyRemotePreferences.spec.ts
+
+No security-relevant scope. The change is limited to how mock functions are declared inside
+`src/utils/applyRemotePreferences.spec.ts` (test-only, dev-time execution via Vitest). It
+touches no user input, no rendered/output content, no Netlify Function boundary, no
+dependencies, no secrets, and no HTTP/CORS surface. No guidelines apply.
+
+status: ready

--- a/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/test-cases.md
+++ b/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/test-cases.md
@@ -1,0 +1,22 @@
+# Test Cases: Fix vi.mock Hoisting ReferenceError in applyRemotePreferences.spec.ts
+
+This is a test-infrastructure fix with no new or changed runtime behaviour in the
+application. No new `.spec.ts` files are written for this task; the existing
+`applyRemotePreferences.spec.ts` is corrected so its already-defined scenarios (successful
+merge, TC-6, TC-7 from issue #106) can run at all.
+
+Verification: running `src/utils/applyRemotePreferences.spec.ts` must succeed with zero
+collection errors (no `ReferenceError` at file load) and the same pass/fail outcome for every
+existing scenario as intended before the hoisting bug:
+- the successful-merge scenarios (station list replaced, default fuel type saved or cleared)
+  still pass
+- TC-6 (a failed default-fuel write rolls back the station list to its pre-merge value) still
+  passes
+- TC-7 (a failed merge restores the pre-merge sync timestamp, not the freshly-marked one,
+  including the never-synced-before/undefined case) still passes
+
+Running the full suite (`npm run test`) after the fix must show no regression in any other
+spec file, in particular `useRemotePreferencesSync.spec.ts`, which mocks the same module via
+an unrelated pattern.
+
+status: ready

--- a/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/test-results.md
+++ b/docs/prompts/tasks/issue-136-vi-mock-hoisting-error/test-results.md
@@ -1,0 +1,23 @@
+# Test Results — Issue #136: Fix vi.mock Hoisting ReferenceError in applyRemotePreferences.spec.ts
+
+## Test Run
+
+Command: `npx vitest run --reporter=json` (Vitest v4.1.2) from the
+`french-gas-stations-scraper_fix-vi-mock-hoisting-error` worktree.
+
+## Files Run
+
+Full suite (no `technical-specifications.md` for this task — the fix was applied directly to
+the test file per [test-cases.md](test-cases.md); see `src/utils/applyRemotePreferences.spec.ts`).
+
+## Results
+
+All tests passed. No failures.
+
+### Test Summary
+
+428 test files, 508 tests total — all passed.
+
+- Duration: ~12 seconds
+
+status: passed

--- a/src/utils/applyRemotePreferences.spec.ts
+++ b/src/utils/applyRemotePreferences.spec.ts
@@ -17,8 +17,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PreferencesFile } from '@/types/preferences'
 import type { Station } from '@/types/station'
 
-const mockGetPreferencesSyncedAt = vi.fn()
-const mockRestorePreferencesSyncedAt = vi.fn().mockResolvedValue(undefined)
+const { mockGetPreferencesSyncedAt, mockRestorePreferencesSyncedAt } = vi.hoisted(() => ({
+  mockGetPreferencesSyncedAt: vi.fn(),
+  mockRestorePreferencesSyncedAt: vi.fn().mockResolvedValue(undefined),
+}))
 
 vi.mock('@/utils/preferencesSyncTimestamp', () => ({
   getPreferencesSyncedAt: mockGetPreferencesSyncedAt,


### PR DESCRIPTION
## Summary

`src/utils/applyRemotePreferences.spec.ts` failed at collection time with `ReferenceError: Cannot access 'mockGetPreferencesSyncedAt' before initialization`. The `vi.mock('@/utils/preferencesSyncTimestamp', ...)` factory referenced `mockGetPreferencesSyncedAt`/`mockRestorePreferencesSyncedAt`, plain top-level `const`s declared earlier in source order — but Vitest hoists every `vi.mock()` call above all other top-level statements, so the factory ran before those consts were initialized.

Fixed by wrapping the mock functions in `vi.hoisted(() => ({...}))`, which Vitest guarantees runs before hoisted `vi.mock` factories, then destructuring the hoisted values for the `vi.mock` factory to reference.

Test-only change — no application code affected.

## Test plan

- [x] `applyRemotePreferences.spec.ts` loads with zero collection errors
- [x] Successful-merge scenarios pass (station list replaced, default fuel type saved/cleared)
- [x] TC-6 (failed default-fuel write rolls back station list) passes
- [x] TC-7 (failed merge restores pre-merge sync timestamp, including undefined case) passes
- [x] Full suite: 428 test files, 508 tests — all passed, no regressions

Closes #136
