### PR TITLE
ci(commands): align code/test commit type with branch type, split review commits to docs

### DIFF
--- a/.claude/commands/jli-commits.md
+++ b/.claude/commands/jli-commits.md
@@ -29,16 +29,26 @@ rtk git status
 
 ## Choosing the commit type from what changed
 
+Two rules decide the type:
+
+- **Markdown-only** changes always use `docs`, scoped to the artifact.
+- Changes that touch **source code** (or `*.spec.ts` test files) use `<type>` — the
+  conventional-commit type `/jli-sets-up` inferred for this issue, encoded in the
+  current branch name as `<type>/<slug>` (e.g. branch `fix/vi-mock-hoisting-fix` ->
+  `<type>` = `fix`). Read the current branch (`rtk git status` or
+  `rtk git branch --show-current`) and parse `<type>` from it — never choose it freely.
+
 Stage and commit the changed files with the message that matches them:
 
 | Changed files | Commit message |
 |---|---|
-| only `business-specifications.md` | `feat(specs): define specs for <short desc> (#[id])` |
-| only `security-guidelines.md` | `feat(security): add security guidelines for <short desc> (#[id])` |
-| only `test-cases.md` | `test(cases): define test scenarios for <short desc> (#[id])` |
-| source files + `technical-specifications.md` (+ `review-results.md`) | implementation message summarising the change from `business-specifications.md` |
-| `*.spec.ts` test files | `test: add tests for <short desc> (#[id])` |
-| `test-results.md` | `test: record test results for <short desc> (#[id])` |
+| only `business-specifications.md` | `docs(specs): define specs for <short desc> (#[id])` |
+| only `security-guidelines.md` | `docs(security): add security guidelines for <short desc> (#[id])` |
+| only `test-cases.md` | `docs(cases): define test scenarios for <short desc> (#[id])` |
+| source files + `technical-specifications.md` | `<type>: <imperative summary of the change from business-specifications.md> (#[id])` |
+| `*.spec.ts` test files | `<type>: add tests for <short desc> (#[id])` |
+| only `review-results.md` | `docs(review): record code review for <short desc> (#[id])` |
+| `test-results.md` | `docs(results): record test results for <short desc> (#[id])` |
 
 General conventional-commit rules: subject in imperative mood, lowercase, no period,
 ≤72 chars; put overflow in the body. Other file classes: `.claude/deprecated-agents`,

--- a/.claude/commands/jli-sets-up.md
+++ b/.claude/commands/jli-sets-up.md
@@ -125,7 +125,8 @@ errors that the branch already exists — delete the stale local branch, then re
 
 - Changes to `.claude/deprecated-agents`, `CLAUDE.md`, or `.claude/settings.local.json` → `ci(agent): …`
 - Changes to `.claude/commands/jli-*.md` → `ci(commands): …`
-- Changes under `docs/` → `docs: …` (pipeline artifacts use the scoped types below)
+- Changes under `docs/` → `docs: …` (pipeline artifacts follow the rules in `jli-commits.md`,
+  which reuses this `type` for commits that touch source code)
 - Changes under `.github/workflows` → `ci: …`
 - Everything else follows conventional commits: `feat`, `fix`, `docs`, `style`, `refactor`,
   `test`, `chore`, `perf`, `ci`. Subject: imperative, lowercase, no period, ≤72 chars.


### PR DESCRIPTION
## Summary
- Markdown-only pipeline-artifact commits (specs, security, cases, results) in `/jli-commits` always use `docs`, scoped to the artifact.
- Source-code and `*.spec.ts` commits now use `<type>`, parsed from the current branch name (`<type>/<slug>`, set by `/jli-sets-up`), instead of a freely chosen type or a hardcoded `test:`.
- `review-results.md` gets its own `docs(review)` row, split out of the old bundled row, since `/jli-reviews-code` only lints/type-checks and writes a report — it never touches source.
- `jli-sets-up.md`'s commit-rules reference now points at `jli-commits.md` instead of the now-inaccurate "scoped types below" wording.

## Why
On PR #147 (issue #136, a bug fix), the spec/security/test-case commits were tagged `feat:` despite the issue being a bug fix, and Markdown-only artifacts never resolved to `docs`. See #151 for the full analysis and the options considered (Option A — strict Markdown-is-docs — was chosen).

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)